### PR TITLE
feat(dicebound): enforce brevity structurally, not by asking

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -94,6 +94,24 @@ export const maxDuration = 120
  */
 const MAX_CHECKS = 3
 
+/**
+ * Output ceiling for a pass of the turn loop. Was 2000, which is permission to
+ * write an essay.
+ *
+ * This is a backstop, not the mechanism — the budget on the `narrate` tool is
+ * what actually shortens a turn. It has to stay clear of the ceiling because
+ * truncation here is not a shorter paragraph, it is a `tool_use` block whose
+ * JSON stops mid-string: unparseable input, a turn that resolves to the
+ * fallback narration, and a player who gets "the moment resolves" instead of
+ * their scene. Two short paragraphs is roughly 200 tokens and a pass may also
+ * carry several `roll_check` calls, so this leaves several times the headroom
+ * the budget asks for while still refusing an essay.
+ *
+ * `openStory` keeps the old ceiling. The opening is the one place the game is
+ * allowed to be expansive.
+ */
+const TURN_TOKENS = 900
+
 /** Sent back for a `narrate` the model wrote before it could have known the die. */
 const PREMATURE_NARRATION =
   'That narration was written in the same message as a roll, before the dice were known, so it has been discarded. Read the roll result above and narrate what actually happened.'
@@ -131,10 +149,12 @@ ${SKILL_LINES}
 Naming a skill matters mechanically: skills are EARNED by being called on, so the skills you name are the ones the character slowly becomes good at. Name the honest one. Do not spread them around to be generous, and do not reach for an exotic skill when the plain attribute is what is really being tested.
 
 NARRATING
-- Deliver every scene through a tool call — narrate during play, begin_story when opening. Never answer with bare prose.
+- Deliver every scene through a tool call — narrate during play, begin_story when opening. Never answer with bare prose. The narrate tool tells you your length budget for that turn. It is a budget, not a target: coming in far under it is good.
 - Second person, present tense. "You push the door; it gives an inch and stops."
-- Short. Two or three paragraphs at the very most, usually one. This is a conversation, not a novel — the player is waiting to act.
-- End on a situation, not a question. Do not write "What do you do?" — just stop somewhere that obviously wants an answer.
+- Begin and end with the fiction. No recap, no summary, no scene-setting preamble, no stepping outside to comment. The player was there last turn; do not replay it for them.
+- Never speak the name of your move. Do not write "you fail" or "you succeed". Do not name the DC, the margin, or how well the roll went. Do not announce a setback as a setback — just let the thing happen and let the player work out what it cost them.
+- Once play is under way, you may ask the player a question about their world and treat the answer as true: "Which of these guards do you already owe money to?" "What did your sister tell you about this place?" A question is two lines where description would take twelve, and it makes the player a co-author instead of an audience. Use it sparingly — at most one turn in four, and never twice running.
+- Two hard limits on that. It is never available in the opening scene: the first thing a new player reads must be a world, not a request for one. And it is never a question about what they do next — "What do you do?" and every variant of it are banned outright. Stop on a situation that obviously wants an answer instead.
 - NEVER decide what the player's character does, says, thinks or feels. That is theirs. You control the world and everyone else in it.
 - Let failure move the story rather than stall it. A failed attempt should change the situation, not repeat it.
 - Keep the world consistent. Names, places and promises from earlier still hold.
@@ -189,7 +209,7 @@ const NarrateSchema = z.object({
   text: z
     .string()
     .describe(
-      'What happens. Second person, present tense, short — usually one paragraph. End on a situation, not a question.'
+      'What happens. Second person, present tense. Open on the fiction and close on the fiction, within the word budget given for this turn. Never state the outcome in the abstract ("you fail", "you succeed") — show the thing itself.'
     ),
 })
 
@@ -200,11 +220,31 @@ const ROLL_CHECK: ToolDef = {
   input_schema: toolSchema(RollCheckSchema),
 }
 
-const NARRATE: ToolDef = {
-  name: NARRATE_TOOL,
-  description:
-    'Tell the player what happens, and end your turn. This is the last thing you do. If the attempt was uncertain, call roll_check first and wait for the result — narration sent in the same message as a roll was written before the dice were known, and is discarded.',
-  input_schema: toolSchema(NarrateSchema),
+/**
+ * The word budget, and why it lives on the tool rather than in the system
+ * prompt.
+ *
+ * A turn that resolved a roll has more to carry than a turn that did not — the
+ * player is owed the outcome of the thing they attempted, which is a beat the
+ * quiet turn simply does not have. One budget for both would either strangle
+ * the roll turn or licence the quiet one, so the budget is built per pass and
+ * stated on the tool the model is about to fill in.
+ *
+ * It also cannot live in SYSTEM, because SYSTEM is shared with `openStory`, and
+ * the opening scene is the one moment the game is allowed to be expansive.
+ * Putting 70 words in the shared prompt would quietly shrink the first thing a
+ * new player ever reads.
+ */
+function narrateTool(rolled: boolean): ToolDef {
+  const budget = rolled
+    ? 'The dice have been rolled, so you have a little more room: two short paragraphs at the very most, and one is usually better.'
+    : 'Nothing was rolled, so this is a small turn. Keep it under about 70 words — one short paragraph.'
+
+  return {
+    name: NARRATE_TOOL,
+    description: `Tell the player what happens, and end your turn. This is the last thing you do. ${budget} If the attempt was uncertain, call roll_check first and wait for the result — narration sent in the same message as a roll was written before the dice were known, and is discarded.`,
+    input_schema: toolSchema(NarrateSchema),
+  }
 }
 
 const OpeningSchema = z.object({
@@ -214,7 +254,7 @@ const OpeningSchema = z.object({
   opening: z
     .string()
     .describe(
-      'The opening scene. Put the character somewhere specific, with something already happening, and stop somewhere that wants a decision. Two or three short paragraphs. Second person.'
+      'The opening scene. Put the character somewhere specific, with something already happening, and stop somewhere that wants a decision. Two or three short paragraphs. Second person. Do not ask the player a question here — the co-authoring question is a move for later turns, and the first thing a new player reads should be a world, not a request for one.'
     ),
 })
 
@@ -370,18 +410,24 @@ Resolve it, then call narrate with what happens.`,
 
   for (let step = 0; step <= MAX_CHECKS; step++) {
     const lastStep = step === MAX_CHECKS
+    // Whether anything has actually been rolled this turn, which is what sets
+    // the word budget. Derived from the entries rather than the step counter: a
+    // model that spent a pass on nothing has not earned the longer budget.
+    const rolled = entries.some(entry => entry.kind === 'check')
+    const narrate = narrateTool(rolled)
+
     const data = await callModel({
       apiKey,
       model: DM_MODEL,
       system: SYSTEM,
       messages,
-      maxTokens: 2000,
+      maxTokens: TURN_TOKENS,
       signal,
       // On the final pass `roll_check` is withdrawn and `narrate` is forced,
       // which is a harder guarantee than asking nicely for prose. There is no
       // fourth roll available to reach for, and finishing is the only move
       // left on the board.
-      tools: lastStep ? [NARRATE] : [ROLL_CHECK, NARRATE],
+      tools: lastStep ? [narrate] : [ROLL_CHECK, narrate],
       toolChoice: lastStep ? { type: 'tool', name: NARRATE_TOOL } : { type: 'auto' },
     })
 


### PR DESCRIPTION
Closes #3525.

**Stacked on #3537** → #3535 → #3534. Dicebound is not on `main` yet; rebase down the stack as each lands.

Taken ahead of #3524 at Nick's call — it is the change with a measurable target, and #3536 suggests prompt growth has a hard failure behind it.

## The mechanism

**The budget lives on the `narrate` tool and is built per pass.** Two reasons, both load-bearing:

- `SYSTEM` is shared with `openStory`. A 70-word rule stated there would quietly shrink the opening scene — the one moment this game should be expansive, and the first thing a new player ever reads.
- A turn that resolved a roll has more to carry than a quiet one; the player is owed the outcome of the thing they attempted, which is a beat the quiet turn does not have. One budget for both would either strangle the roll turn or licence the quiet one.

So `narrateTool(rolled)` states ~70 words when nothing was rolled and two short paragraphs when something was. `rolled` is read off the entries rather than the step counter — a pass spent on nothing has not earned the longer budget.

**`maxTokens` on the turn pass: 2000 → 900.** A backstop, not the mechanism, and it deliberately keeps its distance from the budget. Truncation here is not a shorter paragraph — it is a `tool_use` block whose JSON stops mid-string, which lands the player on the fallback narration instead of their scene. `openStory` keeps the old ceiling.

**The three principles** go in alongside, in the game's own voice.

## Measured, not asserted

Twenty real turns per run, same fixed concept and action list, via the #3526 harness.

| | before | after (run 1) | after (run 2) |
| --- | --- | --- | --- |
| min | 128 | 63 | 59 |
| **median** | **175** | **124** | **126** |
| **p90** | **202** | **158** | **164** |
| max | 241 | 179 | 201 |
| mean | 172.8 | 116.3 | 122.8 |
| opening *(excluded)* | 175 | 211 | 223 |
| turns that failed | 0/20 | 0/20 | 0/20 |

Two after-runs because I changed the prompt after the first one (see below) and the table had to describe what actually ships. They land close to each other, which is the useful part — median −29%/−28%, p90 −22%/−19%. The opening got *longer* in both, which is what confirms the budget did not leak into `openStory`.

## Acceptance

- [x] **Median narration length drops materially.** 175 → 124 and 126 across two runs.
- [x] **Turns still end on a situation rather than a question.** This one broke first and was fixed — see below.
- [x] **The DM still never decides what the player's character does, says, thinks or feels.** Checked by reading real turns, not by grep. The narration executes the action the player declared and stops. Two borderline phrasings appear — "You know that knot", "That is the part you notice" — which assert what the character knows or notices. Both are longstanding DM register and both predate this PR; flagging rather than claiming a clean sheet.

## The regression the word counts would have missed

The numbers looked great on the first pass. Reading the actual prose showed the opening had started ending on a co-authoring question:

> *Tell me one thing while you can still hear yourself think: what did Squire Bramble make you promise, this morning, before you left him at his post?*

Charming in isolation, wrong as the first thing a new player sees — it asks them to invent the world before they have been given one. Tightening `OpeningSchema`'s field description did **not** fix it; the `SYSTEM` principle outranked the schema hint. The fence is now in `SYSTEM` itself: the move is unavailable in the opening and capped at roughly one turn in four. Re-verified — the opening now closes on a print slowly filling with dark water.

Worth carrying into #3524: a word-count harness would have scored that change a clean success.

## A tension in the spec, resolved deliberately

The Voice section wants the DM to *ask questions and use the answers*. Phase 1 forbids ending on a question, and this issue's acceptance repeats it. Those are different questions — a move that makes the player a co-author, versus a prompt for input — and the prompt now says so explicitly rather than leaving the model to split the difference. If you would rather the DM never ask anything, it is a one-line deletion.

## Evidence that "never speak the name of your move" took

A `failure` band, narrated without the word:

> You go off the Third Shelf with your needle out ahead of you […] and you catch the twine, and the twine holds — for eleven glorious feet. Then the cut place comes up under your grip like a torn seam and the rope simply stops being a rope.

## Something I am not claiming

Check rate moved 90% → 65% → 70% across the three runs. Plausible story: a 70-word budget makes a quiet turn a legitimate option, where before every turn had to fill space and a roll gives you something to write about. But that is one run against one run, and I am not asserting causation. It is the #3536 dice-happiness problem moving the right way by accident, not by design.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  7 passed (7)
      Tests  112 passed (112)

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npx prettier --check src/app/api/v1/dicebound/turn/route.ts
All matched files use Prettier code style!
```

Plus three full campaigns played against the live API, read end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)