### PR TITLE
feat(dicebound): relevance window and a recall tool

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -67,6 +67,7 @@ import {
 } from '@/app/dicebound/domain/dice'
 import {
   NARRATE_TOOL,
+  RECALL_TOOL,
   ROLL_CHECK_TOOL,
   type TurnResult,
   applyTurn,
@@ -84,18 +85,23 @@ import {
   MAX_TOUCH_PER_TURN,
   MAX_TURN_MINUTES,
   MIN_DISPOSITION,
+  PLAYER_ID,
   PRESSURES,
   type Pressure,
   RECONCILE_EDGES,
   RECONCILE_TOUCH,
   RESOLUTIONS,
   type Resolution,
+  type ThreadEntity,
   type World,
   applyWorldDelta,
+  currentPlace,
   describeClock,
+  edgesFor,
   ensurePlayer,
-  openThreads,
+  findEntities,
   reconcileWorld,
+  relevanceWindow,
 } from '@/app/dicebound/domain/world'
 import { verifyRequestAuth } from '@/lib/api/auth'
 import {
@@ -220,6 +226,12 @@ Every narrate call also reports what changed. This is an index of the story, not
 - touch: the two or three things that changed or first appeared. Reuse the same id for the same thing forever — "harbour-guard" stays "harbour-guard". Do not restate what did not change.
 - edges: connections that formed or changed. Both ends must be things you registered in touch.
 - threads: loose ends that moved. Close one only when the story is genuinely finished with it.
+REMEMBERING
+What you are shown is a window on the story, not the whole of it. Places, people and promises that have gone quiet are still there and are not listed.
+- If the player refers to someone or something you cannot see in the list, call recall BEFORE you answer. Do not decide it is new because it is not in front of you.
+- Recall is free and costs the player nothing. Inventing a stranger over the top of somebody the story already contains is the one mistake a player always catches, and it is the mistake that makes a long campaign feel disposable.
+- If recall comes back with nothing, then it really is new, and you should invent it with a free hand.
+
 You report what happened. The server decides what it is worth — how far a disposition moves, when a relationship becomes old enough to matter, how much time a turn may consume. Do not try to set those.
 
 TONE
@@ -376,6 +388,21 @@ function narrateTool(rolled: boolean): ToolDef {
     description: `Tell the player what happens, and end your turn. This is the last thing you do. ${budget} If the attempt was uncertain, call roll_check first and wait for the result — narration sent in the same message as a roll was written before the dice were known, and is discarded.`,
     input_schema: toolSchema(NarrateSchema),
   }
+}
+
+const RecallSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      'What you are trying to remember, in the player\'s words: "the man from the harbour", "the debt to Maren".'
+    ),
+})
+
+const RECALL: ToolDef = {
+  name: RECALL_TOOL,
+  description:
+    'Look something up that is not in front of you. Use this when the player refers to a person, place or promise you cannot see listed — the story may well contain it. Returns nothing if there is genuinely no match, and nothing means it is new.',
+  input_schema: toolSchema(RecallSchema),
 }
 
 const OpeningSchema = z.object({
@@ -636,7 +663,7 @@ async function playTurn(
       role: 'user',
       content: `${sheetBlock(campaign)}
 
-${worldBlock(campaign.world)}
+${worldBlock(campaign.world, mentionedIn(action))}
 
 PREMISE: "${campaign.premise}"
 ${(synopsis ?? campaign.synopsis) ? `\nTHE STORY SO FAR:\n${synopsis ?? campaign.synopsis}\n` : ''}
@@ -678,11 +705,11 @@ Resolve it, then call narrate with what happens.`,
       // which is a harder guarantee than asking nicely for prose. There is no
       // fourth roll available to reach for, and finishing is the only move
       // left on the board.
-      tools: lastStep ? [narrate] : [ROLL_CHECK, narrate],
+      tools: lastStep ? [narrate] : [ROLL_CHECK, RECALL, narrate],
       toolChoice: lastStep ? { type: 'tool', name: NARRATE_TOOL } : { type: 'auto' },
     })
 
-    const { rolls, ending, premature } = partitionTurnCalls(toolUses(data))
+    const { rolls, recalls, ending, premature } = partitionTurnCalls(toolUses(data))
 
     if (ending) {
       const text = narrationOf(ending.input)
@@ -729,7 +756,7 @@ Resolve it, then call narrate with what happens.`,
       break
     }
 
-    if (rolls.length === 0 && premature.length === 0) {
+    if (rolls.length === 0 && recalls.length === 0 && premature.length === 0) {
       // The model answered in prose instead of declaring the end of the turn.
       // Take it anyway. The turn is over either way, and spending a round trip
       // teaching the model the ceremony would cost the player fifteen seconds
@@ -745,6 +772,16 @@ Resolve it, then call narrate with what happens.`,
       const { entry, brief } = rollFor(campaign, call.input)
       entries.push(entry)
       results.push({ type: 'tool_result', tool_use_id: call.id, content: brief })
+    }
+    // A lookup costs a pass but not a check: it is the DM checking its notes,
+    // not the story moving. `MAX_CHECKS` still bounds the loop, so a model that
+    // did nothing but recall would still be forced to narrate at the end.
+    for (const call of recalls) {
+      results.push({
+        type: 'tool_result',
+        tool_use_id: call.id,
+        content: recallFor(world, call.input),
+      })
     }
     // Answered, not honoured. The API requires a result for every tool_use
     // block, and this is the one place the model is told why its narration was
@@ -794,6 +831,39 @@ function fuseBrief(world: World, fired: readonly string[]): string {
 function narrationOf(input: unknown): string {
   const raw = (input ?? {}) as { text?: unknown }
   return typeof raw.text === 'string' ? raw.text.trim() : ''
+}
+
+/**
+ * Answer a `recall`.
+ *
+ * Says so plainly when there is no match, because the alternative is a DM that
+ * narrates a stranger as an old acquaintance and a player who is the only one
+ * who notices. "Nothing" is a useful answer here — it means the thing is new,
+ * and inventing it is then the right move rather than a mistake.
+ */
+function recallFor(world: World, input: unknown): string {
+  const query = (input ?? {}) as { query?: unknown }
+  const found = findEntities(world, query.query)
+
+  if (found.length === 0) {
+    return 'Nothing in the story so far matches that. It is new — invent it freely.'
+  }
+
+  return found
+    .map(entity => {
+      const ties = edgesFor(world, entity.id)
+        .slice(0, 4)
+        .map(edge => `${edge.from} ${edge.kind} ${edge.to}${edge.note ? ` (${edge.note})` : ''}`)
+      return [
+        `${entity.name} (${entity.id}, ${entity.kind})`,
+        entity.note,
+        entity.state ? `Currently: ${entity.state}` : '',
+        ties.length ? `Ties: ${ties.join('; ')}` : '',
+      ]
+        .filter(Boolean)
+        .join(' ')
+    })
+    .join('\n')
 }
 
 /** Resolve one `roll_check` call into a transcript entry and a model briefing. */
@@ -869,34 +939,69 @@ function rollFor(campaign: Campaign, input: unknown): { entry: CheckEntry; brief
 }
 
 /**
- * The world, as much of it as the DM needs to stay consistent.
+ * The world as the DM reads it: prose, not JSON.
  *
- * Deliberately small. The point is that the model can reuse an id it has used
- * before and knows what time it is; the full relevance window — who is nearby,
- * what is dormant, what can be recalled — is #3533's problem, and sending the
- * whole graph every turn would undo the prompt budget #3525 just bought.
+ * Bounded by `relevanceWindow` rather than by the size of the graph, which is
+ * the point — a campaign four hundred turns deep sends the same amount of world
+ * as one twenty turns deep, because what it sends is the scene rather than the
+ * archive. Everything outside the window stays in the campaign and is reachable
+ * with `recall`.
+ *
+ * Rendered as sentences because the model reads them better than it reads a
+ * data structure, and because a prompt full of JSON teaches it to answer in the
+ * same register.
  */
-function worldBlock(world: World): string {
-  const known = Object.values(world.entities)
-    .filter(entity => entity.status === 'active')
-    .sort((a, b) => b.lastSeen - a.lastSeen)
-    .slice(0, 12)
-    .map(
-      entity =>
-        `  ${entity.id} (${entity.kind}) — ${entity.name}${entity.state ? `: ${entity.state}` : ''}`
-    )
+function worldBlock(world: World, mentioned: readonly string[]): string {
+  const { entities, edges } = relevanceWindow(world, mentioned)
+  const here = currentPlace(world)
 
-  const threads = openThreads(world)
-    .slice(0, 5)
-    .map(thread => `  ${thread.id} — ${thread.name} [${thread.pressure}]`)
+  const byId = new Map(entities.map(entity => [entity.id, entity]))
+  const name = (id: string) => byId.get(id)?.name ?? id
+
+  const people = entities
+    .filter(entity => entity.kind === 'actor' && entity.id !== PLAYER_ID)
+    .map(entity => `  ${entity.name} (${entity.id})${entity.state ? ` — ${entity.state}` : ''}`)
+
+  const things = entities
+    .filter(entity => entity.kind === 'place' || entity.kind === 'thing')
+    .filter(entity => entity.id !== here?.id)
+    .map(entity => `  ${entity.name} (${entity.id})${entity.state ? ` — ${entity.state}` : ''}`)
+
+  const threads = entities
+    .filter((entity): entity is ThreadEntity => entity.kind === 'thread')
+    .map(entity => `  ${entity.name} (${entity.id}) — ${entity.pressure}`)
+
+  const ties = edges.map(
+    edge =>
+      `  ${name(edge.from)} ${edge.kind} ${name(edge.to)}${edge.note ? ` — ${edge.note}` : ''}`
+  )
 
   return [
     `TIME: ${describeClock(world.clock)}`,
-    known.length ? `KNOWN (reuse these ids):\n${known.join('\n')}` : '',
+    here ? `WHERE YOU ARE: ${here.name} (${here.id})${here.state ? ` — ${here.state}` : ''}` : '',
+    people.length ? `WHO IS AROUND (reuse these ids):\n${people.join('\n')}` : '',
+    things.length ? `WHAT IS AROUND:\n${things.join('\n')}` : '',
+    ties.length ? `HOW THEY STAND:\n${ties.join('\n')}` : '',
     threads.length ? `LOOSE ENDS:\n${threads.join('\n')}` : '',
+    'Anyone or anything not listed here may still exist. If the player refers to something you do not see, call recall before deciding it is new.',
   ]
     .filter(Boolean)
     .join('\n\n')
+}
+
+/**
+ * The words in the player's action worth trying to match against the graph.
+ *
+ * Crude on purpose. It is a hint to the ranking, not a parser: the cost of a
+ * false positive is one extra entity in a twenty-entity window, and the cost of
+ * a false negative is the DM forgetting someone the player just named.
+ */
+function mentionedIn(action: string): string[] {
+  return action
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(word => word.length >= 4)
+    .slice(0, 24)
 }
 
 /** The character sheet, as the DM sees it every turn. */

--- a/src/app/dicebound/domain/__tests__/turn.test.ts
+++ b/src/app/dicebound/domain/__tests__/turn.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   NARRATE_TOOL,
+  RECALL_TOOL,
   ROLL_CHECK_TOOL,
   type ToolCall,
   partitionTurnCalls,
@@ -82,5 +83,36 @@ describe('partitionTurnCalls', () => {
     expect(rolls).toEqual([])
     expect(ending).toBeNull()
     expect(premature).toEqual([])
+  })
+})
+
+describe('recall in the turn loop', () => {
+  const recall = (id: string): ToolCall & { id: string } => ({
+    id,
+    name: RECALL_TOOL,
+    input: { query: 'the man from the harbour' },
+  })
+
+  it('answers a lookup without ending the turn — checking your notes is not a move', () => {
+    const { recalls, ending } = partitionTurnCalls([recall('a')])
+
+    expect(recalls.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+  })
+
+  it('discards narration written alongside a lookup, for the same reason as a roll', () => {
+    // Whatever the DM asked to remember cannot be in prose it wrote before the
+    // answer came back.
+    const { recalls, ending, premature } = partitionTurnCalls([recall('a'), narrate('b')])
+
+    expect(recalls.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+    expect(premature.map(c => c.id)).toEqual(['b'])
+  })
+
+  it('still lets a plain narration end the turn', () => {
+    const { recalls, ending } = partitionTurnCalls([narrate('a')])
+    expect(recalls).toEqual([])
+    expect(ending?.id).toBe('a')
   })
 })

--- a/src/app/dicebound/domain/__tests__/world.test.ts
+++ b/src/app/dicebound/domain/__tests__/world.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   DORMANT_AFTER,
+  type Edge,
   type Entity,
   FUSE_WINDOWS,
   MAX_DISPOSITION,
@@ -13,17 +14,22 @@ import {
   MAX_TURN_MINUTES,
   PLAYER_ID,
   type ThreadEntity,
+  WINDOW_EDGES,
+  WINDOW_ENTITIES,
   type World,
   advance,
   applyWorldDelta,
+  currentPlace,
   describeClock,
   emptyClock,
   emptyWorld,
   ensurePlayer,
+  findEntities,
   fireThreads,
   openThreads,
   pruneWorld,
   reconcileWorld,
+  relevanceWindow,
   timeOfDay,
   validateEdge,
   validateEntity,
@@ -578,5 +584,185 @@ describe('reconcileWorld', () => {
     const before = worldOf(now, actor('ferryman', 0))
     reconcileWorld(before, now)
     expect(before.entities.ferryman.status).toBe('active')
+  })
+})
+
+describe('the relevance window', () => {
+  function person(id: string, over: Partial<Entity> = {}): Entity {
+    return {
+      id,
+      kind: 'actor',
+      name: id,
+      note: '',
+      state: '',
+      status: 'active',
+      disposition: 0,
+      scale: 'person',
+      firstSeen: 0,
+      lastSeen: 0,
+      ...over,
+    } as Entity
+  }
+
+  function place(id: string): Entity {
+    return {
+      id,
+      kind: 'place',
+      name: id,
+      region: '',
+      note: '',
+      state: '',
+      status: 'active',
+      firstSeen: 0,
+      lastSeen: 0,
+    }
+  }
+
+  function build(entities: Entity[], edges: Edge[] = []): World {
+    return {
+      clock: { elapsed: 100, startHour: 9 },
+      entities: Object.fromEntries(entities.map(e => [e.id, e])),
+      edges,
+    }
+  }
+
+  it('stays bounded no matter how large the graph gets', () => {
+    // The whole reason this exists: a campaign four hundred turns deep must
+    // send the same amount of world as one twenty turns deep.
+    const crowd = Array.from({ length: 200 }, (_, i) => person(`p${i}`, { lastSeen: i }))
+    const edges: Edge[] = crowd.slice(0, 150).map((p, i) => ({
+      from: p.id,
+      to: crowd[(i + 1) % 150].id,
+      kind: 'knows',
+      note: '',
+      since: i,
+    }))
+
+    const window = relevanceWindow(build(crowd, edges))
+    expect(window.entities.length).toBeLessThanOrEqual(WINDOW_ENTITIES)
+    expect(window.edges.length).toBeLessThanOrEqual(WINDOW_EDGES)
+  })
+
+  it('always carries the player', () => {
+    const crowd = Array.from({ length: 100 }, (_, i) => person(`p${i}`, { lastSeen: 999 }))
+    const window = relevanceWindow(build([person(PLAYER_ID, { lastSeen: 0 }), ...crowd]))
+    expect(window.entities.map(e => e.id)).toContain(PLAYER_ID)
+  })
+
+  it('carries something the player just named, however long ago it mattered', () => {
+    const crowd = Array.from({ length: 100 }, (_, i) => person(`p${i}`, { lastSeen: 999 }))
+    const old = person('the-ferryman', { lastSeen: 0, name: 'The Ferryman' })
+    const window = relevanceWindow(build([old, ...crowd]), ['ferryman'])
+    expect(window.entities.map(e => e.id)).toContain('the-ferryman')
+  })
+
+  it('keeps every open thread ahead of a bystander', () => {
+    const crowd = Array.from({ length: 100 }, (_, i) => person(`p${i}`, { lastSeen: 999 }))
+    const debt = thread({ id: 'debt', resolution: 'open', pressure: 'urgent', lastSeen: 0 })
+    const window = relevanceWindow(build([debt, ...crowd]))
+    expect(window.entities.map(e => e.id)).toContain('debt')
+  })
+
+  it('leaves dormant entities out unless they were named', () => {
+    const asleep = person('the-ferryman', { status: 'dormant', name: 'The Ferryman' })
+    expect(relevanceWindow(build([asleep])).entities).toEqual([])
+    expect(relevanceWindow(build([asleep]), ['ferryman']).entities.map(e => e.id)).toEqual([
+      'the-ferryman',
+    ])
+  })
+
+  it('finds where the player is standing from the newest at-edge', () => {
+    const world = build(
+      [person(PLAYER_ID), place('quay'), place('tavern')],
+      [
+        { from: PLAYER_ID, to: 'quay', kind: 'at', note: '', since: 10 },
+        { from: PLAYER_ID, to: 'tavern', kind: 'at', note: '', since: 90 },
+      ]
+    )
+    // Walking somewhere new does not delete having been somewhere old, so the
+    // most recent edge is the answer rather than the only one.
+    expect(currentPlace(world)?.id).toBe('tavern')
+  })
+
+  it('drops an edge whose other end did not make the window', () => {
+    const crowd = Array.from({ length: 100 }, (_, i) => person(`p${i}`, { lastSeen: 999 }))
+    const asleep = person('asleep', { status: 'dormant' })
+    const world = build(
+      [person(PLAYER_ID), asleep, ...crowd],
+      [{ from: PLAYER_ID, to: 'asleep', kind: 'knows', note: '', since: 1 }]
+    )
+    expect(relevanceWindow(world).edges).toEqual([])
+  })
+})
+
+describe('findEntities', () => {
+  const ferryman: Entity = {
+    id: 'the-ferryman',
+    kind: 'actor',
+    name: 'Old Cassa',
+    note: 'The man who works the harbour crossing.',
+    state: '',
+    status: 'dormant',
+    disposition: 0,
+    scale: 'person',
+    firstSeen: 0,
+    lastSeen: 5,
+  }
+  const world: World = {
+    clock: { elapsed: 0, startHour: 9 },
+    entities: { [ferryman.id]: ferryman },
+    edges: [],
+  }
+
+  it('reaches things that have gone quiet — that is the whole point', () => {
+    // "Wait, that's the man from the harbour", twelve chapters later. Searching
+    // only active entities would return what the DM could already see.
+    expect(findEntities(world, 'harbour').map(e => e.id)).toEqual(['the-ferryman'])
+  })
+
+  it('matches on the name as well as the note', () => {
+    expect(findEntities(world, 'Cassa').map(e => e.id)).toEqual(['the-ferryman'])
+  })
+
+  it('returns nothing rather than inventing a near miss', () => {
+    // A lookup that guesses is worse than one that admits it has none: the DM
+    // narrates a stranger as an old friend and only the player notices.
+    expect(findEntities(world, 'the queen of thieves')).toEqual([])
+    expect(findEntities(world, '')).toEqual([])
+    expect(findEntities(world, undefined)).toEqual([])
+  })
+
+  it('offers a candidate on one significant word rather than nothing', () => {
+    // Deliberately loose. "The man from the harbour" has exactly one word worth
+    // matching, and handing back nothing tells the DM to invent someone who
+    // already exists. A candidate can be looked at and rejected; an empty
+    // result has already made the decision.
+    expect(findEntities(world, 'harbour').map(e => e.id)).toEqual(['the-ferryman'])
+    expect(findEntities(world, 'the man from the harbour').map(e => e.id)).toEqual(['the-ferryman'])
+  })
+
+  it('ranks a name match above a description match', () => {
+    const other: Entity = {
+      ...ferryman,
+      id: 'harbour-gate',
+      name: 'Harbour Gate',
+      kind: 'place',
+      region: '',
+      note: '',
+    } as Entity
+    const two: World = { ...world, entities: { [ferryman.id]: ferryman, [other.id]: other } }
+    expect(findEntities(two, 'harbour').map(e => e.id)[0]).toBe('harbour-gate')
+  })
+
+  it('strips punctuation before searching', () => {
+    // The first live run searched for `cassa,` with the comma still attached,
+    // found nothing, and told the DM to invent someone who already existed.
+    expect(findEntities(world, 'Old Cassa, the harbour crossing').map(e => e.id)).toEqual([
+      'the-ferryman',
+    ])
+  })
+
+  it('is not carried by common words alone', () => {
+    expect(findEntities(world, 'the man from the place')).toEqual([])
   })
 })

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -19,11 +19,17 @@ export interface ToolCall {
 
 export const ROLL_CHECK_TOOL = 'roll_check'
 export const NARRATE_TOOL = 'narrate'
+export const RECALL_TOOL = 'recall'
 
 /** One pass's tool calls, sorted into what the loop does with each. */
 export interface TurnCalls<T extends ToolCall> {
   /** `roll_check` calls, to resolve against the die in the order they arrived. */
   rolls: T[]
+  /**
+   * `recall` lookups. Answered and the turn continues — a lookup is not a move,
+   * so it neither ends the turn nor spends one of its checks.
+   */
+  recalls: T[]
   /** The `narrate` call that ends the turn, or null while the turn continues. */
   ending: T | null
   /**
@@ -52,13 +58,19 @@ export interface TurnCalls<T extends ToolCall> {
  */
 export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T> {
   const rolls = calls.filter(call => call.name === ROLL_CHECK_TOOL)
+  const recalls = calls.filter(call => call.name === RECALL_TOOL)
   const narrations = calls.filter(call => call.name === NARRATE_TOOL)
 
-  if (rolls.length > 0) return { rolls, ending: null, premature: narrations }
+  // A narration sent alongside a lookup is as blind as one sent alongside a
+  // roll: it was written before the answer came back, so whatever the DM asked
+  // for cannot be in it.
+  if (rolls.length > 0 || recalls.length > 0) {
+    return { rolls, recalls, ending: null, premature: narrations }
+  }
 
   // Only the first narration ends the turn. A second one is a duplicate, not a
   // continuation, and appending both would read as the DM saying it twice.
-  return { rolls, ending: narrations[0] ?? null, premature: narrations.slice(1) }
+  return { rolls, recalls, ending: narrations[0] ?? null, premature: narrations.slice(1) }
 }
 
 /** What a turn produced, before it has been written down anywhere. */

--- a/src/app/dicebound/domain/world.ts
+++ b/src/app/dicebound/domain/world.ts
@@ -618,6 +618,206 @@ export function reconcileWorld(world: World, now: number): World {
   return pruneWorld({ ...world, entities })
 }
 
+// ------------------------------------------------------ the relevance window
+
+/**
+ * How much of the graph reaches the prompt.
+ *
+ * Two hundred entities will not fit, and sending them would make every turn
+ * cost more in tokens than the rest of the game put together. These numbers are
+ * what keep prompt size flat as a campaign grows — a story four hundred turns
+ * deep sends the same amount of world as one twenty turns deep, because what it
+ * sends is the scene rather than the archive.
+ */
+export const WINDOW_ENTITIES = 20
+export const WINDOW_EDGES = 30
+
+export interface WorldWindow {
+  entities: Entity[]
+  edges: Edge[]
+}
+
+/**
+ * Where the player is standing, if the graph knows.
+ *
+ * `at(you → somewhere)` is the edge that answers it. The most recently formed
+ * one wins, because walking somewhere new does not delete the memory of having
+ * been somewhere old.
+ */
+export function currentPlace(world: World): PlaceEntity | null {
+  const here = world.edges
+    .filter(edge => edge.from === PLAYER_ID && edge.kind === 'at')
+    .sort((a, b) => b.since - a.since)[0]
+
+  const place = here ? world.entities[here.to] : undefined
+  return place?.kind === 'place' ? place : null
+}
+
+/**
+ * Choose the slice of world the DM actually needs this turn.
+ *
+ * Ranked rather than filtered, because every rule here is a preference and none
+ * of them is a hard boundary: an open thread outranks a bystander, the place
+ * you are standing in outranks the place you left, and something the player
+ * just named outranks almost everything, because they are about to act on it.
+ *
+ * Dormant entities are excluded unless the player named one — that is what
+ * `recall` is for, and letting them back in by default would undo the whole
+ * point of going dormant.
+ */
+export function relevanceWindow(world: World, mentioned: readonly string[] = []): WorldWindow {
+  // Matched on slug *parts*, not whole slugs. The player types "the ferryman"
+  // and the entity is `the-ferryman`; comparing the whole slug misses it, and
+  // missing it is exactly the case this scoring exists for. Parts rather than
+  // substrings so that "man" does not match every ferryman in the story.
+  const named = new Set(mentioned.map(word => slug(word)).filter(word => word.length >= 3))
+
+  function wasNamed(entity: Entity): boolean {
+    const id = entity.id
+    const name = slug(entity.name)
+    const parts = new Set([id, name, ...id.split('-'), ...name.split('-')])
+    for (const word of named) if (parts.has(word)) return true
+    return false
+  }
+
+  const place = currentPlace(world)
+
+  const hereIds = new Set(
+    world.edges
+      .filter(edge => place && edge.kind === 'at' && edge.to === place.id)
+      .map(edge => edge.from)
+  )
+
+  const pressure: Record<Pressure, number> = { urgent: 3, pressing: 2, patient: 1 }
+
+  function score(entity: Entity): number {
+    if (entity.id === PLAYER_ID) return 1000
+    // A name the player just used. They are about to act on it, and it is the
+    // one thing they will notice the DM having forgotten.
+    if (wasNamed(entity)) return 900
+    if (place && entity.id === place.id) return 800
+    if (entity.kind === 'thread' && entity.resolution === 'open') {
+      return 600 + pressure[entity.pressure]
+    }
+    if (hereIds.has(entity.id)) return 400
+    if (entity.status === 'dormant') return -1
+    if (entity.status === 'gone') return 0
+    return 200
+  }
+
+  const entities = Object.values(world.entities)
+    .map(entity => ({ entity, rank: score(entity) }))
+    .filter(scored => scored.rank >= 0)
+    .sort((a, b) => b.rank - a.rank || b.entity.lastSeen - a.entity.lastSeen)
+    .slice(0, WINDOW_ENTITIES)
+    .map(scored => scored.entity)
+
+  const inWindow = new Set(entities.map(entity => entity.id))
+
+  // Only edges whose both ends are in the window. An edge to something the DM
+  // cannot see reads as a relationship with a hole in it, which is worse than
+  // silence.
+  const edges = world.edges
+    .filter(edge => inWindow.has(edge.from) && inWindow.has(edge.to))
+    .sort((a, b) => {
+      const player =
+        Number(b.from === PLAYER_ID || b.to === PLAYER_ID) -
+        Number(a.from === PLAYER_ID || a.to === PLAYER_ID)
+      return player || b.since - a.since
+    })
+    .slice(0, WINDOW_EDGES)
+
+  return { entities, edges }
+}
+
+/**
+ * Look something up by name, including things that have gone quiet.
+ *
+ * This is the half of the graph that pays for the other half: *"wait, that's
+ * the man from the harbour"* twelve chapters later. It searches dormant
+ * entities on purpose — active ones are already in the window, so a search that
+ * skipped the dormant would only ever return what the DM could already see.
+ *
+ * Returns nothing rather than a near-miss when there is no match. A lookup that
+ * invents an answer is worse than one that admits it has none: the DM would
+ * narrate a stranger as an old acquaintance, and the player would be the only
+ * one who noticed.
+ */
+export function findEntities(world: World, query: unknown, limit = 5): Entity[] {
+  const needle = str(query, MAX_NAME).trim().toLowerCase()
+  if (needle.length < 2) return []
+
+  // Split on anything that is not a letter or digit. Splitting on whitespace
+  // alone leaves the punctuation attached, and the first live run of this
+  // searched for `cassa,` — comma included — against a story containing Cassa,
+  // found nothing, and told the DM to invent someone who already existed.
+  const words = needle.split(/[^a-z0-9]+/).filter(word => word.length > 2 && !STOPWORDS.has(word))
+  if (words.length === 0) return []
+
+  return Object.values(world.entities)
+    .map(entity => {
+      const label = `${entity.id} ${entity.name}`.toLowerCase()
+      const haystack = `${label} ${entity.note} ${entity.state}`.toLowerCase()
+
+      // A hit on the name or id is worth more than a hit in the note. "Cassa"
+      // naming someone called Cassa is an identification; "harbour" appearing
+      // in their description is a coincidence waiting to happen.
+      const named = words.filter(word => label.includes(word)).length
+      const hits = words.filter(word => haystack.includes(word)).length
+
+      // One significant word is enough, and the ranking sorts out the rest.
+      //
+      // The stricter rule — two words unless one is the name — was tried first
+      // and broke the case this whole tool exists for: "the man from the
+      // harbour" has exactly one significant word in it, and being handed
+      // nothing tells the DM to invent someone who already exists. The two
+      // failures are not symmetrical. A search that offers a candidate lets the
+      // model look at it and decide it is not the one; a search that offers
+      // nothing has already made the decision, wrongly, and nobody but the
+      // player will notice.
+      return { entity, rank: hits === 0 ? 0 : named * 10 + hits }
+    })
+    .filter(scored => scored.rank > 0)
+    .sort((a, b) => b.rank - a.rank || b.entity.lastSeen - a.entity.lastSeen)
+    .slice(0, limit)
+    .map(scored => scored.entity)
+}
+
+/**
+ * Words too common to identify anything.
+ *
+ * Short list on purpose: this is here so "the man from the harbour" is not
+ * carried by "the", not to do linguistics.
+ */
+const STOPWORDS = new Set([
+  'the',
+  'and',
+  'for',
+  'from',
+  'with',
+  'that',
+  'this',
+  'his',
+  'her',
+  'him',
+  'she',
+  'they',
+  'them',
+  'who',
+  'was',
+  'were',
+  'had',
+  'has',
+  'about',
+  'man',
+  'woman',
+  'person',
+  'thing',
+  'place',
+  'old',
+  'new',
+])
+
 // ------------------------------------------------------------ housekeeping
 
 /** Open threads, most pressing first. This is the player's "loose ends". */


### PR DESCRIPTION
Closes #3533. **Completes epic #3519** — and with it, every child issue in the phase 2 tree.

Two hundred entities will not fit in a prompt, and sending them would cost more per turn than the rest of the game. The window sends the *scene* rather than the archive.

## Bounded regardless of graph size

```
graph   5 entities /   4 edges  ->  window  6 entities,  4 edges, ~1716 chars
graph  50 entities /  49 edges  ->  window 20 entities, 18 edges, ~6391 chars
graph 200 entities / 199 edges  ->  window 20 entities, 18 edges, ~6502 chars
```

A campaign four hundred turns deep sends the same amount of world as one twenty turns deep. Also asserted in the unit tests.

**Ranked, not filtered**, because every rule is a preference and none is a boundary: the player outranks everything; something they just named outranks almost everything else, because they are about to act on it; the place they are standing outranks the place they left; an open thread outranks a bystander. Dormant entities stay out unless named — letting them in by default would undo the point of going dormant.

**Rendered as prose, not JSON.** The model reads sentences better, and a prompt full of data structures teaches it to answer in the same register.

## `recall`

A lookup, not a move: it costs a pass but not a check. A narration sent alongside one is discarded for exactly the reason a narration sent alongside a roll is — whatever was asked for cannot be in prose written before the answer came back.

## Two bugs live play found that reading would not have

**The tool failed silently behind a good paragraph.** The first run searched for `cassa,` — comma attached — against a story containing Cassa, found nothing, and told the DM to invent someone who already existed. The narration still *looked* right, because the player had supplied the details in their own message. Only the instrumentation showed `hits=NONE`. Tokenising now strips punctuation.

**Then it was too strict the other way.** Requiring two significant words unless one was the name broke the case the tool exists for: *"the man from the harbour"* has exactly one word worth matching. I had written a test asserting that stricter rule, and the rule was wrong — the two failures are not symmetrical. A search that offers a candidate lets the model look at it and reject it. A search that offers nothing has already made the decision, wrongly, and only the player will notice. It now takes one word and ranks name matches above description matches.

## Acceptance

- [x] **Prompt size is bounded regardless of graph size** — asserted at 200 entities in a test, and measured above.
- [x] **`recall` returns nothing rather than inventing when there is no match** — `"a dragon"` → `NONE`, and the tool result says so in words, which is a useful answer: it means the thing is new and inventing it is then correct.
- [x] **The window renders in prose the DM can read, not as JSON** — `WHERE YOU ARE`, `WHO IS AROUND`, `HOW THEY STAND`, `LOOSE ENDS`.

## End to end, against a dormant NPC the window deliberately excluded

Player refers to him obliquely — no name:

> *"The traveller turns around and I know the face. It is the ferryman who used to work the crossing, years ago, the one I never settled up with."*

```
RECALLDEBUG query="the ferryman at the crossing I never settled up with" hits=old-cassa
```

> *Old Cassa. Greyer, and thinner through the shoulders, but the same slow way of turning, like a boat coming about. […] "Ashwell," he says. "I was upriver till the water came up. Sit, if you like." He nudges the bench with his boot. **"You still owe me a crossing."***

That last line came from the `owes` edge's note, not from anything the player said. That is the graph paying for itself.

Worth noting the *other* path also works and needed no tool: when the player names someone directly, `wasNamed` pulls them into the window even while dormant, so `recall` is reserved for oblique reference. That is why the DM does not call it constantly.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  7 passed (7)
      Tests  165 passed (165)          # 148 before, +17

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npm run build
✓ Compiled successfully
```

Instrumentation removed before commit (`grep -c console.log` → 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)