### PR TITLE
feat(dicebound): move campaign state server-side

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -48,6 +48,7 @@ import {
   MAX_ACTION,
   TRANSCRIPT_WINDOW,
   type TranscriptEntry,
+  trimToFit,
   validateCampaign,
 } from '@/app/dicebound/domain/campaign'
 import { attributeRank, earnedSkills, skillRank } from '@/app/dicebound/domain/character'
@@ -68,8 +69,10 @@ import {
   NARRATE_TOOL,
   ROLL_CHECK_TOOL,
   type TurnResult,
+  applyTurn,
   partitionTurnCalls,
 } from '@/app/dicebound/domain/turn'
+import { verifyRequestAuth } from '@/lib/api/auth'
 import {
   type ContentBlock,
   DM_MODEL,
@@ -85,6 +88,7 @@ import {
   toolSchema,
   toolUses,
 } from '@/lib/dicebound/anthropic'
+import { loadCampaign, saveCampaign } from '@/lib/dicebound/campaign-store'
 
 /** The DM can be slow, and a scene worth waiting for is worth the headroom. */
 export const maxDuration = 120
@@ -288,6 +292,56 @@ interface TurnRequest {
   action?: unknown
 }
 
+/**
+ * Find the campaign this turn runs against, and say whether the server owns it.
+ *
+ * Two callers, and the difference is not cosmetic.
+ *
+ * A request carrying a token gets the *stored* campaign, whatever it sent. That
+ * is the whole point of this issue: the mechanical facts of a saved game — skill
+ * ranks, and soon items, powers and edges — stop being something the client can
+ * assert and become something only a resolved turn can produce. The body's
+ * campaign is ignored outright once a stored one exists.
+ *
+ * The exception is a player who has no stored campaign yet, whose first turn
+ * carries the campaign that character creation just built. That is a creation,
+ * not an edit, and it is no weaker than the `PUT /campaign` the client would
+ * otherwise have called a moment earlier.
+ *
+ * A request with no token is the local-only backend — Firebase unconfigured, so
+ * there is no server-side story to protect and nothing to load. It keeps the old
+ * shape. Sending no token buys an attacker nothing: without a uid there is
+ * nowhere to persist the result, and they already own their own localStorage.
+ */
+async function campaignFor(
+  request: NextRequest,
+  body: TurnRequest
+): Promise<
+  { campaign: Campaign; uid: string | null } | { error: NextResponse } | { notFound: true }
+> {
+  const hasToken = /^Bearer\s+.+$/i.test(
+    request.headers.get('authorization') ?? request.headers.get('Authorization') ?? ''
+  )
+
+  if (!hasToken) {
+    const campaign = validateCampaign(body.campaign)
+    if (!campaign) {
+      return { error: NextResponse.json({ error: 'That is not a campaign.' }, { status: 400 }) }
+    }
+    return { campaign, uid: null }
+  }
+
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return { error: auth.error }
+
+  const stored = await loadCampaign(auth.claims.uid)
+  if (stored) return { campaign: stored, uid: auth.claims.uid }
+
+  const created = validateCampaign(body.campaign)
+  if (!created) return { notFound: true }
+  return { campaign: created, uid: auth.claims.uid }
+}
+
 export async function POST(request: NextRequest) {
   let body: TurnRequest
   try {
@@ -296,10 +350,20 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Expected a JSON body.' }, { status: 400 })
   }
 
-  const campaign = validateCampaign(body.campaign)
-  if (!campaign) {
-    return NextResponse.json({ error: 'That is not a campaign.' }, { status: 400 })
+  let found: Awaited<ReturnType<typeof campaignFor>>
+  try {
+    found = await campaignFor(request, body)
+  } catch (error) {
+    console.error('dicebound turn could not load the campaign:', error)
+    return NextResponse.json({ error: 'Could not find your story.' }, { status: 500 })
   }
+
+  if ('error' in found) return found.error
+  if ('notFound' in found) {
+    return NextResponse.json({ error: 'There is no story here yet.' }, { status: 404 })
+  }
+
+  const { campaign, uid } = found
 
   const action = typeof body.action === 'string' ? body.action.trim().slice(0, MAX_ACTION) : ''
   const isOpening = campaign.transcript.length === 0
@@ -316,7 +380,28 @@ export async function POST(request: NextRequest) {
     const result = isOpening
       ? await openStory(apiKey, campaign, controller.signal)
       : await playTurn(apiKey, campaign, action, controller.signal)
-    return NextResponse.json({ result })
+
+    // Anonymous-first (CLAUDE.md #1). `uid` is null only when there is no
+    // Firebase at all, and that player still gets their turn — they just apply
+    // and store it themselves, exactly as before.
+    if (uid === null) return NextResponse.json({ result })
+
+    // The server folds the turn in and hands back what it saved. Returning the
+    // whole campaign rather than a diff is deliberate: the client applying its
+    // own `applyTurn` to a result is precisely the client-side authority this
+    // issue removes, and two implementations of that arithmetic is two chances
+    // for the sheet and the save file to disagree. The request is a sentence;
+    // it is the response that carries the story.
+    const next = applyTurn(campaign, result, Date.now())
+    try {
+      await saveCampaign(uid, trimToFit(next))
+    } catch (error) {
+      // The turn happened and the player is owed it. A failed save reads as a
+      // dropped turn next reload, which is worse than nothing but far better
+      // than throwing away narration the model has already been paid for.
+      console.error('dicebound turn save failed:', error)
+    }
+    return NextResponse.json({ result, campaign: next })
   } catch (error) {
     clearTimeout(timeout)
 

--- a/src/app/dicebound/api.ts
+++ b/src/app/dicebound/api.ts
@@ -40,17 +40,50 @@ export async function createCharacter(concept: string, premise: string): Promise
   return body.character
 }
 
-export async function takeTurn(campaign: Campaign, action: string): Promise<TurnResult> {
+export interface TurnResponse {
+  result: TurnResult
+  /**
+   * The campaign the server saved. Present only on the authoritative path —
+   * when it is here, it replaces whatever the client was holding, and the
+   * client does not apply the result itself.
+   */
+  campaign?: Campaign
+}
+
+/**
+ * Take a turn.
+ *
+ * With a token the body is a sentence: the server loads its own campaign,
+ * resolves against that, saves, and returns what it saved.
+ *
+ * The one exception is the opening turn, which carries the campaign character
+ * creation just built, because the server has nothing to load yet. Every turn
+ * after that sends the action alone — which is the point, since a campaign
+ * grows to six figures of bytes and was being uploaded on every line the player
+ * typed.
+ *
+ * Without a token there is no server-side story, so the old shape stands: send
+ * the campaign, get a result, apply it here.
+ */
+export async function takeTurn(
+  action: string,
+  { token, campaign }: { token: string | null; campaign: Campaign }
+): Promise<TurnResponse> {
+  const creating = campaign.transcript.length === 0
+  const body = token ? (creating ? { action, campaign } : { action }) : { campaign, action }
+
   const response = await fetch('/api/v1/dicebound/turn', {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ campaign, action }),
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
   })
 
   if (!response.ok) {
     throw await errorFrom(response, 'The telling faltered. Try that again.')
   }
 
-  const body = (await response.json()) as { result: TurnResult }
-  return body.result
+  return (await response.json()) as TurnResponse
 }

--- a/src/app/dicebound/backend.ts
+++ b/src/app/dicebound/backend.ts
@@ -21,6 +21,18 @@ export interface CampaignBackend {
   load(): Promise<Campaign | null>
   save(campaign: Campaign): Promise<void>
   clear(): Promise<void>
+  /**
+   * A bearer token for the turn route, or null when this backend has no server
+   * side to speak of.
+   *
+   * This is what tells the store which of two games it is playing. With a token
+   * the server owns the campaign: it loads its own copy, resolves the turn,
+   * saves, and hands back what it saved. Without one — no Firebase configured,
+   * so nothing is stored anywhere but this browser — the client still sends its
+   * campaign and applies the result itself, because there is no server-side
+   * story to be authoritative about.
+   */
+  token(): Promise<string | null>
 }
 
 const STORAGE_KEY = 'dicebound:campaign'
@@ -60,6 +72,11 @@ export const localBackend: CampaignBackend = {
       // As above.
     }
   },
+
+  // No account, so no server-authoritative turn. This browser is the authority.
+  async token() {
+    return null
+  },
 }
 
 /** Remembers nothing. For server rendering and tests. */
@@ -69,6 +86,9 @@ export const nullBackend: CampaignBackend = {
   },
   async save() {},
   async clear() {},
+  async token() {
+    return null
+  },
 }
 
 const ENDPOINT = '/api/v1/dicebound/campaign'
@@ -127,5 +147,10 @@ export function accountBackend(getToken: () => Promise<string | null>): Campaign
         // As above.
       }
     },
+
+    // Handed straight to the turn route. Null here means the user is not signed
+    // in yet — including anonymously — and the caller falls back to sending its
+    // own campaign rather than failing the turn.
+    token: getToken,
   }
 }

--- a/src/app/dicebound/store.ts
+++ b/src/app/dicebound/store.ts
@@ -86,11 +86,17 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
       // attached is a form the player just filled in; the first paragraph is
       // what makes it a person.
       set({ campaign, phase: 'playing' })
-      const result = await takeTurn(campaign, '')
-      const opened = applyTurn(campaign, result, Date.now())
+
+      const token = await get().backend.token()
+      const { result, campaign: authoritative } = await takeTurn('', { token, campaign })
+      const opened = authoritative ?? applyTurn(campaign, result, Date.now())
 
       set({ campaign: opened, pending: false })
-      void get().backend.save(opened)
+      // Only the local path still writes from here. On the authoritative path
+      // the server already saved before it answered, and saving again would
+      // send the whole campaign straight back to the endpoint this change
+      // exists to stop trusting.
+      if (!authoritative) void get().backend.save(opened)
     } catch (error) {
       set({
         pending: false,
@@ -117,10 +123,15 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
     })
 
     try {
-      const result = await takeTurn(campaign, text)
-      const next = applyTurn(campaign, result, Date.now())
+      const token = await get().backend.token()
+      // `campaign` here is the pre-optimistic one on purpose. On the local path
+      // it is what the result gets applied to, and applying a turn to a
+      // campaign that already contains the player's line would record it twice.
+      const { result, campaign: authoritative } = await takeTurn(text, { token, campaign })
+      const next = authoritative ?? applyTurn(campaign, result, Date.now())
+
       set({ campaign: next, pending: false })
-      void get().backend.save(next)
+      if (!authoritative) void get().backend.save(next)
     } catch (error) {
       // Roll the optimistic line back out, so the player can edit and resend
       // rather than staring at an action the story never received.


### PR DESCRIPTION
Closes #3530.

The client held the campaign and POSTed the whole thing with every line the player typed, and `validateCampaign` treated that body as hostile. That was sound while every mechanical fact had a legal range to clamp to. It stops being sound the moment inventory exists — there is no range that distinguishes a power the story granted from a power the sender typed.

## What changed

A turn request is now a sentence. The route takes the token, loads the campaign stored for that uid, resolves against **that**, saves, and hands back what it saved. The body's campaign is ignored outright once a stored one exists.

**The creation exception.** A player with nothing stored yet sends the campaign character creation just built. That is a creation rather than an edit, and it is no weaker than the `PUT` the client would otherwise have made a moment earlier. It also means the opening scene does not depend on a fire-and-forget save having landed first.

**The response carries the campaign, not a diff.** Having the client run its own `applyTurn` against a result is exactly the client-side authority this removes, and two implementations of that arithmetic is two chances for the sheet and the save file to disagree. The request is a sentence; it is the response that is large.

**No token keeps the old shape.** That is the local-only backend — Firebase unconfigured, nothing stored anywhere but the browser, so there is no server-side story to be authoritative about. Omitting the token buys an attacker nothing: with no uid there is nowhere to persist a result, and they already own their own `localStorage`. A token that is *present but invalid* is a 401, not a fall-through to trusting the body — I tested that specifically, since it is the obvious way to try to get the permissive path back.

## Acceptance — all verified against the running app

Minted a real Firebase ID token via the admin SDK and drove the live routes.

- [x] **A turn request body is a sentence, not 185 KB.**
  ```
  NORMAL TURN request body is 48 bytes
  ```
- [x] **A crafted request cannot add an item, a power, a skill rank or an edge.** Took the server's own campaign, added a tier-3 Fireball with 9 charges and `hand-eye` at rank 3, and sent it with the turn:
  ```
  CRAFTED REQUEST:
    powers after:   []
    hand-eye after: undefined
  ```
  And the fall-through attempt:
  ```
  GARBAGE TOKEN: http 401 {"error":"Invalid auth token."}
  ```
- [x] **Anonymous play still works end to end, including on a fresh browser profile.** Exercised the actual anonymous flow — `accounts:signUp` with no credentials is what the web SDK's `signInAnonymously` does on a fresh profile:
  ```
  anonymous uid: NiWUYYHm0JSgz8OjVZAVGhTUosC2
  opening ok: true | title: The Town That Stopped
  turn ok:    true | transcript: 4
  persisted across reload: 4 entries | The Town That Stopped
  ```
- [x] **The local (no-Firebase) path is unchanged.** Live, no token: `http 200`, no `campaign` in the response, client applies as before.
- [x] **The optimistic player line and its rollback survive.** Untouched. One subtlety worth a look in review: `act` deliberately passes the *pre-optimistic* campaign to `takeTurn`, because on the local path applying a result to a campaign that already contains the player's line would record it twice.

## What this does not close

`PUT /campaign` is still open, and is now **the** remaining way to write a campaign the server did not author. The issue asks for it to be kept because the local path uses it, and notes it "must not be the only thing standing between a crafted request and a fabricated power" — after this change it is no longer the only thing, but it is still a door.

Worth its own issue. The shape I would suggest: allow `PUT` only when nothing is stored, and move the `withVisit` streak update server-side so the client has no remaining reason to write a whole campaign. I have not done it here because it is a separate behaviour change with its own acceptance.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  7 passed (7)
      Tests  123 passed (123)

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npm run build
✓ Compiled successfully

$ npx prettier --check <touched files>
All matched files use Prettier code style!
```

Branched off `main`. Unblocks #3531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)