### PR TITLE
feat(dicebound): reconciliation and chapter archiving in condense

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -86,6 +86,8 @@ import {
   MIN_DISPOSITION,
   PRESSURES,
   type Pressure,
+  RECONCILE_EDGES,
+  RECONCILE_TOUCH,
   RESOLUTIONS,
   type Resolution,
   type World,
@@ -93,6 +95,7 @@ import {
   describeClock,
   ensurePlayer,
   openThreads,
+  reconcileWorld,
 } from '@/app/dicebound/domain/world'
 import { verifyRequestAuth } from '@/lib/api/auth'
 import {
@@ -110,7 +113,7 @@ import {
   toolSchema,
   toolUses,
 } from '@/lib/dicebound/anthropic'
-import { loadCampaign, saveCampaign } from '@/lib/dicebound/campaign-store'
+import { archiveChapter, loadCampaign, saveCampaign } from '@/lib/dicebound/campaign-store'
 
 /** The DM can be slow, and a scene worth waiting for is worth the headroom. */
 export const maxDuration = 120
@@ -478,7 +481,7 @@ export async function POST(request: NextRequest) {
     const apiKey = requireApiKey()
     const result = isOpening
       ? await openStory(apiKey, campaign, controller.signal)
-      : await playTurn(apiKey, campaign, action, controller.signal)
+      : await playTurn(apiKey, campaign, action, controller.signal, uid)
 
     // Anonymous-first (CLAUDE.md #1). `uid` is null only when there is no
     // Firebase at all, and that player still gets their turn — they just apply
@@ -586,16 +589,45 @@ async function playTurn(
   apiKey: string,
   campaign: Campaign,
   action: string,
-  signal: AbortSignal
+  signal: AbortSignal,
+  uid: string | null
 ): Promise<TurnResult> {
   // Condense before building the prompt, so a long campaign sends a bounded
   // window and the synopsis the model reads is already current.
   let synopsis: string | undefined
   let dropped: number | undefined
+  let chapters: number | undefined
+  let repaired: World | undefined
+
   if (campaign.transcript.length > CONDENSE_AT) {
     const cut = campaign.transcript.length - TRANSCRIPT_WINDOW
+    const older = campaign.transcript.slice(0, cut)
+
     synopsis = await condense(apiKey, campaign, cut, signal)
     dropped = cut
+
+    // Archived before anything else touches it. `condense` used to be the only
+    // lossy operation in the game; the chapter is what makes the loss a change
+    // of address rather than a deletion, and it has to happen even if the
+    // reconciliation below falls over.
+    if (uid) {
+      try {
+        await archiveChapter(uid, {
+          index: campaign.chapters,
+          entries: older,
+          synopsis: synopsis || campaign.synopsis,
+          archivedAt: campaign.world.clock.elapsed,
+        })
+        chapters = campaign.chapters + 1
+      } catch (error) {
+        // A failed archive must not cost the player their turn. It does cost
+        // this slice of transcript, which is why it is logged loudly rather
+        // than swallowed silently like a save.
+        console.error('dicebound chapter archive failed:', error)
+      }
+    }
+
+    repaired = await reconcile(apiKey, campaign, older, signal)
   }
 
   const history = campaign.transcript.slice(dropped ?? 0)
@@ -621,7 +653,7 @@ Resolve it, then call narrate with what happens.`,
   // The player is seeded before the first delta so that edges pointing at them
   // have somewhere to land. An `owes(guard -> you)` with no `you` is dropped for
   // having a missing endpoint, and that is most of what the graph is for.
-  let world = ensurePlayer(campaign.world, campaign.character.name)
+  let world = ensurePlayer(repaired ?? campaign.world, campaign.character.name)
   // A fuse is allowed to reopen the turn exactly once. Without the flag a
   // thread that fires on the interruption's own elapsed minutes could keep
   // reopening it, and a turn that never stops is a turn that never comes back.
@@ -730,7 +762,7 @@ Resolve it, then call narrate with what happens.`,
   }
 
   entries.push({ kind: 'narration', text: narration })
-  return { entries, synopsis, dropped, world }
+  return { entries, synopsis, dropped, world, chapters }
 }
 
 /**
@@ -907,6 +939,106 @@ function transcriptBlock(entries: TranscriptEntry[]): string {
   })
 
   return `RECENT PLAY:\n${lines.join('\n\n')}`
+}
+
+const ReconcileSchema = z.object({
+  touch: z
+    .array(
+      z.object({
+        id: z.string().describe('Stable lowercase slug.'),
+        kind: z.enum(ENTITY_KINDS as unknown as [EntityKind, ...EntityKind[]]),
+        name: z.string(),
+        note: z.string().optional(),
+        state: z.string().optional().describe('How it stands at the END of this stretch.'),
+      })
+    )
+    .max(RECONCILE_TOUCH)
+    .optional(),
+  edges: z
+    .array(
+      z.object({
+        from: z.string(),
+        to: z.string(),
+        kind: z.enum(EDGE_KINDS as unknown as [EdgeKind, ...EdgeKind[]]),
+        note: z.string().optional(),
+      })
+    )
+    .max(RECONCILE_EDGES)
+    .optional(),
+})
+
+/**
+ * Rebuild the graph from the prose, then tidy what is left.
+ *
+ * The DM maintains the index in passing, two or three entities at a time, while
+ * doing something else. It drifts — people get named and never registered,
+ * relationships get described and never drawn — and that drift is the price of
+ * not making it run a simulation every turn. This is where the price is paid,
+ * inside `condense`, because that is the one moment the game has already
+ * accepted a slow call and the player is already waiting.
+ *
+ * The transcript is the authority here, not the graph. That is the whole
+ * premise: the index is rebuilt from the story, never the other way round.
+ *
+ * A failure is survivable by construction. The caller keeps the previous world
+ * and the turn proceeds, which reads as a DM whose notes are slightly behind —
+ * exactly how a failed `condense` already reads.
+ */
+async function reconcile(
+  apiKey: string,
+  campaign: Campaign,
+  older: TranscriptEntry[],
+  signal: AbortSignal
+): Promise<World> {
+  const now = campaign.world.clock.elapsed
+
+  try {
+    const input = (await callForTool({
+      apiKey,
+      model: UTILITY_MODEL,
+      system: `You keep the table's index. You are given a stretch of play and the entities already on file, and you list what the story actually contains: the people, places, things and loose ends that matter, and how they are connected.
+
+Reuse an existing id whenever the story means the same thing — matching an id is the entire point, and a second id for the same person is worse than a missing one. Invent an id only for something genuinely absent from the file. Use lowercase-hyphenated ids.
+
+Register only what the story would notice going missing. A tavern the player slept in once is worth keeping; the bowl they ate from is not. Describe state as it stands at the END of this stretch, not as it was in the middle.`,
+      maxTokens: 2000,
+      signal,
+      messages: [
+        {
+          role: 'user',
+          content: `ALREADY ON FILE:
+${
+  Object.values(campaign.world.entities)
+    .map(entity => `  ${entity.id} (${entity.kind}) — ${entity.name}`)
+    .join('\n') || '  nothing yet'
+}
+
+THE STRETCH OF PLAY:
+${transcriptBlock(older)}`,
+        },
+      ],
+      tool: {
+        name: 'index_world',
+        description: 'Record what this stretch of story contains.',
+        input_schema: toolSchema(ReconcileSchema),
+      },
+    })) as Record<string, unknown>
+
+    // Applied through the same path a turn's deltas take, so reconciliation
+    // cannot write anything a turn could not have written. `elapsed: 0` because
+    // this is bookkeeping about time that has already passed — advancing the
+    // clock here would move the story forward for having tidied its notes.
+    const { world } = applyWorldDelta(
+      campaign.world,
+      { elapsed: 0, touch: input.touch, edges: input.edges },
+      { touch: RECONCILE_TOUCH, edges: RECONCILE_EDGES }
+    )
+    return reconcileWorld(world, now)
+  } catch (error) {
+    console.error('dicebound reconcile failed:', error)
+    // Still worth the pure pass: dormancy and cold threads need no model.
+    return reconcileWorld(campaign.world, now)
+  }
 }
 
 /**

--- a/src/app/dicebound/domain/__tests__/world.test.ts
+++ b/src/app/dicebound/domain/__tests__/world.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  DORMANT_AFTER,
   type Entity,
   FUSE_WINDOWS,
   MAX_DISPOSITION,
@@ -22,6 +23,7 @@ import {
   fireThreads,
   openThreads,
   pruneWorld,
+  reconcileWorld,
   timeOfDay,
   validateEdge,
   validateEntity,
@@ -496,5 +498,85 @@ describe('ensurePlayer', () => {
 
   it('falls back to a name rather than an entity nobody can address', () => {
     expect(ensurePlayer(emptyWorld(), '   ').entities[PLAYER_ID]?.name).toBe('You')
+  })
+})
+
+describe('reconcileWorld', () => {
+  const actor = (id: string, lastSeen: number): Entity => ({
+    id,
+    kind: 'actor',
+    name: id,
+    note: '',
+    state: '',
+    status: 'active',
+    disposition: 0,
+    scale: 'person',
+    firstSeen: 0,
+    lastSeen,
+  })
+
+  function worldOf(now: number, ...entities: Entity[]): World {
+    return {
+      clock: { elapsed: now, startHour: 9 },
+      entities: Object.fromEntries(entities.map(e => [e.id, e])),
+      edges: [],
+    }
+  }
+
+  it('lets someone who walked out of the story go dormant', () => {
+    const now = DORMANT_AFTER * 2
+    const world = reconcileWorld(worldOf(now, actor('ferryman', 0)), now)
+    expect(world.entities.ferryman.status).toBe('dormant')
+  })
+
+  it('keeps someone who was just here active', () => {
+    const now = DORMANT_AFTER * 2
+    const world = reconcileWorld(worldOf(now, actor('bel', now - 10)), now)
+    expect(world.entities.bel.status).toBe('active')
+  })
+
+  it('never lets the player go dormant in their own story', () => {
+    const now = DORMANT_AFTER * 5
+    const world = reconcileWorld(worldOf(now, actor(PLAYER_ID, 0)), now)
+    expect(world.entities[PLAYER_ID].status).toBe('active')
+  })
+
+  it('keeps an unmentioned open thread in front of the DM', () => {
+    // A debt nobody has spoken of for a week is exactly the thing that should
+    // still be pressing. Going dormant would quietly forgive it.
+    const now = DORMANT_AFTER * 3
+    const world = reconcileWorld(
+      worldOf(now, thread({ id: 'debt', resolution: 'open', lastSeen: 0 })),
+      now
+    )
+    expect(world.entities.debt.status).toBe('active')
+  })
+
+  it('retires a thread that fired its allowance without ever being engaged', () => {
+    const now = 100
+    const world = reconcileWorld(
+      worldOf(now, thread({ id: 'old-promise', resolution: 'cold', due: 500, lastSeen: now })),
+      now
+    )
+    const after = world.entities['old-promise'] as ThreadEntity
+    expect(after.status).toBe('dormant')
+    expect(after.due).toBeNull()
+  })
+
+  it('drops an edge whose endpoint did not survive the pass', () => {
+    const now = 0
+    const base = worldOf(now, actor('bel', 0))
+    const world = reconcileWorld(
+      { ...base, edges: [{ from: 'bel', to: 'ghost', kind: 'knows', note: '', since: 0 }] },
+      now
+    )
+    expect(world.edges).toEqual([])
+  })
+
+  it('does not mutate the world it was given', () => {
+    const now = DORMANT_AFTER * 2
+    const before = worldOf(now, actor('ferryman', 0))
+    reconcileWorld(before, now)
+    expect(before.entities.ferryman.status).toBe('active')
   })
 })

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -78,6 +78,13 @@ export interface TurnResult {
    * treating a missing field as an emptied graph.
    */
   world?: World
+  /**
+   * The chapter counter after an archive. Set only on a turn that condensed and
+   * successfully wrote what it dropped — a failed archive leaves the counter
+   * alone, so the next condense reuses the index and overwrites rather than
+   * leaving a gap where a chapter should be.
+   */
+  chapters?: number
 }
 
 export function tallyChecks(stats: CampaignStats, entries: TranscriptEntry[]): CampaignStats {
@@ -137,6 +144,7 @@ export function applyTurn(campaign: Campaign, result: TurnResult, now: number): 
     title: result.title ?? campaign.title,
     synopsis: result.synopsis ?? campaign.synopsis,
     world: result.world ?? campaign.world,
+    chapters: result.chapters ?? campaign.chapters,
     character,
     transcript: [...kept, ...entries],
     stats: tallyChecks(campaign.stats, entries),

--- a/src/app/dicebound/domain/world.ts
+++ b/src/app/dicebound/domain/world.ts
@@ -330,6 +330,26 @@ export function fireThreads(world: World, fired: readonly EntityId[]): World {
 export const MAX_TOUCH_PER_TURN = 6
 export const MAX_EDGES_PER_TURN = 6
 
+/**
+ * The same caps for the reconciliation pass, which is allowed to be much
+ * bigger.
+ *
+ * A turn touching forty entities is a DM that has stopped telling a story and
+ * started filing. A *reconciliation* touching forty is the repair pass reading
+ * twenty turns of prose at once, which is exactly its job — it is rebuilding
+ * the index, not maintaining it.
+ */
+export const RECONCILE_TOUCH = 40
+export const RECONCILE_EDGES = 40
+
+/** How much of the world one call to `applyWorldDelta` may rewrite. */
+export interface DeltaLimits {
+  touch: number
+  edges: number
+}
+
+const TURN_LIMITS: DeltaLimits = { touch: MAX_TOUCH_PER_TURN, edges: MAX_EDGES_PER_TURN }
+
 /** How far a single turn may move an actor's opinion of the player. */
 export const MAX_DISPOSITION_STEP = 1
 
@@ -398,7 +418,11 @@ export function ensurePlayer(world: World, name: string): World {
   }
 }
 
-export function applyWorldDelta(world: World, delta: WorldDelta): AppliedDelta {
+export function applyWorldDelta(
+  world: World,
+  delta: WorldDelta,
+  limits: DeltaLimits = TURN_LIMITS
+): AppliedDelta {
   const { clock, fired, interrupted } = advance(world.clock, delta.elapsed, world)
 
   // The clock is set before threads fire, because `fireThreads` re-arms the
@@ -407,21 +431,21 @@ export function applyWorldDelta(world: World, delta: WorldDelta): AppliedDelta {
   let next = fireThreads({ ...world, clock }, fired)
   const now = clock.elapsed
 
-  next = applyTouches(next, delta.touch, now)
-  next = applyThreadUpdates(next, delta.threads, now)
-  next = applyEdges(next, delta.edges, now)
+  next = applyTouches(next, delta.touch, now, limits.touch)
+  next = applyThreadUpdates(next, delta.threads, now, limits.touch)
+  next = applyEdges(next, delta.edges, now, limits.edges)
 
   return { world: pruneWorld(next), fired, interrupted }
 }
 
-function applyTouches(world: World, touch: unknown, now: number): World {
+function applyTouches(world: World, touch: unknown, now: number, limit: number): World {
   if (!Array.isArray(touch)) return world
 
   const entities = { ...world.entities }
   let applied = 0
 
   for (const raw of touch) {
-    if (applied >= MAX_TOUCH_PER_TURN) break
+    if (applied >= limit) break
     if (!isPlainObject(raw)) continue
 
     const id = slug(raw.id)
@@ -465,14 +489,14 @@ function applyTouches(world: World, touch: unknown, now: number): World {
   return { ...world, entities }
 }
 
-function applyThreadUpdates(world: World, threads: unknown, now: number): World {
+function applyThreadUpdates(world: World, threads: unknown, now: number, limit: number): World {
   if (!Array.isArray(threads)) return world
 
   const entities = { ...world.entities }
   let applied = 0
 
   for (const raw of threads) {
-    if (applied >= MAX_TOUCH_PER_TURN) break
+    if (applied >= limit) break
     if (!isPlainObject(raw)) continue
 
     const id = slug(raw.id)
@@ -503,14 +527,14 @@ function applyThreadUpdates(world: World, threads: unknown, now: number): World 
   return { ...world, entities }
 }
 
-function applyEdges(world: World, edges: unknown, now: number): World {
+function applyEdges(world: World, edges: unknown, now: number, limit: number): World {
   if (!Array.isArray(edges)) return world
 
   const out = [...world.edges]
   let applied = 0
 
   for (const raw of edges) {
-    if (applied >= MAX_EDGES_PER_TURN) break
+    if (applied >= limit) break
 
     // `since` is stamped here and never read from the model. It is what makes
     // "an edge must predate this turn to grant a bonus" enforceable — without
@@ -537,6 +561,61 @@ function applyEdges(world: World, edges: unknown, now: number): World {
   }
 
   return { ...world, edges: out }
+}
+
+/**
+ * How long an entity may go unmentioned before it stops being sent to the DM.
+ *
+ * Three days of fiction, matching the patient fuse window. Dormant is not gone:
+ * the entity is still there to be pulled back, which is how "wait, that's the
+ * man from the harbour" works twelve chapters later. What this buys is a prompt
+ * that describes the scene the player is in rather than every scene they have
+ * ever been in.
+ */
+export const DORMANT_AFTER = 3 * 24 * 60
+
+/**
+ * The repair pass, run when `condense` runs.
+ *
+ * The graph is an index the DM maintains in passing, two or three entities at a
+ * time, while doing something else. It drifts: things get mentioned and never
+ * registered, people stay `active` for a week of fiction after walking out of
+ * the story, threads go cold and keep sitting in the loose-ends list. None of
+ * that is a bug in the DM — it is the cost of not making it maintain a
+ * simulation, and this is where it gets paid.
+ *
+ * Pure. The half that needs a model — reading prose for entities that were
+ * never registered — happens in the route and arrives here already applied.
+ */
+export function reconcileWorld(world: World, now: number): World {
+  const entities: Record<EntityId, Entity> = {}
+
+  for (const entity of Object.values(world.entities)) {
+    // The player never goes dormant, and neither does open business. A debt
+    // nobody has mentioned for a week is exactly the thing that should still
+    // be in front of the DM.
+    const open = entity.kind === 'thread' && entity.resolution === 'open'
+    const stale = entity.status === 'active' && now - entity.lastSeen > DORMANT_AFTER
+
+    let next = entity
+    if (stale && !open && entity.id !== PLAYER_ID) {
+      next = { ...entity, status: 'dormant' }
+    }
+
+    // A cold thread has fired its allowance without the story engaging it.
+    // Retiring it here is what stops the loose-ends list becoming a list of
+    // things the player has decided not to care about.
+    if (next.kind === 'thread' && next.resolution === 'cold') {
+      next = { ...next, status: 'dormant', due: null }
+    }
+
+    entities[next.id] = next
+  }
+
+  // pruneWorld drops edges whose endpoints did not survive, which is the other
+  // half of the repair — an edge pointing at a deleted entity renders as a
+  // relationship with a hole in it.
+  return pruneWorld({ ...world, entities })
 }
 
 // ------------------------------------------------------------ housekeeping


### PR DESCRIPTION
Closes #3532.

`condense` already runs every twenty turns and already pays for a slow model call. That makes it the one moment the game can afford to repair the graph *and* archive what it drops, so both now happen there.

## Reconciliation

The DM maintains the index in passing — two or three entities at a time, while doing something else. It drifts: people get named and never registered, relationships get described and never drawn. That is not a bug in the DM; it is the price of not making it run a simulation every turn, and this is where the price is paid.

**The transcript is the authority.** The index is rebuilt from the story, never the other way round.

The rebuild goes through `applyWorldDelta` — the same path a turn's deltas take — so reconciliation cannot write anything a turn could not have written. Two differences, both deliberate:

- **Larger caps** (`RECONCILE_TOUCH`/`RECONCILE_EDGES` = 40). A *turn* touching forty entities is a DM that has stopped telling a story and started filing. A reconciliation touching forty is reading twenty turns at once, which is its job.
- **`elapsed: 0`.** This is bookkeeping about time that has already passed. Advancing the clock here would move the story forward for having tidied its notes.

The pure half (`reconcileWorld`) needs no model and runs either way: people who walked out of the story go dormant, cold threads are retired, dangling edges are dropped. **Open threads and the player never go dormant** — a debt nobody has mentioned for a week is exactly the thing that should still be pressing, and going quiet would quietly forgive it.

## Archiving

Happens *before* reconciliation and before anything else touches the dropped slice, so a failure in the repair cannot cost the player the transcript. `archiveChapter` was already idempotent on index; the counter only advances when the write actually landed, so a failed archive leaves the next condense reusing the index rather than leaving a gap where a chapter should be.

## Acceptance — verified live

Built a 70-entry campaign with a **deliberately empty world** — which is exactly what a v1 campaign looks like on its first condense — then took one turn.

- [x] **A campaign deep in play has a graph that matches its transcript, not a graph with holes.** 0 entities → 12 entities and 9 edges, every one drawn from prose the DM had never registered:
  ```
  entities: maren(actor), tace(actor), pip(actor), saltmarket(place),
            corrin-point-lighthouse(place), cormorant(thing), gullwing(thing),
            gullwing-mystery-light(thread), tace-fate-thread(thread), you(actor), …
  edges:    maren-holds->cormorant, tace-guards->corrin-point-lighthouse,
            pip-at->saltmarket, tace-involves->gullwing-mystery-light, …
  ```
  Those edges are the story: Maren owns the only boat, Tace tended the lighthouse. Nothing in the graph said so before this ran.
- [x] **Nothing dropped from the transcript is unrecoverable.** 42 kept + 30 archived = 72 against 70 in (the turn itself added two).
- [x] **`archiveChapter` is idempotent on index.** Re-archived index 0 and got one chapter back, not two.
- [~] **A reconciliation failure is survivable.** By construction — the `catch` returns `reconcileWorld(campaign.world, now)`, so the turn proceeds on the previous graph with the pure tidying still applied, exactly as a failed `condense` proceeds on the previous synopsis. I did not force a live failure to observe it, so I am flagging rather than ticking.

## It also answers the softness I flagged in #3544

That PR noted the DM draws edges sparingly and said it was worth re-checking after this landed. It was: edges were thin because nothing was rebuilding them. Reconciliation produced nine from a stretch where the per-turn deltas had produced almost none. The architecture was right; the repair pass was just missing.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  7 passed (7)
      Tests  148 passed (148)          # 141 before, +7 for reconcileWorld

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npm run build
✓ Compiled successfully
```

Branched off `main`. Leaves #3533 as the last child of #3519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)