### PR TITLE
chore(dicebound): a script that measures narration length over a real run

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eval:trivia:smoke": "tsx --env-file=.env.local scripts/eval-trivia.ts --smoke",
     "seed-ai-questions": "tsx --env-file=.env.local scripts/seed-ai-questions.ts",
     "sim:micro-land": "tsx scripts/micro-land-sim.ts",
+    "voice:dicebound": "tsx --env-file-if-exists=.env.local scripts/dicebound-voice-check.ts",
     "migrate:daily-trivia": "tsx --env-file=.env.local scripts/migrate-daily-trivia-to-firestore.ts"
   },
   "dependencies": {

--- a/scripts/dicebound-voice-check.ts
+++ b/scripts/dicebound-voice-check.ts
@@ -1,0 +1,250 @@
+/**
+ * Does the dungeon master actually talk less?
+ *
+ * The GM-moves epic (#3517) claims turns are too long and too expository. That
+ * is a claim about length, and "it feels shorter" is not a measurement — prose
+ * quality is hard to judge from inside a change you just made, and the failure
+ * mode of a brevity instruction is a model that writes the same paragraph with
+ * a shorter first sentence. So this plays a real campaign against the real API
+ * and prints the distribution.
+ *
+ * It drives the actual route handler rather than reimplementing the turn loop.
+ * A harness with its own copy of the loop measures the harness: it would not
+ * see a prompt change, a tool schema change, or a pass that quietly stopped
+ * terminating. Importing `POST` means whatever the player would get is what
+ * gets counted.
+ *
+ * Nothing here touches Firestore. The campaign is threaded through in memory by
+ * `applyTurn`, exactly as the browser store does it, and thrown away at the end.
+ *
+ * Usage:
+ *   npm run voice:dicebound                  # 20 turns, the full run
+ *   npm run voice:dicebound -- --turns 4     # a quick smoke check
+ *
+ * The npm script reads `.env.local` with `--env-file-if-exists` rather than the
+ * `--env-file` the other scripts here use. The difference only shows up on a
+ * checkout that has no `.env.local` and exports `ANTHROPIC_API_KEY` in the
+ * environment instead: `--env-file` aborts on the missing file before this
+ * script runs at all, and the person running it gets a node error about a
+ * dotfile rather than the run they asked for.
+ *
+ * Run it BEFORE and AFTER a voice change and paste both tables. Note that the
+ * model is not deterministic and there is no seed to fix: a few words of
+ * movement between runs is noise, and only a shift across the whole
+ * distribution is evidence.
+ */
+import { POST as characterRoute } from '@/app/api/v1/dicebound/character/route'
+import { POST as turnRoute } from '@/app/api/v1/dicebound/turn/route'
+import {
+  type Campaign,
+  type NarrationEntry,
+  type TranscriptEntry,
+  newCampaign,
+  validateCharacter,
+} from '@/app/dicebound/domain/campaign'
+import type { Character } from '@/app/dicebound/domain/character'
+import { type TurnResult, applyTurn } from '@/app/dicebound/domain/turn'
+
+import type { NextRequest } from 'next/server'
+
+/**
+ * Fixed, so two runs differ by the prompt and the model's mood rather than by
+ * the story. A concept with a negative innate rank in it also keeps the sheet
+ * honest — see the Size −2 regression in the design notes.
+ */
+const CONCEPT = 'a very small mouse knight with a sewing-needle sword, brave past all sense'
+const PREMISE = 'the cellar under a bakery, which the mouse knights call the Deeplands'
+
+/**
+ * Deliberately story-agnostic. The DM invents the world, so an action list that
+ * named places or characters would fall apart on the second run. These are the
+ * things a player can always do: look, ask, move, try, wait, push.
+ *
+ * The mix matters as much as the count. Roughly half of these should not need a
+ * roll at all, because "share of turns with a check" is the other number this
+ * script exists to watch — a DM that answers every line with dice is a
+ * different problem from a DM that writes too much, and a brevity change that
+ * fixes one by worsening the other should be visible here.
+ */
+const ACTIONS: readonly string[] = [
+  'I look around and take in where I am.',
+  'I call out to see if anyone answers.',
+  'I move toward whatever is making the most noise.',
+  'I search the nearest container or hiding place.',
+  'I ask the nearest person what is going on here.',
+  'I wait, and listen, and let the moment pass.',
+  'I try to climb up somewhere higher to get a better view.',
+  'I draw my sword and stand ready.',
+  'I try to talk my way past whoever is in front of me.',
+  'I go back the way I came.',
+  'I look closely at the thing that seems most out of place.',
+  'I try to move quietly and stay out of sight.',
+  'I offer to help with whatever is wrong.',
+  'I push on the nearest door or barrier as hard as I can.',
+  'I ask about the thing nobody has explained yet.',
+  'I sit down and rest for a moment.',
+  'I follow whoever left most recently.',
+  'I try something reckless rather than wait any longer.',
+  'I take stock of what I am carrying.',
+  'I head for the way out.',
+]
+
+function arg(name: string, fallback: number): number {
+  const index = process.argv.indexOf(`--${name}`)
+  if (index === -1) return fallback
+  const value = Number(process.argv[index + 1])
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+/**
+ * The route handlers only ever call `request.json()`, so a plain `Request` is
+ * enough. This is a cast rather than a real `NextRequest` because constructing
+ * one outside the Next runtime pulls in machinery none of this needs.
+ */
+function post(body: unknown): NextRequest {
+  return new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest
+}
+
+async function makeCharacter(): Promise<Character> {
+  const response = await characterRoute(post({ concept: CONCEPT, premise: PREMISE }))
+  const data = (await response.json()) as { character?: unknown; source?: string }
+  const character = validateCharacter(data.character)
+  if (!character) throw new Error('character route returned something unusable')
+
+  // `source: 'offline'` means the model call failed and the route fell back to a
+  // playable default. That is correct behaviour for a player and useless for a
+  // measurement, so say so loudly rather than quietly reporting a run that was
+  // never really about the prompt.
+  if (data.source !== 'model') {
+    console.warn(`WARNING: character came from the '${data.source}' path, not the model.`)
+  }
+  return character
+}
+
+async function playTurn(campaign: Campaign, action: string): Promise<TurnResult> {
+  const response = await turnRoute(post({ campaign, action }))
+  const data = (await response.json()) as { result?: TurnResult; error?: string }
+  if (!data.result) throw new Error(data.error ?? 'turn route returned no result')
+  return data.result
+}
+
+/** Words as a reader counts them, not as a tokenizer does. */
+function words(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length
+}
+
+/** Total words of narration in a turn, across however many entries it produced. */
+function narrationWords(entries: TranscriptEntry[]): number {
+  return entries
+    .filter((e): e is NarrationEntry => e.kind === 'narration')
+    .reduce((sum, e) => sum + words(e.text), 0)
+}
+
+/**
+ * Nearest-rank percentile. No interpolation: with twenty samples an interpolated
+ * p90 invents a number that no turn actually was, and the point of this table is
+ * to describe turns that happened.
+ */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0
+  const rank = Math.ceil((p / 100) * sorted.length)
+  return sorted[Math.min(sorted.length, Math.max(1, rank)) - 1]
+}
+
+function row(label: string, value: string): string {
+  return `  ${label.padEnd(26)}${value.padStart(8)}`
+}
+
+async function main(): Promise<void> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('ANTHROPIC_API_KEY is not set. Run via `npm run voice:dicebound`.')
+    process.exit(1)
+  }
+
+  const turns = Math.min(arg('turns', 20), ACTIONS.length)
+  const now = Date.now()
+
+  console.log(`Dicebound voice check — ${turns} turns against the live API.`)
+  console.log(`Concept: "${CONCEPT}"\n`)
+
+  const character = await makeCharacter()
+  let campaign = newCampaign(PREMISE, character, now, null)
+
+  // The opening turn takes no action and produces the title. It is measured
+  // separately below: it is allowed to be longer than a normal turn, and
+  // folding it into the distribution would flatter every table by one long
+  // sample that no brevity change is trying to shorten.
+  const opening = await playTurn(campaign, '')
+  campaign = applyTurn(campaign, opening, now)
+  const openingWords = narrationWords(opening.entries)
+  console.log(`  opening: "${campaign.title}" (${openingWords} words)\n`)
+
+  const lengths: number[] = []
+  let withCheck = 0
+  let failed = 0
+
+  for (let i = 0; i < turns; i++) {
+    const action = ACTIONS[i]
+
+    // A turn that fails is recorded and stepped over rather than thrown.
+    // Letting one failure end the process throws away every turn measured
+    // before it, which is how a twenty-minute run produces a stack trace and no
+    // table — and the failure this actually caught was worth measuring: the
+    // route aborts a turn at 105 seconds, and turns get slower as the
+    // transcript grows, so a long campaign starts losing them.
+    let result: TurnResult
+    try {
+      result = await playTurn(campaign, action)
+    } catch (error) {
+      failed++
+      console.log(
+        `  turn ${String(i + 1).padStart(2)}: FAILED — ${error instanceof Error ? error.message : String(error)}`
+      )
+      continue
+    }
+
+    campaign = applyTurn(campaign, result, now + i + 1)
+
+    const narration = narrationWords(result.entries)
+    const checks = result.entries.filter(e => e.kind === 'check').length
+
+    lengths.push(narration)
+    if (checks > 0) withCheck++
+    console.log(
+      `  turn ${String(i + 1).padStart(2)}: ${String(narration).padStart(4)} words, ${checks} check(s)`
+    )
+  }
+
+  const sorted = [...lengths].sort((a, b) => a - b)
+  const total = sorted.reduce((sum, n) => sum + n, 0)
+
+  console.log(`\nNARRATION LENGTH (words per turn, n=${lengths.length})`)
+  console.log(row('min', String(sorted[0] ?? 0)))
+  console.log(row('median', String(percentile(sorted, 50))))
+  console.log(row('p90', String(percentile(sorted, 90))))
+  console.log(row('max', String(sorted[sorted.length - 1] ?? 0)))
+  console.log(row('mean', lengths.length ? (total / lengths.length).toFixed(1) : '0'))
+
+  console.log(`\nTURN SHAPE`)
+  console.log(row('turns with a check', `${withCheck}/${lengths.length}`))
+  console.log(
+    row(
+      'share with a check',
+      lengths.length ? `${Math.round((withCheck / lengths.length) * 100)}%` : '0%'
+    )
+  )
+  console.log(row('opening (not counted)', String(openingWords)))
+  // Printed always, including as 0. A reader comparing two tables needs to know
+  // whether the second one is shorter or simply missing its slowest turns.
+  console.log(row('turns that failed', `${failed}/${turns}`))
+  console.log(row('total checks rolled', String(campaign.stats.checks)))
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #3526.

**Stacked on #3535** (`feat/dicebound-narrate-tool`), which is itself on #3534. Dicebound is not on `main` yet. Rebase down the stack as each lands.

## Why this is out of order

The epic lists #3526 fourth, after #3524 and #3525. I did it first, because its entire value is a *before* table — once the voice changes land there is no baseline left to capture, and the epic's own verification section asks for both tables in the PR. That looked like a bug in the ordering rather than a call to make quietly.

## What it does

Plays a real campaign against the real API from a fixed concept and a fixed, story-agnostic action list, then prints the word-count distribution of narration and the share of turns that contained a check.

It drives the actual route handler rather than reimplementing the turn loop. A harness carrying its own copy of the loop measures the harness — it would not notice a prompt change, a tool schema change, or a pass that had quietly stopped terminating. Importing `POST` means the thing counted is the thing the player would have read.

The opening turn is measured but excluded from the distribution: it is allowed to be longer, and folding it in would flatter every table with one long sample no brevity change is trying to shorten.

Share-of-turns-with-a-check sits next to the word counts deliberately. A DM that answers every line with dice is a different failure from a DM that writes too much, and a change that fixes the second by worsening the first should not be able to hide behind a smaller median.

## The baseline

20 turns, live API, current `main`-of-this-stack prompt (i.e. after #3523, before any voice change):

```
NARRATION LENGTH (words per turn, n=20)
  min                            128
  median                         175
  p90                            202
  max                            241
  mean                         172.8

TURN SHAPE
  turns with a check           18/20
  share with a check             90%
  opening (not counted)          175
  turns that failed             0/20
  total checks rolled             18
```

Two things stand out before a single word of prompt has changed:

- **Median 175 words, p90 202.** For a game whose loop is "say what you attempt", that is a lot of reading between decisions.
- **90% of turns contained a check.** This is the number I did not expect, and #3525 will not fix it — a word budget makes narration shorter, not less dice-happy. Several of these were rolls on actions a player would not think of as uncertain.

## A bug this found

The first attempt at this run died on turn 14 with the route's 105-second abort, surfacing to the player as *"The telling faltered. Try that again."* Filed as #3536. A second run completed all 20 turns cleanly, so it is intermittent rather than a wall — the issue has been corrected to say so.

That first failure also exposed a flaw in this script: one thrown turn took thirteen turns of measurements with it and produced a stack trace instead of a table, which fails this issue's own acceptance. A failed turn is now recorded and stepped over, and `turns that failed` prints even at zero — a reader comparing two tables needs to know whether the second is shorter or merely missing its slowest turns.

## Acceptance

- [x] **Runs from a clean checkout with only `ANTHROPIC_API_KEY` set.** Verified literally, with no `.env.local` reachable and the key in the environment only:
  ```
  $ env -i PATH=... ANTHROPIC_API_KEY=... npx tsx --env-file-if-exists=/nonexistent/.env.local scripts/dicebound-voice-check.ts --turns 1
  /nonexistent/.env.local not found. Continuing without it.
  Dicebound voice check — 1 turns against the live API.
  ```
- [x] **Does not write to Firestore.** No store import; the campaign is threaded in memory through `applyTurn` and dropped.
- [x] **Prints a table, not a wall of prose.** Above.

## One deviation from the issue

The issue specifies the `tsx --env-file=.env.local` pattern the other scripts use. I used `--env-file-if-exists`, because `--env-file` aborts on a missing dotfile *before* the script runs — which would have made the first acceptance box impossible to tick. The reasoning is in a comment at the top of the file. Happy to switch back if you would rather the scripts stay uniform.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  7 passed (7)
      Tests  112 passed (112)

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint scripts/dicebound-voice-check.ts
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npx prettier --check scripts/dicebound-voice-check.ts package.json
All matched files use Prettier code style!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)