### PR TITLE
feat(dicebound): key narration to a GM move list instead of open-ended guidance

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -53,7 +53,11 @@ import {
 import { attributeRank, earnedSkills, skillRank } from '@/app/dicebound/domain/character'
 import {
   BAND_BRIEF,
+  BAND_LABEL,
+  BAND_MOVE,
+  BAND_ORDER,
   DC_TABLE,
+  HARD_MOVES,
   MAX_SITUATIONAL,
   type Modifier,
   clampDc,
@@ -118,6 +122,18 @@ const PREMATURE_NARRATION =
 
 const DC_LINES = DC_TABLE.map(row => `  DC ${row.dc} — ${row.label} (${row.example})`).join('\n')
 
+/**
+ * The move table, rendered from the same record the tool result quotes.
+ *
+ * Written out by hand in the prompt it would be a second copy of `BAND_MOVE`,
+ * and the acceptance criterion on this is precisely that the two must not
+ * drift — a model given one instruction in the table and a different one at the
+ * moment of the roll resolves the contradiction in the player's favour.
+ */
+const MOVE_LINES = BAND_ORDER.map(band => `  ${BAND_LABEL[band]} — ${BAND_MOVE[band]}`).join('\n')
+
+const HARD_MOVE_LINES = HARD_MOVES.map(move => `  - ${move}`).join('\n')
+
 const SKILL_LINES = ATTRIBUTE_IDS.map(
   id =>
     `  ${ATTRIBUTES[id].name} — ${skillsOf(id)
@@ -133,7 +149,16 @@ You describe the situation. The player says what their character attempts. You d
 DECIDING OUTCOMES
 - If the attempt is trivial, or success is guaranteed for this character, it simply works. Describe it happening and move on. Do NOT call for a roll. Walking through an open door is not a Dexterity check, and asking for one is the fastest way to make a game feel like paperwork.
 - If the attempt is uncertain — if it could plausibly fail, and failing would be interesting — call roll_check. Then narrate the result you are given.
-- Narrate by DEGREE. A near miss and a disaster are different stories; so are a narrow success and a spectacular one. The tool tells you which you got.
+- Narrate by DEGREE. The tool tells you which band you got, and the band tells you which move to make. You do not get to pick the band.
+
+WHEN THE DICE HAVE SPOKEN
+Every roll comes back in one of six bands. Each band has a move. Make that move — do not improvise a different one, and do not blend two because the result was close.
+${MOVE_LINES}
+
+THE HARD MOVES
+When a band calls for a hard move, take one of these. One is enough for a turn.
+${HARD_MOVE_LINES}
+A hard move is not a punishment and it is never the end of the story. It changes the situation and hands the ball back. If the player is in the same position after your move as before it, you did not make one.
 
 DIFFICULTY
 ${DC_LINES}
@@ -546,7 +571,12 @@ function rollFor(campaign: Campaign, input: unknown): { entry: CheckEntry; brief
   const brief = [
     `Rolled ${outcome.roll} on a d20, ${outcome.modifier >= 0 ? '+' : ''}${outcome.modifier} = ${outcome.total} against DC ${outcome.dc}.`,
     `Margin ${sign}${outcome.margin}.`,
-    BAND_BRIEF[outcome.band],
+    `${BAND_LABEL[outcome.band]}. ${BAND_BRIEF[outcome.band]}`,
+    // The same string the move table in the prompt was rendered from, repeated
+    // at the one moment it is actually being acted on. A table read once at the
+    // top of a long prompt loses to whatever the model feels like doing by the
+    // time a roll comes back; the move quoted next to the number does not.
+    `YOUR MOVE: ${BAND_MOVE[outcome.band]}`,
     'Narrate this outcome. Do not restate the numbers — the player can already see them.',
   ].join(' ')
 

--- a/src/app/dicebound/domain/__tests__/dice.test.ts
+++ b/src/app/dicebound/domain/__tests__/dice.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  BAND_BRIEF,
+  BAND_LABEL,
+  BAND_MOVE,
+  BAND_ORDER,
+  HARD_MOVES,
   MAX_SITUATIONAL,
   MAX_SITUATIONAL_TOTAL,
   clampDc,
@@ -142,5 +147,48 @@ describe('resolveCheck', () => {
     expect(outcome.band).toBe('critical-failure')
     expect(outcome.succeeded).toBe(false)
     expect(outcome.margin).toBe(2)
+  })
+})
+
+describe('the move list', () => {
+  it('names a move for every band the dice can actually produce', () => {
+    // The failure this protects against is silent: add a band, forget a move,
+    // and the table in the prompt is simply missing a row for an outcome the
+    // player can still roll.
+    for (const band of BAND_ORDER) {
+      expect(BAND_MOVE[band], `no move for ${band}`).toBeTruthy()
+      expect(BAND_BRIEF[band], `no brief for ${band}`).toBeTruthy()
+      expect(BAND_LABEL[band], `no label for ${band}`).toBeTruthy()
+    }
+  })
+
+  it('orders every band exactly once, so the rendered table cannot skip or repeat one', () => {
+    expect(BAND_ORDER).toHaveLength(Object.keys(BAND_MOVE).length)
+    expect(new Set(BAND_ORDER).size).toBe(BAND_ORDER.length)
+  })
+
+  it('agrees with the brief about which bands succeeded and which did not', () => {
+    // The acceptance criterion this exists for: the model is given BAND_BRIEF
+    // and BAND_MOVE for the same roll, and if one says the attempt worked while
+    // the other calls for a hard move, it splits the difference — always in the
+    // player's favour. A success band must never be told to make a hard move.
+    const succeeded = BAND_ORDER.filter(band => band.endsWith('success'))
+    const failed = BAND_ORDER.filter(band => band.endsWith('failure'))
+
+    for (const band of succeeded) {
+      expect(BAND_MOVE[band].toLowerCase(), band).not.toContain('hard move')
+    }
+    for (const band of failed.filter(b => b !== 'failure')) {
+      // 'failure' is the near miss and gets the soft move; the other two are hard.
+      expect(BAND_MOVE[band].toLowerCase(), band).toContain('hard move')
+    }
+    expect(BAND_MOVE.failure.toLowerCase()).toContain('soft move')
+  })
+
+  it('gives the hard moves as concrete things to do, not adjectives', () => {
+    expect(HARD_MOVES.length).toBeGreaterThan(3)
+    for (const move of HARD_MOVES) {
+      expect(move.endsWith('.'), move).toBe(true)
+    }
   })
 })

--- a/src/app/dicebound/domain/dice.ts
+++ b/src/app/dicebound/domain/dice.ts
@@ -199,6 +199,79 @@ export const BAND_BRIEF: Record<OutcomeBand, string> = {
     'NATURAL 1. It fails badly and something new goes wrong — but never something that ends the story outright.',
 }
 
+/**
+ * Every band, best to worst.
+ *
+ * The type is a union and unions have no order, but anything that renders all
+ * six — the move table in the prompt, and any future legend on the die card —
+ * needs them in the order a reader expects. Declaring it once means adding a
+ * band is a type error here rather than a row silently missing from a table.
+ */
+export const BAND_ORDER: readonly OutcomeBand[] = [
+  'critical-success',
+  'strong-success',
+  'success',
+  'failure',
+  'strong-failure',
+  'critical-failure',
+]
+
+/**
+ * What the dungeon master should actually *do* with each band.
+ *
+ * `BAND_BRIEF` says what the die meant; this says what to write. They are
+ * separate strings because they answer different questions, but they must never
+ * disagree — a model told "it fails and the situation gets worse" in one breath
+ * and "give them what they wanted" in the next will split the difference, and
+ * the split always lands in the player's favour.
+ *
+ * The way they are kept honest is that this record is the *only* source for
+ * both places the moves appear: the table in the system prompt is rendered from
+ * it, and the tool result at the point of the roll quotes the same entry. There
+ * is no second copy to fall out of date, which is the whole reason this lives
+ * in the domain next to the band it belongs to rather than being written out
+ * again inside the prompt.
+ *
+ * Six bands, not the five in the issue that asked for this. The issue's table
+ * was written against Dungeon World's three tiers and its row names collide
+ * with the band ids here — its "near miss" is this file's `success` (a success
+ * that costs something), and its "failure" is `strong-failure`. Mapping its
+ * five moves onto six bands rather than collapsing the bands keeps
+ * `resolveCheck` untouched and keeps the die card honest.
+ */
+export const BAND_MOVE: Record<OutcomeBand, string> = {
+  'critical-success':
+    'Give them what they were reaching for, and one thing more they never asked for — an opening, someone deciding to trust them, a way through that was not there a moment ago.',
+  'strong-success':
+    'Give them what they wanted, cleanly, and then get out of the way. A sentence is usually enough. Spend the rest of the turn on what is happening next, not on admiring the result.',
+  success:
+    'They get it, and it costs. Noise, time, something broken, somebody noticing. Put the cost in the fiction where they can see it, and do not soften it afterwards.',
+  failure:
+    'A soft move. Show the trouble arriving rather than landing — a hand closing on the latch, the rope starting to give, the sound getting nearer — and leave them room to answer it.',
+  'strong-failure':
+    'A hard move. Pick one from the list and let it happen. Do not replay the attempt back at them; the situation they are in afterwards must be a different situation.',
+  'critical-failure':
+    'A hard move that changes the scene: the floor gives way, the door shuts behind them, the thing they were avoiding is simply here now. Never one that ends the story.',
+}
+
+/**
+ * The hard moves, named so the model reaches for one instead of improvising a
+ * paragraph of consequence.
+ *
+ * Paraphrased from Dungeon World's GM moves rather than pasted. It is CC-BY so
+ * lifting would be permitted, but its register is not this game's — Dicebound is
+ * played at all ages and the list has to read that way.
+ */
+export const HARD_MOVES: readonly string[] = [
+  'Use up something they were relying on.',
+  'Put someone they care about in a bad spot.',
+  'Show a threat getting closer.',
+  'Offer them what they want, at a price.',
+  'Turn their own move back on them.',
+  'Separate them from someone or something.',
+  'Tell them an unwelcome truth about where they are.',
+]
+
 /** Player-facing label on the die card. */
 export const BAND_LABEL: Record<OutcomeBand, string> = {
   'critical-success': 'Critical success',


### PR DESCRIPTION
Closes #3524.

The `NARRATING` block asked the model to "narrate by degree" and trusted it to work out what a degree meant. This replaces that judgement call with a move keyed to the band the dice already produced.

## The issue's table does not match the game

The issue specifies **five** rows; `resolveCheck` produces **six** bands. The row names also collide with the band ids:

| issue row | what it describes | actual band |
| --- | --- | --- |
| "success" | what they wanted, cleanly | `strong-success` |
| "near miss" | success *with a cost* | `success` (labelled "Narrow success") |
| "failure" | a hard move | `strong-failure` |
| — | *fails, but small and still workable* | `failure` — **no row at all** |

Taken literally it would have mis-keyed half the table and left `failure`, the softest miss in the game, with no instruction. I mapped the five moves onto the real six instead, using `BAND_BRIEF` as the source of truth for what each band already means. `resolveCheck` is untouched and the die card is unchanged. The band the issue had no row for gets the soft move.

Rendered from the code:

```
Critical success — Give them what they were reaching for, and one thing more they never asked for…
Success         — Give them what they wanted, cleanly, and then get out of the way…
Narrow success  — They get it, and it costs. Noise, time, something broken, somebody noticing…
Near miss       — A soft move. Show the trouble arriving rather than landing…
Failure         — A hard move. Pick one from the list and let it happen…
Critical failure— A hard move that changes the scene… Never one that ends the story.
```

## Not drifting is a mechanism, not a promise

The first acceptance criterion is that `BAND_BRIEF` and the prompt must agree, because a model told *"it fails and the situation gets worse"* in one place and *"give them what they wanted"* in another will split the difference — and the split always lands in the player's favour.

Writing the table carefully into the prompt and hoping is not a mechanism. So `BAND_MOVE` lives in `dice.ts` beside the brief; the prompt's table is **rendered** from it; and the tool result quotes the same entry at the moment of the roll. There is no second copy that can go stale.

Repeating the move next to the number is not redundancy. A table read once at the top of a long prompt loses to whatever the model feels like doing by the time a roll comes back; the move quoted beside the result does not.

Four tests enforce it: every band has a move, brief and label; `BAND_ORDER` covers each exactly once so a rendered table cannot skip a row; no success band is ever told to make a hard move and `failure` is told to make a soft one; hard moves are concrete actions.

## Acceptance

- [x] **`BAND_BRIEF` and the prompt agree.** Structurally — same constant, plus tests.
- [x] **A failed check produces a changed situation, not a repeated one.** Six consecutive `strong-failure` bands on deliberately doomed attempts (a Strength −2, Size −2 mouse attempting things that need a giant). Each took a *different* hard move and left the player somewhere new:

  1. sack stack collapses, buried, stair cut off — *use up something they relied on* + *separate them*
  2. door holds, the boom gives away position; a blade-thing arrives and speaks — *show a threat getting closer*
  3. jump falls short; **the needle-sword goes into the water and is gone** — *use up something they relied on*
  4. grip tears loose, swept into the pipe — *separate them*
  5. wall is slime, washed out somewhere new — *show a threat getting closer*
  6. the shout tells everything exactly where they are — *turn their own move back on them*

  Nothing repeated. None said "you fail". Six straight failures and the story is more interesting, not over.
- [x] **Paraphrased, not pasted.** Dungeon World is CC-BY so lifting would be permitted, but its register is not this game's — Dicebound is played at all ages and the list reads that way.

## It did not undo #3525

| | before budget | after budget (2 runs) | with move list |
| --- | --- | --- | --- |
| median | 175 | 124 / 126 | **130** |
| p90 | 202 | 158 / 164 | **148** |
| max | 241 | 179 / 201 | **165** |
| mean | 172.8 | 116.3 / 122.8 | **122.5** |

Median held and the **tail tightened** — p90 and max are both below either previous run. A named move is a bounded thing to write; open guidance invited sprawl.

## Not claiming

Check rate read 80% here against 65% and 70% on the two previous runs. That is one run against two and I am not asserting the move list caused it. Dice-happiness (#3536's comment thread) is still unaddressed and still looks like the biggest remaining pacing problem — it wants its own issue rather than being folded into a voice PR.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  7 passed (7)
      Tests  116 passed (116)          # 112 before, +4 for the move list

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npx prettier --check <touched files>
All matched files use Prettier code style!
```

Plus two full campaigns against the live API — one 20-turn measured run, one doomed-attempt run read end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)