### PR TITLE
fix(dicebound): land the three stacked PRs that never reached main

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eval:trivia:smoke": "tsx --env-file=.env.local scripts/eval-trivia.ts --smoke",
     "seed-ai-questions": "tsx --env-file=.env.local scripts/seed-ai-questions.ts",
     "sim:micro-land": "tsx scripts/micro-land-sim.ts",
+    "voice:dicebound": "tsx --env-file-if-exists=.env.local scripts/dicebound-voice-check.ts",
     "migrate:daily-trivia": "tsx --env-file=.env.local scripts/migrate-daily-trivia-to-firestore.ts"
   },
   "dependencies": {

--- a/scripts/dicebound-voice-check.ts
+++ b/scripts/dicebound-voice-check.ts
@@ -1,0 +1,250 @@
+/**
+ * Does the dungeon master actually talk less?
+ *
+ * The GM-moves epic (#3517) claims turns are too long and too expository. That
+ * is a claim about length, and "it feels shorter" is not a measurement — prose
+ * quality is hard to judge from inside a change you just made, and the failure
+ * mode of a brevity instruction is a model that writes the same paragraph with
+ * a shorter first sentence. So this plays a real campaign against the real API
+ * and prints the distribution.
+ *
+ * It drives the actual route handler rather than reimplementing the turn loop.
+ * A harness with its own copy of the loop measures the harness: it would not
+ * see a prompt change, a tool schema change, or a pass that quietly stopped
+ * terminating. Importing `POST` means whatever the player would get is what
+ * gets counted.
+ *
+ * Nothing here touches Firestore. The campaign is threaded through in memory by
+ * `applyTurn`, exactly as the browser store does it, and thrown away at the end.
+ *
+ * Usage:
+ *   npm run voice:dicebound                  # 20 turns, the full run
+ *   npm run voice:dicebound -- --turns 4     # a quick smoke check
+ *
+ * The npm script reads `.env.local` with `--env-file-if-exists` rather than the
+ * `--env-file` the other scripts here use. The difference only shows up on a
+ * checkout that has no `.env.local` and exports `ANTHROPIC_API_KEY` in the
+ * environment instead: `--env-file` aborts on the missing file before this
+ * script runs at all, and the person running it gets a node error about a
+ * dotfile rather than the run they asked for.
+ *
+ * Run it BEFORE and AFTER a voice change and paste both tables. Note that the
+ * model is not deterministic and there is no seed to fix: a few words of
+ * movement between runs is noise, and only a shift across the whole
+ * distribution is evidence.
+ */
+import { POST as characterRoute } from '@/app/api/v1/dicebound/character/route'
+import { POST as turnRoute } from '@/app/api/v1/dicebound/turn/route'
+import {
+  type Campaign,
+  type NarrationEntry,
+  type TranscriptEntry,
+  newCampaign,
+  validateCharacter,
+} from '@/app/dicebound/domain/campaign'
+import type { Character } from '@/app/dicebound/domain/character'
+import { type TurnResult, applyTurn } from '@/app/dicebound/domain/turn'
+
+import type { NextRequest } from 'next/server'
+
+/**
+ * Fixed, so two runs differ by the prompt and the model's mood rather than by
+ * the story. A concept with a negative innate rank in it also keeps the sheet
+ * honest — see the Size −2 regression in the design notes.
+ */
+const CONCEPT = 'a very small mouse knight with a sewing-needle sword, brave past all sense'
+const PREMISE = 'the cellar under a bakery, which the mouse knights call the Deeplands'
+
+/**
+ * Deliberately story-agnostic. The DM invents the world, so an action list that
+ * named places or characters would fall apart on the second run. These are the
+ * things a player can always do: look, ask, move, try, wait, push.
+ *
+ * The mix matters as much as the count. Roughly half of these should not need a
+ * roll at all, because "share of turns with a check" is the other number this
+ * script exists to watch — a DM that answers every line with dice is a
+ * different problem from a DM that writes too much, and a brevity change that
+ * fixes one by worsening the other should be visible here.
+ */
+const ACTIONS: readonly string[] = [
+  'I look around and take in where I am.',
+  'I call out to see if anyone answers.',
+  'I move toward whatever is making the most noise.',
+  'I search the nearest container or hiding place.',
+  'I ask the nearest person what is going on here.',
+  'I wait, and listen, and let the moment pass.',
+  'I try to climb up somewhere higher to get a better view.',
+  'I draw my sword and stand ready.',
+  'I try to talk my way past whoever is in front of me.',
+  'I go back the way I came.',
+  'I look closely at the thing that seems most out of place.',
+  'I try to move quietly and stay out of sight.',
+  'I offer to help with whatever is wrong.',
+  'I push on the nearest door or barrier as hard as I can.',
+  'I ask about the thing nobody has explained yet.',
+  'I sit down and rest for a moment.',
+  'I follow whoever left most recently.',
+  'I try something reckless rather than wait any longer.',
+  'I take stock of what I am carrying.',
+  'I head for the way out.',
+]
+
+function arg(name: string, fallback: number): number {
+  const index = process.argv.indexOf(`--${name}`)
+  if (index === -1) return fallback
+  const value = Number(process.argv[index + 1])
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+/**
+ * The route handlers only ever call `request.json()`, so a plain `Request` is
+ * enough. This is a cast rather than a real `NextRequest` because constructing
+ * one outside the Next runtime pulls in machinery none of this needs.
+ */
+function post(body: unknown): NextRequest {
+  return new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest
+}
+
+async function makeCharacter(): Promise<Character> {
+  const response = await characterRoute(post({ concept: CONCEPT, premise: PREMISE }))
+  const data = (await response.json()) as { character?: unknown; source?: string }
+  const character = validateCharacter(data.character)
+  if (!character) throw new Error('character route returned something unusable')
+
+  // `source: 'offline'` means the model call failed and the route fell back to a
+  // playable default. That is correct behaviour for a player and useless for a
+  // measurement, so say so loudly rather than quietly reporting a run that was
+  // never really about the prompt.
+  if (data.source !== 'model') {
+    console.warn(`WARNING: character came from the '${data.source}' path, not the model.`)
+  }
+  return character
+}
+
+async function playTurn(campaign: Campaign, action: string): Promise<TurnResult> {
+  const response = await turnRoute(post({ campaign, action }))
+  const data = (await response.json()) as { result?: TurnResult; error?: string }
+  if (!data.result) throw new Error(data.error ?? 'turn route returned no result')
+  return data.result
+}
+
+/** Words as a reader counts them, not as a tokenizer does. */
+function words(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length
+}
+
+/** Total words of narration in a turn, across however many entries it produced. */
+function narrationWords(entries: TranscriptEntry[]): number {
+  return entries
+    .filter((e): e is NarrationEntry => e.kind === 'narration')
+    .reduce((sum, e) => sum + words(e.text), 0)
+}
+
+/**
+ * Nearest-rank percentile. No interpolation: with twenty samples an interpolated
+ * p90 invents a number that no turn actually was, and the point of this table is
+ * to describe turns that happened.
+ */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0
+  const rank = Math.ceil((p / 100) * sorted.length)
+  return sorted[Math.min(sorted.length, Math.max(1, rank)) - 1]
+}
+
+function row(label: string, value: string): string {
+  return `  ${label.padEnd(26)}${value.padStart(8)}`
+}
+
+async function main(): Promise<void> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('ANTHROPIC_API_KEY is not set. Run via `npm run voice:dicebound`.')
+    process.exit(1)
+  }
+
+  const turns = Math.min(arg('turns', 20), ACTIONS.length)
+  const now = Date.now()
+
+  console.log(`Dicebound voice check — ${turns} turns against the live API.`)
+  console.log(`Concept: "${CONCEPT}"\n`)
+
+  const character = await makeCharacter()
+  let campaign = newCampaign(PREMISE, character, now, null)
+
+  // The opening turn takes no action and produces the title. It is measured
+  // separately below: it is allowed to be longer than a normal turn, and
+  // folding it into the distribution would flatter every table by one long
+  // sample that no brevity change is trying to shorten.
+  const opening = await playTurn(campaign, '')
+  campaign = applyTurn(campaign, opening, now)
+  const openingWords = narrationWords(opening.entries)
+  console.log(`  opening: "${campaign.title}" (${openingWords} words)\n`)
+
+  const lengths: number[] = []
+  let withCheck = 0
+  let failed = 0
+
+  for (let i = 0; i < turns; i++) {
+    const action = ACTIONS[i]
+
+    // A turn that fails is recorded and stepped over rather than thrown.
+    // Letting one failure end the process throws away every turn measured
+    // before it, which is how a twenty-minute run produces a stack trace and no
+    // table — and the failure this actually caught was worth measuring: the
+    // route aborts a turn at 105 seconds, and turns get slower as the
+    // transcript grows, so a long campaign starts losing them.
+    let result: TurnResult
+    try {
+      result = await playTurn(campaign, action)
+    } catch (error) {
+      failed++
+      console.log(
+        `  turn ${String(i + 1).padStart(2)}: FAILED — ${error instanceof Error ? error.message : String(error)}`
+      )
+      continue
+    }
+
+    campaign = applyTurn(campaign, result, now + i + 1)
+
+    const narration = narrationWords(result.entries)
+    const checks = result.entries.filter(e => e.kind === 'check').length
+
+    lengths.push(narration)
+    if (checks > 0) withCheck++
+    console.log(
+      `  turn ${String(i + 1).padStart(2)}: ${String(narration).padStart(4)} words, ${checks} check(s)`
+    )
+  }
+
+  const sorted = [...lengths].sort((a, b) => a - b)
+  const total = sorted.reduce((sum, n) => sum + n, 0)
+
+  console.log(`\nNARRATION LENGTH (words per turn, n=${lengths.length})`)
+  console.log(row('min', String(sorted[0] ?? 0)))
+  console.log(row('median', String(percentile(sorted, 50))))
+  console.log(row('p90', String(percentile(sorted, 90))))
+  console.log(row('max', String(sorted[sorted.length - 1] ?? 0)))
+  console.log(row('mean', lengths.length ? (total / lengths.length).toFixed(1) : '0'))
+
+  console.log(`\nTURN SHAPE`)
+  console.log(row('turns with a check', `${withCheck}/${lengths.length}`))
+  console.log(
+    row(
+      'share with a check',
+      lengths.length ? `${Math.round((withCheck / lengths.length) * 100)}%` : '0%'
+    )
+  )
+  console.log(row('opening (not counted)', String(openingWords)))
+  // Printed always, including as 0. A reader comparing two tables needs to know
+  // whether the second one is shorter or simply missing its slowest turns.
+  console.log(row('turns that failed', `${failed}/${turns}`))
+  console.log(row('total checks rolled', String(campaign.stats.checks)))
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -94,6 +94,24 @@ export const maxDuration = 120
  */
 const MAX_CHECKS = 3
 
+/**
+ * Output ceiling for a pass of the turn loop. Was 2000, which is permission to
+ * write an essay.
+ *
+ * This is a backstop, not the mechanism — the budget on the `narrate` tool is
+ * what actually shortens a turn. It has to stay clear of the ceiling because
+ * truncation here is not a shorter paragraph, it is a `tool_use` block whose
+ * JSON stops mid-string: unparseable input, a turn that resolves to the
+ * fallback narration, and a player who gets "the moment resolves" instead of
+ * their scene. Two short paragraphs is roughly 200 tokens and a pass may also
+ * carry several `roll_check` calls, so this leaves several times the headroom
+ * the budget asks for while still refusing an essay.
+ *
+ * `openStory` keeps the old ceiling. The opening is the one place the game is
+ * allowed to be expansive.
+ */
+const TURN_TOKENS = 900
+
 /** Sent back for a `narrate` the model wrote before it could have known the die. */
 const PREMATURE_NARRATION =
   'That narration was written in the same message as a roll, before the dice were known, so it has been discarded. Read the roll result above and narrate what actually happened.'
@@ -131,10 +149,12 @@ ${SKILL_LINES}
 Naming a skill matters mechanically: skills are EARNED by being called on, so the skills you name are the ones the character slowly becomes good at. Name the honest one. Do not spread them around to be generous, and do not reach for an exotic skill when the plain attribute is what is really being tested.
 
 NARRATING
-- Deliver every scene through a tool call — narrate during play, begin_story when opening. Never answer with bare prose.
+- Deliver every scene through a tool call — narrate during play, begin_story when opening. Never answer with bare prose. The narrate tool tells you your length budget for that turn. It is a budget, not a target: coming in far under it is good.
 - Second person, present tense. "You push the door; it gives an inch and stops."
-- Short. Two or three paragraphs at the very most, usually one. This is a conversation, not a novel — the player is waiting to act.
-- End on a situation, not a question. Do not write "What do you do?" — just stop somewhere that obviously wants an answer.
+- Begin and end with the fiction. No recap, no summary, no scene-setting preamble, no stepping outside to comment. The player was there last turn; do not replay it for them.
+- Never speak the name of your move. Do not write "you fail" or "you succeed". Do not name the DC, the margin, or how well the roll went. Do not announce a setback as a setback — just let the thing happen and let the player work out what it cost them.
+- Once play is under way, you may ask the player a question about their world and treat the answer as true: "Which of these guards do you already owe money to?" "What did your sister tell you about this place?" A question is two lines where description would take twelve, and it makes the player a co-author instead of an audience. Use it sparingly — at most one turn in four, and never twice running.
+- Two hard limits on that. It is never available in the opening scene: the first thing a new player reads must be a world, not a request for one. And it is never a question about what they do next — "What do you do?" and every variant of it are banned outright. Stop on a situation that obviously wants an answer instead.
 - NEVER decide what the player's character does, says, thinks or feels. That is theirs. You control the world and everyone else in it.
 - Let failure move the story rather than stall it. A failed attempt should change the situation, not repeat it.
 - Keep the world consistent. Names, places and promises from earlier still hold.
@@ -189,7 +209,7 @@ const NarrateSchema = z.object({
   text: z
     .string()
     .describe(
-      'What happens. Second person, present tense, short — usually one paragraph. End on a situation, not a question.'
+      'What happens. Second person, present tense. Open on the fiction and close on the fiction, within the word budget given for this turn. Never state the outcome in the abstract ("you fail", "you succeed") — show the thing itself.'
     ),
 })
 
@@ -200,11 +220,31 @@ const ROLL_CHECK: ToolDef = {
   input_schema: toolSchema(RollCheckSchema),
 }
 
-const NARRATE: ToolDef = {
-  name: NARRATE_TOOL,
-  description:
-    'Tell the player what happens, and end your turn. This is the last thing you do. If the attempt was uncertain, call roll_check first and wait for the result — narration sent in the same message as a roll was written before the dice were known, and is discarded.',
-  input_schema: toolSchema(NarrateSchema),
+/**
+ * The word budget, and why it lives on the tool rather than in the system
+ * prompt.
+ *
+ * A turn that resolved a roll has more to carry than a turn that did not — the
+ * player is owed the outcome of the thing they attempted, which is a beat the
+ * quiet turn simply does not have. One budget for both would either strangle
+ * the roll turn or licence the quiet one, so the budget is built per pass and
+ * stated on the tool the model is about to fill in.
+ *
+ * It also cannot live in SYSTEM, because SYSTEM is shared with `openStory`, and
+ * the opening scene is the one moment the game is allowed to be expansive.
+ * Putting 70 words in the shared prompt would quietly shrink the first thing a
+ * new player ever reads.
+ */
+function narrateTool(rolled: boolean): ToolDef {
+  const budget = rolled
+    ? 'The dice have been rolled, so you have a little more room: two short paragraphs at the very most, and one is usually better.'
+    : 'Nothing was rolled, so this is a small turn. Keep it under about 70 words — one short paragraph.'
+
+  return {
+    name: NARRATE_TOOL,
+    description: `Tell the player what happens, and end your turn. This is the last thing you do. ${budget} If the attempt was uncertain, call roll_check first and wait for the result — narration sent in the same message as a roll was written before the dice were known, and is discarded.`,
+    input_schema: toolSchema(NarrateSchema),
+  }
 }
 
 const OpeningSchema = z.object({
@@ -214,7 +254,7 @@ const OpeningSchema = z.object({
   opening: z
     .string()
     .describe(
-      'The opening scene. Put the character somewhere specific, with something already happening, and stop somewhere that wants a decision. Two or three short paragraphs. Second person.'
+      'The opening scene. Put the character somewhere specific, with something already happening, and stop somewhere that wants a decision. Two or three short paragraphs. Second person. Do not ask the player a question here — the co-authoring question is a move for later turns, and the first thing a new player reads should be a world, not a request for one.'
     ),
 })
 
@@ -370,18 +410,24 @@ Resolve it, then call narrate with what happens.`,
 
   for (let step = 0; step <= MAX_CHECKS; step++) {
     const lastStep = step === MAX_CHECKS
+    // Whether anything has actually been rolled this turn, which is what sets
+    // the word budget. Derived from the entries rather than the step counter: a
+    // model that spent a pass on nothing has not earned the longer budget.
+    const rolled = entries.some(entry => entry.kind === 'check')
+    const narrate = narrateTool(rolled)
+
     const data = await callModel({
       apiKey,
       model: DM_MODEL,
       system: SYSTEM,
       messages,
-      maxTokens: 2000,
+      maxTokens: TURN_TOKENS,
       signal,
       // On the final pass `roll_check` is withdrawn and `narrate` is forced,
       // which is a harder guarantee than asking nicely for prose. There is no
       // fourth roll available to reach for, and finishing is the only move
       // left on the board.
-      tools: lastStep ? [NARRATE] : [ROLL_CHECK, NARRATE],
+      tools: lastStep ? [narrate] : [ROLL_CHECK, narrate],
       toolChoice: lastStep ? { type: 'tool', name: NARRATE_TOOL } : { type: 'auto' },
     })
 

--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -5,12 +5,12 @@
  * the dungeon master may stop and ask for a die roll — and that is the whole
  * architecture of this file.
  *
- * The model is given exactly one tool, `roll_check`. It decides *whether* the
- * attempt is uncertain, *which* attribute and skill it leans on, *how hard* it
- * is, and *what* in the scene makes it easier or harder. Then it stops, because
- * it has to: the tool returns the result, and the model has already committed
- * to the difficulty by the time it learns the number. It narrates around a fact
- * it cannot edit.
+ * The model is given two tools. `roll_check` decides *whether* the attempt is
+ * uncertain, *which* attribute and skill it leans on, *how hard* it is, and
+ * *what* in the scene makes it easier or harder. Then it stops, because it has
+ * to: the tool returns the result, and the model has already committed to the
+ * difficulty by the time it learns the number. It narrates around a fact it
+ * cannot edit.
  *
  * If instead the model rolled its own dice, the difficulty and the outcome
  * would be chosen at the same instant by something that wants the story to go
@@ -18,8 +18,14 @@
  * problem to be solved with a stern instruction; it is why `resolveCheck` lives
  * in code and this route is a loop rather than a single call.
  *
- * The loop runs at most MAX_CHECKS times, then forces a final text-only call —
- * a turn that never stops rolling is a turn that never comes back.
+ * `narrate` is the other tool, and it ends the turn. The terminal state is
+ * *declared* rather than inferred from an absence of tool calls, which matters
+ * for two reasons: the model saying "I am done" is a stronger signal than it
+ * happening not to call anything, and sprint 3 needs somewhere to hang the
+ * clock and the world deltas that a finished turn also produces.
+ *
+ * The loop runs at most MAX_CHECKS times, then forces `narrate` — a turn that
+ * never stops rolling is a turn that never comes back.
  */
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
@@ -54,13 +60,19 @@ import {
   clampSituational,
   resolveCheck,
 } from '@/app/dicebound/domain/dice'
-import type { TurnResult } from '@/app/dicebound/domain/turn'
+import {
+  NARRATE_TOOL,
+  ROLL_CHECK_TOOL,
+  type TurnResult,
+  partitionTurnCalls,
+} from '@/app/dicebound/domain/turn'
 import {
   type ContentBlock,
   DM_MODEL,
   type Message,
   NoApiKeyError,
   RefusedError,
+  type ToolDef,
   UTILITY_MODEL,
   callForTool,
   callModel,
@@ -81,6 +93,10 @@ export const maxDuration = 120
  * swallowed a whole scene, which robs the player of the decisions in between.
  */
 const MAX_CHECKS = 3
+
+/** Sent back for a `narrate` the model wrote before it could have known the die. */
+const PREMATURE_NARRATION =
+  'That narration was written in the same message as a roll, before the dice were known, so it has been discarded. Read the roll result above and narrate what actually happened.'
 
 const DC_LINES = DC_TABLE.map(row => `  DC ${row.dc} — ${row.label} (${row.example})`).join('\n')
 
@@ -115,6 +131,7 @@ ${SKILL_LINES}
 Naming a skill matters mechanically: skills are EARNED by being called on, so the skills you name are the ones the character slowly becomes good at. Name the honest one. Do not spread them around to be generous, and do not reach for an exotic skill when the plain attribute is what is really being tested.
 
 NARRATING
+- Deliver every scene through a tool call — narrate during play, begin_story when opening. Never answer with bare prose.
 - Second person, present tense. "You push the door; it gives an inch and stops."
 - Short. Two or three paragraphs at the very most, usually one. This is a conversation, not a novel — the player is waiting to act.
 - End on a situation, not a question. Do not write "What do you do?" — just stop somewhere that obviously wants an answer.
@@ -160,6 +177,35 @@ const RollCheckSchema = z.object({
       'Bonuses and penalties from the current scene. Omit when nothing in particular applies.'
     ),
 })
+
+/**
+ * Text only, for now.
+ *
+ * Sprint 3 extends this same tool with the clock and the world deltas a
+ * finished turn also produces (#3531). Landing it text-only first is what makes
+ * that a schema change rather than a rewrite of the loop.
+ */
+const NarrateSchema = z.object({
+  text: z
+    .string()
+    .describe(
+      'What happens. Second person, present tense, short — usually one paragraph. End on a situation, not a question.'
+    ),
+})
+
+const ROLL_CHECK: ToolDef = {
+  name: ROLL_CHECK_TOOL,
+  description:
+    'Roll the dice for an uncertain attempt. Returns the roll, the total, and how far above or below the DC it landed. Call this BEFORE narrating an uncertain outcome — you do not know whether it works until you do.',
+  input_schema: toolSchema(RollCheckSchema),
+}
+
+const NARRATE: ToolDef = {
+  name: NARRATE_TOOL,
+  description:
+    'Tell the player what happens, and end your turn. This is the last thing you do. If the attempt was uncertain, call roll_check first and wait for the result — narration sent in the same message as a roll was written before the dice were known, and is discarded.',
+  input_schema: toolSchema(NarrateSchema),
+}
 
 const OpeningSchema = z.object({
   title: z
@@ -315,7 +361,7 @@ ${transcriptBlock(history)}
 
 The player says: "${action}"
 
-Resolve it and narrate what happens.`,
+Resolve it, then call narrate with what happens.`,
     },
   ]
 
@@ -331,25 +377,26 @@ Resolve it and narrate what happens.`,
       messages,
       maxTokens: 2000,
       signal,
-      // On the final pass the tool is withdrawn entirely, which is a harder
-      // guarantee than asking nicely for prose. The model has to finish.
-      ...(lastStep
-        ? {}
-        : {
-            tools: [
-              {
-                name: 'roll_check',
-                description:
-                  'Roll the dice for an uncertain attempt. Returns the roll, the total, and how far above or below the DC it landed. Call this BEFORE narrating an uncertain outcome — you do not know whether it works until you do.',
-                input_schema: toolSchema(RollCheckSchema),
-              },
-            ],
-            toolChoice: { type: 'auto' as const },
-          }),
+      // On the final pass `roll_check` is withdrawn and `narrate` is forced,
+      // which is a harder guarantee than asking nicely for prose. There is no
+      // fourth roll available to reach for, and finishing is the only move
+      // left on the board.
+      tools: lastStep ? [NARRATE] : [ROLL_CHECK, NARRATE],
+      toolChoice: lastStep ? { type: 'tool', name: NARRATE_TOOL } : { type: 'auto' },
     })
 
-    const calls = toolUses(data)
-    if (calls.length === 0) {
+    const { rolls, ending, premature } = partitionTurnCalls(toolUses(data))
+
+    if (ending) {
+      narration = narrationOf(ending.input)
+      break
+    }
+
+    if (rolls.length === 0 && premature.length === 0) {
+      // The model answered in prose instead of declaring the end of the turn.
+      // Take it anyway. The turn is over either way, and spending a round trip
+      // teaching the model the ceremony would cost the player fifteen seconds
+      // to arrive at the same paragraph.
       narration = textOf(data)
       break
     }
@@ -357,10 +404,16 @@ Resolve it and narrate what happens.`,
     messages.push({ role: 'assistant', content: data.content ?? [] })
 
     const results: ContentBlock[] = []
-    for (const call of calls) {
+    for (const call of rolls) {
       const { entry, brief } = rollFor(campaign, call.input)
       entries.push(entry)
       results.push({ type: 'tool_result', tool_use_id: call.id, content: brief })
+    }
+    // Answered, not honoured. The API requires a result for every tool_use
+    // block, and this is the one place the model is told why its narration was
+    // dropped rather than being left to wonder.
+    for (const call of premature) {
+      results.push({ type: 'tool_result', tool_use_id: call.id, content: PREMATURE_NARRATION })
     }
     messages.push({ role: 'user', content: results })
   }
@@ -373,6 +426,18 @@ Resolve it and narrate what happens.`,
 
   entries.push({ kind: 'narration', text: narration })
   return { entries, synopsis, dropped }
+}
+
+/**
+ * The text out of a `narrate` call.
+ *
+ * Returns '' rather than a placeholder when the model sends a `narrate` with
+ * nothing in it, so the caller's existing fallback narration is what the player
+ * actually reads. A tool call is not a promise that the field arrived.
+ */
+function narrationOf(input: unknown): string {
+  const raw = (input ?? {}) as { text?: unknown }
+  return typeof raw.text === 'string' ? raw.text.trim() : ''
 }
 
 /** Resolve one `roll_check` call into a transcript entry and a model briefing. */

--- a/src/app/dicebound/domain/__tests__/turn.test.ts
+++ b/src/app/dicebound/domain/__tests__/turn.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  NARRATE_TOOL,
+  ROLL_CHECK_TOOL,
+  type ToolCall,
+  partitionTurnCalls,
+} from '@/app/dicebound/domain/turn'
+
+const roll = (id: string): ToolCall & { id: string } => ({
+  id,
+  name: ROLL_CHECK_TOOL,
+  input: { dc: 15 },
+})
+
+const narrate = (id: string, text = 'You push the door.'): ToolCall & { id: string } => ({
+  id,
+  name: NARRATE_TOOL,
+  input: { text },
+})
+
+describe('partitionTurnCalls', () => {
+  it('ends the turn when the only call is narrate', () => {
+    const { rolls, ending, premature } = partitionTurnCalls([narrate('a')])
+
+    expect(rolls).toEqual([])
+    expect(ending?.id).toBe('a')
+    expect(premature).toEqual([])
+  })
+
+  it('keeps the turn open when the model asks for a roll', () => {
+    const { rolls, ending } = partitionTurnCalls([roll('a')])
+
+    expect(rolls.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+  })
+
+  it('discards narration sent in the same breath as a roll — it was written before the die', () => {
+    // The whole point of roll_check is that the model commits to a difficulty
+    // before it learns the number. Narration composed alongside the roll cannot
+    // be about the result, so honouring it would resolve the turn without the
+    // dice.
+    const { rolls, ending, premature } = partitionTurnCalls([roll('a'), narrate('b')])
+
+    expect(rolls.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+    expect(premature.map(c => c.id)).toEqual(['b'])
+  })
+
+  it('still answers the discarded narration, because the wire demands a result for every call', () => {
+    const { premature } = partitionTurnCalls([narrate('b'), roll('a')])
+
+    // Dropping it silently would send an assistant turn with a tool_use block
+    // that has no matching tool_result, which the API rejects outright.
+    expect(premature.map(c => c.id)).toEqual(['b'])
+  })
+
+  it('resolves every roll in a multi-roll pass, in the order they arrived', () => {
+    const { rolls } = partitionTurnCalls([roll('a'), roll('b'), roll('c')])
+
+    expect(rolls.map(c => c.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('takes only the first of two narrations — the second is a duplicate, not a continuation', () => {
+    const { ending, premature } = partitionTurnCalls([narrate('a'), narrate('b')])
+
+    expect(ending?.id).toBe('a')
+    expect(premature.map(c => c.id)).toEqual(['b'])
+  })
+
+  it('reports nothing to do when the model called no tools at all', () => {
+    const { rolls, ending, premature } = partitionTurnCalls([])
+
+    expect(rolls).toEqual([])
+    expect(ending).toBeNull()
+    expect(premature).toEqual([])
+  })
+
+  it('ignores a tool the loop does not know about rather than mistaking it for an ending', () => {
+    const { rolls, ending, premature } = partitionTurnCalls([{ name: 'recall', input: {} }])
+
+    expect(rolls).toEqual([])
+    expect(ending).toBeNull()
+    expect(premature).toEqual([])
+  })
+})

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -10,6 +10,56 @@ import { type Character, recordSkillUse } from './character'
 
 import type { Campaign, CampaignStats, CheckEntry, TranscriptEntry } from './campaign'
 
+/** A tool call as the turn loop sees it: a name, and whatever the model sent. */
+export interface ToolCall {
+  name: string
+  input: unknown
+}
+
+export const ROLL_CHECK_TOOL = 'roll_check'
+export const NARRATE_TOOL = 'narrate'
+
+/** One pass's tool calls, sorted into what the loop does with each. */
+export interface TurnCalls<T extends ToolCall> {
+  /** `roll_check` calls, to resolve against the die in the order they arrived. */
+  rolls: T[]
+  /** The `narrate` call that ends the turn, or null while the turn continues. */
+  ending: T | null
+  /**
+   * `narrate` calls that must be answered on the wire but must not be used.
+   * The API requires a `tool_result` for every `tool_use` block, so these are
+   * replied to and thrown away.
+   */
+  premature: T[]
+}
+
+/**
+ * Sort one pass's tool calls into rolls, an ending, and narration to discard.
+ *
+ * The rule worth protecting is the third bucket. A model may emit `roll_check`
+ * and `narrate` in the same response — the tools are offered together, and
+ * parallel tool use is the API's default. That narration was composed before
+ * the die existed, which is precisely the failure `roll_check` was built to
+ * prevent: a difficulty and an outcome chosen in the same breath by something
+ * that wants the story to go well. Whether the model *meant* to peek is beside
+ * the point. It could not have known the number, so its narration is not about
+ * the number, and using it would let the turn resolve without the dice.
+ *
+ * So a pass with any roll in it never ends. The rolls resolve, the blind
+ * narration is answered and dropped, and the model narrates again on the next
+ * pass — this time reading a result it cannot edit.
+ */
+export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T> {
+  const rolls = calls.filter(call => call.name === ROLL_CHECK_TOOL)
+  const narrations = calls.filter(call => call.name === NARRATE_TOOL)
+
+  if (rolls.length > 0) return { rolls, ending: null, premature: narrations }
+
+  // Only the first narration ends the turn. A second one is a duplicate, not a
+  // continuation, and appending both would read as the DM saying it twice.
+  return { rolls, ending: narrations[0] ?? null, premature: narrations.slice(1) }
+}
+
 /** What a turn produced, before it has been written down anywhere. */
 export interface TurnResult {
   entries: TranscriptEntry[]


### PR DESCRIPTION
No new work. This carries #3523, #3526 and #3525 onto `main`, where they were meant to be.

## What happened

The four Dicebound PRs were stacked — each based on the one below it, because Dicebound was not on `main` when the first was opened. All four show as MERGED, but only #3534 targeted `main`:

| PR | base at merge | landed in |
| --- | --- | --- |
| #3534 | `main` | **main** |
| #3535 | `feat/dicebound-world-clock-kit` | that branch |
| #3537 | `feat/dicebound-narrate-tool` | that branch |
| #3538 | `feat/dicebound-voice-check` | that branch |

They merged 7–9 seconds apart, which is faster than GitHub retargets a stacked PR's base after its base branch merges. So each squash landed in an intermediate branch and `main` got only the first. Nothing was lost, but three of the four were not shipped — `main` had no `narrate` tool, no voice harness and no word budget.

## What this does

Replays the three original commits onto `main`. It is a recovery, not a rewrite:

```
$ git diff --stat main beb58241        # main vs the original #3534 commit
(empty — identical content, so the later commits replay cleanly)

$ git cherry-pick df598d15 93b8fd49 829c7c3f

$ git diff --stat HEAD 829c7c3f        # result vs the full stack tip
(empty — byte-exact)
```

That last check is the one that matters: the tree this produces is identical to the top of the stack that was reviewed and approved.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  7 passed (7)
      Tests  112 passed (112)

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound scripts/dicebound-voice-check.ts
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npm run build
✓ Compiled successfully
  ƒ /api/v1/dicebound/{campaign,character,turn}
  ○ /dicebound
```

## Afterwards

The four stack branches can be deleted once this lands. Worth avoiding the same shape next time: with Dicebound now on `main`, every remaining phase 2 issue can branch off `main` directly, so there is no reason to stack again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)