### PR TITLE
feat(dicebound): narrate carries the clock and world deltas

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -72,6 +72,28 @@ import {
   applyTurn,
   partitionTurnCalls,
 } from '@/app/dicebound/domain/turn'
+import {
+  EDGE_KINDS,
+  ENTITY_KINDS,
+  ENTITY_STATUSES,
+  type EdgeKind,
+  type EntityKind,
+  type EntityStatus,
+  MAX_DISPOSITION,
+  MAX_EDGES_PER_TURN,
+  MAX_TOUCH_PER_TURN,
+  MAX_TURN_MINUTES,
+  MIN_DISPOSITION,
+  PRESSURES,
+  type Pressure,
+  RESOLUTIONS,
+  type Resolution,
+  type World,
+  applyWorldDelta,
+  describeClock,
+  ensurePlayer,
+  openThreads,
+} from '@/app/dicebound/domain/world'
 import { verifyRequestAuth } from '@/lib/api/auth'
 import {
   type ContentBlock,
@@ -188,6 +210,15 @@ NARRATING
 - Let failure move the story rather than stall it. A failed attempt should change the situation, not repeat it.
 - Keep the world consistent. Names, places and promises from earlier still hold.
 
+KEEPING THE WORLD
+Every narrate call also reports what changed. This is an index of the story, not a copy of it — the transcript is still the record, and anything you miss gets picked up later.
+- elapsed: how many minutes of story this turn actually took. Most turns are minutes. Be honest about long ones; you cannot skip past trouble by claiming a week went by.
+- safe: true only if the character could have rested here uninterrupted.
+- touch: the two or three things that changed or first appeared. Reuse the same id for the same thing forever — "harbour-guard" stays "harbour-guard". Do not restate what did not change.
+- edges: connections that formed or changed. Both ends must be things you registered in touch.
+- threads: loose ends that moved. Close one only when the story is genuinely finished with it.
+You report what happened. The server decides what it is worth — how far a disposition moves, when a relationship becomes old enough to matter, how much time a turn may consume. Do not try to set those.
+
 TONE
 - All ages. Adventure, danger, mystery and real stakes are welcome. Gore, cruelty and horror are not.
 - Take the player's premise completely seriously, however silly it is. "Pirates but everyone is a cat" is a real pirate story, and the cats are real pirates.
@@ -240,6 +271,74 @@ const NarrateSchema = z.object({
     .describe(
       'What happens. Second person, present tense. Open on the fiction and close on the fiction, within the word budget given for this turn. Never state the outcome in the abstract ("you fail", "you succeed") — show the thing itself.'
     ),
+  elapsed: z
+    .number()
+    .int()
+    .min(0)
+    .max(MAX_TURN_MINUTES)
+    .describe(
+      'Minutes of story this turn consumed. A conversation is 5, crossing a town is 30, a night is 480. Be honest and be small — most turns are minutes, not hours.'
+    ),
+  safe: z
+    .boolean()
+    .describe('True only if the character could have rested here without being interrupted.'),
+  touch: z
+    .array(
+      z.object({
+        id: z.string().describe('Stable lowercase slug. Reuse the same id for the same thing.'),
+        kind: z.enum(ENTITY_KINDS as unknown as [EntityKind, ...EntityKind[]]),
+        name: z.string().describe('What the player would call it.'),
+        note: z.string().optional().describe('One line, the first time you meet it.'),
+        state: z
+          .string()
+          .optional()
+          .describe('What is true about it NOW: "the bridge is burned", "hiding in the cellar".'),
+        status: z.enum(ENTITY_STATUSES as unknown as [EntityStatus, ...EntityStatus[]]).optional(),
+        disposition: z
+          .number()
+          .int()
+          .min(MIN_DISPOSITION)
+          .max(MAX_DISPOSITION)
+          .optional()
+          .describe(
+            'Actors only. Where this person now stands toward the player. Move it by one at most; the server will not take a larger step.'
+          ),
+      })
+    )
+    .max(MAX_TOUCH_PER_TURN)
+    .optional()
+    .describe(
+      'Only the two or three things that actually changed or first appeared this turn. This is an index, not a world state — do not restate what is unchanged.'
+    ),
+  edges: z
+    .array(
+      z.object({
+        from: z.string(),
+        to: z.string(),
+        kind: z.enum(EDGE_KINDS as unknown as [EdgeKind, ...EdgeKind[]]),
+        note: z.string().optional().describe('Why, in a few words: "for the boat he lost".'),
+      })
+    )
+    .max(MAX_EDGES_PER_TURN)
+    .optional()
+    .describe('New or changed connections. Both ends must be things you have registered in touch.'),
+  threads: z
+    .array(
+      z.object({
+        id: z.string(),
+        resolution: z
+          .enum(RESOLUTIONS as unknown as [Resolution, ...Resolution[]])
+          .optional()
+          .describe('Close a thread when the story has actually finished with it.'),
+        pressure: z
+          .enum(PRESSURES as unknown as [Pressure, ...Pressure[]])
+          .optional()
+          .describe('How soon this presses again.'),
+      })
+    )
+    .max(MAX_TOUCH_PER_TURN)
+    .optional()
+    .describe('Loose ends that moved. Register the thread itself in touch first.'),
 })
 
 const ROLL_CHECK: ToolDef = {
@@ -505,6 +604,8 @@ async function playTurn(
       role: 'user',
       content: `${sheetBlock(campaign)}
 
+${worldBlock(campaign.world)}
+
 PREMISE: "${campaign.premise}"
 ${(synopsis ?? campaign.synopsis) ? `\nTHE STORY SO FAR:\n${synopsis ?? campaign.synopsis}\n` : ''}
 ${transcriptBlock(history)}
@@ -517,6 +618,14 @@ Resolve it, then call narrate with what happens.`,
 
   const entries: TranscriptEntry[] = [{ kind: 'player', text: action }]
   let narration = ''
+  // The player is seeded before the first delta so that edges pointing at them
+  // have somewhere to land. An `owes(guard -> you)` with no `you` is dropped for
+  // having a missing endpoint, and that is most of what the graph is for.
+  let world = ensurePlayer(campaign.world, campaign.character.name)
+  // A fuse is allowed to reopen the turn exactly once. Without the flag a
+  // thread that fires on the interruption's own elapsed minutes could keep
+  // reopening it, and a turn that never stops is a turn that never comes back.
+  let fuseAnswered = false
 
   for (let step = 0; step <= MAX_CHECKS; step++) {
     const lastStep = step === MAX_CHECKS
@@ -544,7 +653,47 @@ Resolve it, then call narrate with what happens.`,
     const { rolls, ending, premature } = partitionTurnCalls(toolUses(data))
 
     if (ending) {
-      narration = narrationOf(ending.input)
+      const text = narrationOf(ending.input)
+      if (text) {
+        // Two narrations can happen in one turn — the action, then the thing
+        // that interrupted it — and both are the player's to read.
+        narration = narration ? `${narration}\n\n${text}` : text
+      }
+
+      const applied = applyWorldDelta(world, (ending.input ?? {}) as Record<string, unknown>)
+      world = applied.world
+
+      // The clock ran into an open thread's fuse. The turn is not over: the
+      // player asked for a week and got four hours, and they are owed the
+      // reason. This is the one place `narrate` is not terminal, and it costs a
+      // pass only when a fuse actually fires.
+      if (applied.interrupted && !fuseAnswered && !lastStep) {
+        fuseAnswered = true
+        // The narration is discarded, not kept, and this is the same rule that
+        // governs a `narrate` sent alongside a roll: it was written before a
+        // fact it depends on. The model narrated the whole span the player
+        // asked for — "dawn finds you still moving, by the second afternoon" —
+        // and then reported an `elapsed` that ran into a fuse forty-five
+        // minutes in. Keeping both gives the player two days of walking
+        // followed by an ambush that happened before breakfast. It could not
+        // have known where the clock would stop, so it does not get to describe
+        // the time that did not pass.
+        narration = ''
+
+        messages.push({ role: 'assistant', content: data.content ?? [] })
+        messages.push({
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: ending.id,
+              content: fuseBrief(world, applied.fired),
+            },
+          ],
+        })
+        continue
+      }
+
       break
     }
 
@@ -581,7 +730,26 @@ Resolve it, then call narrate with what happens.`,
   }
 
   entries.push({ kind: 'narration', text: narration })
-  return { entries, synopsis, dropped }
+  return { entries, synopsis, dropped, world }
+}
+
+/**
+ * What the DM is told when the clock ran into a fuse.
+ *
+ * It is handed a move to make, not a fact to mention. The thread caught up with
+ * the player; that is a hard move by definition, and the alternative — noting
+ * that time passed and carrying on — is how a deadline becomes scenery.
+ */
+function fuseBrief(world: World, fired: readonly string[]): string {
+  const names = fired
+    .map(id => world.entities[id])
+    .filter(entity => entity !== undefined)
+    .map(entity => `${entity.name}${entity.state ? ` (${entity.state})` : ''}`)
+
+  return [
+    `Your narration has been discarded — it described time that did not happen. The player did not get the span they asked for: ${names.join('; ') || 'something they had been ignoring'} caught up with them first, and it is now ${describeClock(world.clock)}.`,
+    'Narrate the whole turn again from the start, short, ending on that interruption as a hard move. Begin where they began, cover only the time that actually passed, and never mention a clock or say that less time went by than they wanted — just let the thing arrive.',
+  ].join(' ')
 }
 
 /**
@@ -666,6 +834,37 @@ function rollFor(campaign: Campaign, input: unknown): { entry: CheckEntry; brief
   ].join(' ')
 
   return { entry, brief }
+}
+
+/**
+ * The world, as much of it as the DM needs to stay consistent.
+ *
+ * Deliberately small. The point is that the model can reuse an id it has used
+ * before and knows what time it is; the full relevance window — who is nearby,
+ * what is dormant, what can be recalled — is #3533's problem, and sending the
+ * whole graph every turn would undo the prompt budget #3525 just bought.
+ */
+function worldBlock(world: World): string {
+  const known = Object.values(world.entities)
+    .filter(entity => entity.status === 'active')
+    .sort((a, b) => b.lastSeen - a.lastSeen)
+    .slice(0, 12)
+    .map(
+      entity =>
+        `  ${entity.id} (${entity.kind}) — ${entity.name}${entity.state ? `: ${entity.state}` : ''}`
+    )
+
+  const threads = openThreads(world)
+    .slice(0, 5)
+    .map(thread => `  ${thread.id} — ${thread.name} [${thread.pressure}]`)
+
+  return [
+    `TIME: ${describeClock(world.clock)}`,
+    known.length ? `KNOWN (reuse these ids):\n${known.join('\n')}` : '',
+    threads.length ? `LOOSE ENDS:\n${threads.join('\n')}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n')
 }
 
 /** The character sheet, as the DM sees it every turn. */

--- a/src/app/dicebound/domain/__tests__/world.test.ts
+++ b/src/app/dicebound/domain/__tests__/world.test.ts
@@ -3,16 +3,22 @@ import { describe, expect, it } from 'vitest'
 import {
   type Entity,
   FUSE_WINDOWS,
+  MAX_DISPOSITION,
+  MAX_DISPOSITION_STEP,
+  MAX_EDGES_PER_TURN,
   MAX_ENTITIES,
   MAX_FIRINGS,
+  MAX_TOUCH_PER_TURN,
   MAX_TURN_MINUTES,
   PLAYER_ID,
   type ThreadEntity,
   type World,
   advance,
+  applyWorldDelta,
   describeClock,
   emptyClock,
   emptyWorld,
+  ensurePlayer,
   fireThreads,
   openThreads,
   pruneWorld,
@@ -272,5 +278,223 @@ describe('validateWorld', () => {
     // The second edge points at an entity that never validated, so it goes too.
     expect(parsed.edges).toEqual([])
     expect(parsed.clock.elapsed).toBe(300)
+  })
+})
+
+describe('applyWorldDelta', () => {
+  function worldWith(...entities: Entity[]): World {
+    return {
+      ...emptyWorld(),
+      entities: Object.fromEntries(entities.map(e => [e.id, e])),
+    }
+  }
+
+  const innkeeper: Entity = {
+    id: 'innkeeper',
+    name: 'Bel',
+    kind: 'actor',
+    disposition: 0,
+    scale: 'person',
+    note: '',
+    state: '',
+    status: 'active',
+    firstSeen: 0,
+    lastSeen: 0,
+  }
+
+  it('survives a turn where the model returned nothing but text', () => {
+    // The commonest delta in practice. Nothing said is nothing changed, not an
+    // emptied world.
+    const before = worldWith(innkeeper)
+    const { world, fired, interrupted } = applyWorldDelta(before, {})
+
+    expect(world.entities.innkeeper).toEqual(innkeeper)
+    expect(fired).toEqual([])
+    expect(interrupted).toBe(false)
+  })
+
+  it('does not skip a year when the model asks for one', () => {
+    const { world } = applyWorldDelta(emptyWorld(), { elapsed: 525_600 })
+    expect(world.clock.elapsed).toBe(MAX_TURN_MINUTES)
+  })
+
+  it('stops the clock at a fuse and names the thread that caught up', () => {
+    const before: World = {
+      ...emptyWorld(),
+      entities: {
+        debt: thread({ id: 'debt', due: 240, pressure: 'pressing', resolution: 'open' }),
+      },
+    }
+    // "We travel for a week" — four hours in, the thing being ignored arrives.
+    const { world, fired, interrupted } = applyWorldDelta(before, { elapsed: MAX_TURN_MINUTES })
+
+    expect(world.clock.elapsed).toBe(240)
+    expect(fired).toEqual(['debt'])
+    expect(interrupted).toBe(true)
+  })
+
+  it('stamps Edge.since from the clock, never from the model', () => {
+    // The rule this protects: an edge must predate a turn to grant a bonus.
+    // Reading `since` from the model would let the DM invent a debt and cash it
+    // in the same breath.
+    const before = worldWith(innkeeper, { ...innkeeper, id: 'you', name: 'You' })
+    const { world } = applyWorldDelta(before, {
+      elapsed: 60,
+      edges: [{ from: 'innkeeper', to: 'you', kind: 'owes', note: 'for the boat', since: 0 }],
+    })
+
+    expect(world.edges).toHaveLength(1)
+    expect(world.edges[0].since).toBe(60)
+  })
+
+  it('keeps the original since when an edge is mentioned again', () => {
+    // Restamping would silently withdraw a bonus the player had already earned
+    // just because the DM brought the relationship up a second time.
+    const before = worldWith(innkeeper, { ...innkeeper, id: 'you', name: 'You' })
+    const first = applyWorldDelta(before, {
+      elapsed: 60,
+      edges: [{ from: 'innkeeper', to: 'you', kind: 'owes', note: 'for the boat' }],
+    })
+    const second = applyWorldDelta(first.world, {
+      elapsed: 600,
+      edges: [{ from: 'innkeeper', to: 'you', kind: 'owes', note: 'for the boat, still' }],
+    })
+
+    expect(second.world.edges).toHaveLength(1)
+    expect(second.world.edges[0].since).toBe(60)
+  })
+
+  it('drops an edge pointing at an entity that does not exist', () => {
+    // Worse than no edge: it renders as a relationship with a hole in it.
+    const { world } = applyWorldDelta(worldWith(innkeeper), {
+      edges: [{ from: 'innkeeper', to: 'nobody', kind: 'knows' }],
+    })
+    expect(world.edges).toEqual([])
+  })
+
+  it('moves disposition one step at a time, however far the model reached', () => {
+    // The model proposes a nudge; code applies it. A stranger does not become a
+    // sworn ally in one sentence, and the DM cannot hand itself a relationship
+    // bonus to spend on the next roll.
+    let world = worldWith(innkeeper)
+    world = applyWorldDelta(world, { touch: [{ id: 'innkeeper', disposition: 3 }] }).world
+
+    const after = world.entities.innkeeper
+    expect(after.kind === 'actor' && after.disposition).toBe(MAX_DISPOSITION_STEP)
+  })
+
+  it('takes several turns of warming to reach the ceiling, and stops there', () => {
+    let world = worldWith(innkeeper)
+    for (let i = 0; i < 10; i++) {
+      world = applyWorldDelta(world, { touch: [{ id: 'innkeeper', disposition: 3 }] }).world
+    }
+    const after = world.entities.innkeeper
+    expect(after.kind === 'actor' && after.disposition).toBe(MAX_DISPOSITION)
+  })
+
+  it('caps how much of the world one turn may touch', () => {
+    const touch = Array.from({ length: 20 }, (_, i) => ({
+      id: `place-${i}`,
+      name: `Place ${i}`,
+      kind: 'place',
+    }))
+    const { world } = applyWorldDelta(emptyWorld(), { touch })
+    expect(Object.keys(world.entities)).toHaveLength(MAX_TOUCH_PER_TURN)
+  })
+
+  it('caps how many edges one turn may draw', () => {
+    const touch = Array.from({ length: MAX_TOUCH_PER_TURN }, (_, i) => ({
+      id: `p${i}`,
+      name: `P${i}`,
+      kind: 'place',
+    }))
+    const edges = Array.from({ length: 20 }, (_, i) => ({
+      from: 'p0',
+      to: `p${(i % (MAX_TOUCH_PER_TURN - 1)) + 1}`,
+      kind: 'leads-to',
+    }))
+    const { world } = applyWorldDelta(emptyWorld(), { touch, edges })
+    expect(world.edges.length).toBeLessThanOrEqual(MAX_EDGES_PER_TURN)
+  })
+
+  it('drops an entity whose id normalises to nothing rather than inventing one', () => {
+    // An entity nobody can name is an entity no edge can point at, and a
+    // generated id would be a different name every turn.
+    const { world } = applyWorldDelta(emptyWorld(), {
+      touch: [{ id: '!!!', name: 'The Nameless', kind: 'place' }],
+    })
+    expect(Object.keys(world.entities)).toEqual([])
+  })
+
+  it('keeps the name an entity already had when a touch only updates its state', () => {
+    const { world } = applyWorldDelta(worldWith(innkeeper), {
+      touch: [{ id: 'innkeeper', state: 'behind the bar, wary' }],
+    })
+    expect(world.entities.innkeeper.name).toBe('Bel')
+    expect(world.entities.innkeeper.state).toBe('behind the bar, wary')
+  })
+
+  it('takes the fuse off a thread the story has finished with', () => {
+    // A kept promise that keeps its due time is how a resolved story goes on
+    // interrupting the one being told now.
+    const before: World = {
+      ...emptyWorld(),
+      entities: { debt: thread({ id: 'debt', due: 500, resolution: 'open' }) },
+    }
+    const { world } = applyWorldDelta(before, { threads: [{ id: 'debt', resolution: 'kept' }] })
+
+    const after = world.entities.debt as ThreadEntity
+    expect(after.resolution).toBe('kept')
+    expect(after.due).toBeNull()
+  })
+
+  it('re-arms the fuse when a thread is made more pressing', () => {
+    const before: World = {
+      ...emptyWorld(),
+      entities: {
+        debt: thread({ id: 'debt', due: 5000, pressure: 'patient', resolution: 'open' }),
+      },
+    }
+    const { world } = applyWorldDelta(before, {
+      elapsed: 30,
+      threads: [{ id: 'debt', pressure: 'urgent' }],
+    })
+
+    const after = world.entities.debt as ThreadEntity
+    expect(after.pressure).toBe('urgent')
+    expect(after.due).toBe(30 + FUSE_WINDOWS.urgent)
+  })
+
+  it('ignores a thread update naming something that is not a thread', () => {
+    const { world } = applyWorldDelta(worldWith(innkeeper), {
+      threads: [{ id: 'innkeeper', resolution: 'kept' }],
+    })
+    expect(world.entities.innkeeper).toEqual(innkeeper)
+  })
+})
+
+describe('ensurePlayer', () => {
+  it('puts the player in the world so edges have somewhere to land', () => {
+    // Without this every owes/fears/wants edge aimed at the player is dropped
+    // for a missing endpoint, and the graph fills with NPCs connected to
+    // nobody.
+    const world = ensurePlayer(emptyWorld(), 'Sir Pellam Crumb')
+    expect(world.entities[PLAYER_ID]?.name).toBe('Sir Pellam Crumb')
+  })
+
+  it('does not overwrite the player once they exist', () => {
+    const first = ensurePlayer(emptyWorld(), 'Bel')
+    const withState = {
+      ...first,
+      entities: {
+        ...first.entities,
+        [PLAYER_ID]: { ...first.entities[PLAYER_ID], state: 'bleeding' },
+      },
+    }
+    expect(ensurePlayer(withState, 'Bel').entities[PLAYER_ID].state).toBe('bleeding')
+  })
+
+  it('falls back to a name rather than an entity nobody can address', () => {
+    expect(ensurePlayer(emptyWorld(), '   ').entities[PLAYER_ID]?.name).toBe('You')
   })
 })

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -9,6 +9,7 @@
 import { type Character, recordSkillUse } from './character'
 
 import type { Campaign, CampaignStats, CheckEntry, TranscriptEntry } from './campaign'
+import type { World } from './world'
 
 /** A tool call as the turn loop sees it: a name, and whatever the model sent. */
 export interface ToolCall {
@@ -69,6 +70,14 @@ export interface TurnResult {
   synopsis?: string
   /** How many leading transcript entries the synopsis replaced. */
   dropped?: number
+  /**
+   * The world after the turn's deltas, clock included.
+   *
+   * Absent on the opening turn and on any path that did not reach a `narrate`
+   * — `applyTurn` keeps the campaign's existing world in that case rather than
+   * treating a missing field as an emptied graph.
+   */
+  world?: World
 }
 
 export function tallyChecks(stats: CampaignStats, entries: TranscriptEntry[]): CampaignStats {
@@ -127,6 +136,7 @@ export function applyTurn(campaign: Campaign, result: TurnResult, now: number): 
     ...campaign,
     title: result.title ?? campaign.title,
     synopsis: result.synopsis ?? campaign.synopsis,
+    world: result.world ?? campaign.world,
     character,
     transcript: [...kept, ...entries],
     stats: tallyChecks(campaign.stats, entries),

--- a/src/app/dicebound/domain/world.ts
+++ b/src/app/dicebound/domain/world.ts
@@ -317,6 +317,228 @@ export function fireThreads(world: World, fired: readonly EntityId[]): World {
   return { ...world, entities }
 }
 
+// ----------------------------------------------------------- turn deltas
+
+/**
+ * How much of the world one turn may touch.
+ *
+ * A turn that rewrites the world is a bug, not a big turn. The DM is indexing
+ * the two or three things that mattered this minute, not maintaining a
+ * simulation — anything it misses is `condense`'s problem to reconcile from the
+ * transcript, which is the authoritative record either way.
+ */
+export const MAX_TOUCH_PER_TURN = 6
+export const MAX_EDGES_PER_TURN = 6
+
+/** How far a single turn may move an actor's opinion of the player. */
+export const MAX_DISPOSITION_STEP = 1
+
+/** The state half of a `narrate` call, exactly as the model sent it. */
+export interface WorldDelta {
+  elapsed?: unknown
+  touch?: unknown
+  edges?: unknown
+  threads?: unknown
+}
+
+export interface AppliedDelta {
+  world: World
+  /** Threads whose fuse the clock ran into. The DM is told to make a move. */
+  fired: EntityId[]
+  /** True when a fuse cut the turn short. */
+  interrupted: boolean
+}
+
+/**
+ * Fold one turn's state report into the world.
+ *
+ * Every number here is the server's. The model says *that* an hour passed and
+ * *that* the innkeeper warmed to you; it does not get to say that the hour was
+ * a year or that the warming was +3. That split is the same one `roll_check`
+ * enforces for dice, and it matters more here, because a disposition or an
+ * `owes` edge is a modifier on a future roll — a model allowed to write those
+ * directly would be setting its own bonuses one turn in advance.
+ *
+ * Order is load-bearing. The clock moves first, because everything stamped this
+ * turn — `lastSeen`, `firstSeen`, `Edge.since`, a re-armed fuse — is stamped
+ * from where the clock actually stopped, which may be earlier than where the
+ * turn asked to go.
+ */
+/**
+ * Make sure the player is in their own world.
+ *
+ * Everything interesting the graph holds is a relationship *to the player* —
+ * who is owed what, who is afraid of whom. Without an entity to point at, every
+ * one of those edges is dropped for having a missing endpoint, and the graph
+ * fills up with places and NPCs who have nothing to do with anybody. It is
+ * seeded here rather than in `newCampaign` so that campaigns migrated from v1,
+ * which never had a world at all, get it too.
+ */
+export function ensurePlayer(world: World, name: string): World {
+  const existing = world.entities[PLAYER_ID]
+  if (existing) return world
+
+  return {
+    ...world,
+    entities: {
+      ...world.entities,
+      [PLAYER_ID]: {
+        id: PLAYER_ID,
+        kind: 'actor',
+        name: str(name, MAX_NAME).trim() || 'You',
+        note: 'The player.',
+        state: '',
+        status: 'active',
+        disposition: 0,
+        scale: 'person',
+        firstSeen: world.clock.elapsed,
+        lastSeen: world.clock.elapsed,
+      },
+    },
+  }
+}
+
+export function applyWorldDelta(world: World, delta: WorldDelta): AppliedDelta {
+  const { clock, fired, interrupted } = advance(world.clock, delta.elapsed, world)
+
+  // The clock is set before threads fire, because `fireThreads` re-arms the
+  // next fuse from `world.clock.elapsed`. Firing against the old clock would
+  // schedule the next pressing from a moment that has already passed.
+  let next = fireThreads({ ...world, clock }, fired)
+  const now = clock.elapsed
+
+  next = applyTouches(next, delta.touch, now)
+  next = applyThreadUpdates(next, delta.threads, now)
+  next = applyEdges(next, delta.edges, now)
+
+  return { world: pruneWorld(next), fired, interrupted }
+}
+
+function applyTouches(world: World, touch: unknown, now: number): World {
+  if (!Array.isArray(touch)) return world
+
+  const entities = { ...world.entities }
+  let applied = 0
+
+  for (const raw of touch) {
+    if (applied >= MAX_TOUCH_PER_TURN) break
+    if (!isPlainObject(raw)) continue
+
+    const id = slug(raw.id)
+    // An entity whose id normalises to nothing is dropped rather than given a
+    // generated one. An entity nobody can name is an entity no edge can point
+    // at, and a generated id would be a different name every turn.
+    if (!id) continue
+
+    const existing = entities[id]
+    const merged = validateEntity({
+      ...existing,
+      ...raw,
+      id,
+      // A name is required by `validateEntity`, so a touch that only updates
+      // state on a known entity keeps the name it already had.
+      name: str(raw.name, MAX_NAME).trim() || existing?.name,
+      kind: existing?.kind ?? raw.kind,
+      firstSeen: existing?.firstSeen ?? now,
+      lastSeen: now,
+    })
+    if (!merged) continue
+
+    if (merged.kind === 'actor') {
+      // The model proposes a nudge; this applies it. Clamped to one step per
+      // turn and to the overall range, so nobody goes from stranger to sworn
+      // ally in a single sentence — and so the DM cannot hand itself a +3
+      // relationship bonus to spend on the next roll.
+      const before = existing?.kind === 'actor' ? existing.disposition : 0
+      const proposed = boundedInt(raw.disposition, MIN_DISPOSITION, MAX_DISPOSITION)
+      const step = Math.max(
+        -MAX_DISPOSITION_STEP,
+        Math.min(MAX_DISPOSITION_STEP, proposed - before)
+      )
+      merged.disposition = boundedInt(before + step, MIN_DISPOSITION, MAX_DISPOSITION)
+    }
+
+    entities[id] = merged
+    applied += 1
+  }
+
+  return { ...world, entities }
+}
+
+function applyThreadUpdates(world: World, threads: unknown, now: number): World {
+  if (!Array.isArray(threads)) return world
+
+  const entities = { ...world.entities }
+  let applied = 0
+
+  for (const raw of threads) {
+    if (applied >= MAX_TOUCH_PER_TURN) break
+    if (!isPlainObject(raw)) continue
+
+    const id = slug(raw.id)
+    const thread = entities[id]
+    if (!thread || thread.kind !== 'thread') continue
+
+    const resolution = oneOf(raw.resolution, RESOLUTIONS, thread.resolution)
+    const pressure = oneOf(raw.pressure, PRESSURES, thread.pressure)
+    const stillOpen = resolution === 'open'
+
+    entities[id] = {
+      ...thread,
+      resolution,
+      pressure,
+      // A closed thread loses its fuse. Leaving `due` set on a kept promise is
+      // how a resolved story keeps interrupting the one being told now.
+      due: stillOpen
+        ? pressure === thread.pressure
+          ? thread.due
+          : now + FUSE_WINDOWS[pressure]
+        : null,
+      status: stillOpen ? thread.status : 'dormant',
+      lastSeen: now,
+    }
+    applied += 1
+  }
+
+  return { ...world, entities }
+}
+
+function applyEdges(world: World, edges: unknown, now: number): World {
+  if (!Array.isArray(edges)) return world
+
+  const out = [...world.edges]
+  let applied = 0
+
+  for (const raw of edges) {
+    if (applied >= MAX_EDGES_PER_TURN) break
+
+    // `since` is stamped here and never read from the model. It is what makes
+    // "an edge must predate this turn to grant a bonus" enforceable — without
+    // it the DM could invent `owes(guard → you)` and cash it in the same
+    // breath, which is situational modifiers with extra steps.
+    const edge = validateEdge({ ...(isPlainObject(raw) ? raw : {}), since: now })
+    if (!edge) continue
+
+    // Both endpoints must exist. An edge pointing at nothing renders as a
+    // relationship with a hole in it, and reconciliation can rebuild it later
+    // from the transcript if it was real.
+    if (!world.entities[edge.from] || !world.entities[edge.to]) continue
+
+    const at = out.findIndex(e => e.from === edge.from && e.to === edge.to && e.kind === edge.kind)
+    if (at === -1) {
+      out.push(edge)
+    } else {
+      // Re-asserting an edge keeps the original `since`. Restamping it to now
+      // would silently withdraw a bonus the player had already earned, just
+      // because the DM mentioned the relationship again.
+      out[at] = { ...edge, since: Math.min(out[at].since, edge.since) }
+    }
+    applied += 1
+  }
+
+  return { ...world, edges: out }
+}
+
 // ------------------------------------------------------------ housekeeping
 
 /** Open threads, most pressing first. This is the player's "loose ends". */


### PR DESCRIPTION
Closes #3531.

The terminal `narrate` call now returns prose **and** state together, so keeping the world costs no extra round trip.

## The split, again

Everything the model sends is a report, not a decision. It says *that* an hour passed and *that* the innkeeper warmed to you; the server decides that the hour is capped, that the warming is one step, and when a relationship became old enough to matter.

`Edge.since` is stamped from the clock and never read from the model. That is what makes "an edge must predate this turn to grant a bonus" enforceable — without it the DM could invent `owes(guard → you)` and cash it on the same roll.

**Order inside `applyWorldDelta` is load-bearing.** The clock moves first, because everything stamped this turn — `lastSeen`, `Edge.since`, a re-armed fuse — is stamped from where the clock *actually stopped*, which may be earlier than where the turn asked to go. Threads fire after the clock is set, since `fireThreads` re-arms the next fuse from `world.clock.elapsed`.

## Two things the live runs forced, that I would not have found by reading

**The player was not in their own world.** Everything the graph is *for* is a relationship to the player, and with no entity to point at, every such edge was dropped for a missing endpoint. The first live run produced a tidy world of NPCs connected to nobody. `ensurePlayer` runs against the campaign rather than in `newCampaign`, so v1 campaigns — which never had a world at all — get it too.

**A fuse now discards the narration that preceded it.** The model writes prose and reports `elapsed` in the same call, so on a turn that runs into a fuse it has *already* described the whole span the player asked for. The first run read:

> *"Dawn finds you still moving. Midday finds you slower. By the second afternoon your legs have stopped being yours…"*

— and then stopped the clock **45 minutes in**. Two days of walking followed by an ambush that happened before breakfast.

It could not have known where the clock would stop, so it does not get to describe time that did not pass. This is exactly the rule that already governs a `narrate` sent alongside a roll, applied to the other fact the model cannot see in advance. After the fix, same scenario:

> *"You put your head down and set the pace you can hold forever, the courier's pace… Three switchbacks. Four. Then the scree above you clatters — not behind, above — and a grey shape drops onto the road twenty feet ahead."*

## Acceptance — verified live

- [x] **One model call per narration. No separate bookkeeping pass.** State rides on `narrate`. A fuse costs one extra pass, but that is a second *narration*, not bookkeeping, and only when a fuse actually fires.
- [x] **A turn that crosses a fuse stops the clock there and the DM is told to make a move.** Seeded a `threat` thread due at minute 45, then asked for a night and a day:
  ```
  clock stopped at: 90 min  (fuse was at 45; a night and a day was asked for)
  thread firings: 1 | pressure: urgent | next due: 105
  ```
  The wolves came around, ahead and behind. The hard move made itself.
- [x] **`elapsed: 525600` does not skip a year.** Unit test — clamped to `MAX_TURN_MINUTES`.
- [x] **The world survives a turn where the model returns nothing but `text`.** Unit test. Nothing said is nothing changed, not an emptied world.

Live three-turn run showing ids staying stable and disposition moving one step at a time:

```
turn 1  clock 6min   you(d=0), kettleby(d=0), counting-house, tall-man-ledger(d=-1), pells-note
turn 2  clock 8min   kettleby(d=1), tall-man-ledger(d=0)
turn 3  clock 14min  + quay, black-lighter    edges: black-lighter -at-> quay @14
```

## Known softness, not a blocker

The model draws **edges** sparingly — it registers entities readily but often does not connect them. That is what reconciliation (#3532) exists to repair from the transcript, and the graph is explicitly an index rather than a simulation. Worth watching after #3532 lands; if it is still thin then, it is a prompt problem rather than an architecture one.

Also: on a fuse continuation the second `elapsed` is applied, and if it crosses *another* fuse that thread escalates without being narrated. Bounded and rare, and the alternative is a turn that can reopen itself indefinitely.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  7 passed (7)
      Tests  141 passed (141)          # 123 before, +18

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npm run build
✓ Compiled successfully
```

Branched off `main`. Unblocks #3532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)