### PR TITLE
feat(dicebound): show the world on the sheet

### DIFF
--- a/src/app/dicebound/components/__tests__/world.test.tsx
+++ b/src/app/dicebound/components/__tests__/world.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { WorldPanel } from '@/app/dicebound/components/world'
+import { type Campaign, newCampaign } from '@/app/dicebound/domain/campaign'
+import { blankAttributes } from '@/app/dicebound/domain/character'
+import type { Entity, World } from '@/app/dicebound/domain/world'
+
+afterEach(cleanup)
+
+function campaignWith(world: Partial<World>): Campaign {
+  const base = newCampaign(
+    'a fishing town',
+    { name: 'Ilda', concept: 'a salvager', reading: '', attributes: blankAttributes(), skills: {} },
+    0,
+    null
+  )
+  return { ...base, world: { ...base.world, ...world } }
+}
+
+const person = (over: Partial<Entity> = {}): Entity =>
+  ({
+    id: 'maren',
+    kind: 'actor',
+    name: 'Maren the harbourmaster',
+    note: '',
+    state: '',
+    status: 'active',
+    disposition: 0,
+    scale: 'person',
+    firstSeen: 0,
+    lastSeen: 0,
+    ...over,
+  }) as Entity
+
+describe('WorldPanel', () => {
+  it('renders nothing at all for a character who has just been made', () => {
+    // The stated rule: a new player must not be able to tell these systems are
+    // there. An empty "People you know" heading advertises a feature they have
+    // not met and turns the sheet into a form to fill in.
+    const { container } = render(<WorldPanel campaign={campaignWith({})} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows where you are and what time it is once the story has a place', () => {
+    render(
+      <WorldPanel
+        campaign={campaignWith({
+          clock: { elapsed: 1450, startHour: 9 },
+          entities: {
+            quay: {
+              id: 'quay',
+              kind: 'place',
+              name: 'Saltmarket Quay',
+              region: 'the coast',
+              note: '',
+              state: 'tar and rain',
+              status: 'active',
+              firstSeen: 0,
+              lastSeen: 0,
+            },
+            you: person({ id: 'you', name: 'Ilda' }),
+          },
+          edges: [{ from: 'you', to: 'quay', kind: 'at', note: '', since: 10 }],
+        })}
+      />
+    )
+    expect(screen.getByText('Saltmarket Quay')).toBeDefined()
+    expect(screen.getByText('tar and rain')).toBeDefined()
+    expect(screen.getByText(/Day 2/)).toBeDefined()
+  })
+
+  it('describes how someone stands toward you in words, never as a number', () => {
+    // A visible +2 turns a person into a stat to farm.
+    render(
+      <WorldPanel campaign={campaignWith({ entities: { maren: person({ disposition: 2 }) } })} />
+    )
+    expect(screen.getByText(/on your side/)).toBeDefined()
+    expect(screen.queryByText(/\+2/)).toBeNull()
+  })
+
+  it('says nothing beside someone the story has no opinion about yet', () => {
+    render(
+      <WorldPanel campaign={campaignWith({ entities: { maren: person({ disposition: 0 }) } })} />
+    )
+    expect(screen.getByText('Maren the harbourmaster')).toBeDefined()
+    expect(screen.queryByText(/neutral/i)).toBeNull()
+  })
+
+  it('lists loose ends with their pressure — the reason to come back', () => {
+    render(
+      <WorldPanel
+        campaign={campaignWith({
+          entities: {
+            debt: {
+              id: 'debt',
+              kind: 'thread',
+              name: 'What you owe for the Cormorant',
+              threadKind: 'debt',
+              resolution: 'open',
+              due: 900,
+              pressure: 'urgent',
+              firings: 0,
+              note: '',
+              state: '',
+              status: 'active',
+              firstSeen: 0,
+              lastSeen: 0,
+            },
+          },
+        })}
+      />
+    )
+    expect(screen.getByText('What you owe for the Cormorant')).toBeDefined()
+    expect(screen.getByText('urgent')).toBeDefined()
+  })
+
+  it('leaves a settled thread off the list', () => {
+    // Loose ends are what is unfinished. A kept promise sitting in the list
+    // makes the list a log rather than a reason to open the tab.
+    render(
+      <WorldPanel
+        campaign={campaignWith({
+          entities: {
+            debt: {
+              id: 'debt',
+              kind: 'thread',
+              name: 'A promise already kept',
+              threadKind: 'promise',
+              resolution: 'kept',
+              due: null,
+              pressure: 'patient',
+              firings: 0,
+              note: '',
+              state: '',
+              status: 'active',
+              firstSeen: 0,
+              lastSeen: 0,
+            },
+          },
+        })}
+      />
+    )
+    expect(screen.queryByText('A promise already kept')).toBeNull()
+  })
+})

--- a/src/app/dicebound/components/sheet.tsx
+++ b/src/app/dicebound/components/sheet.tsx
@@ -25,6 +25,8 @@ import {
 import type { Campaign } from '@/app/dicebound/domain/campaign'
 import { RANK_THRESHOLDS, type SkillRecord, usesToNextRank } from '@/app/dicebound/domain/character'
 
+import { WorldPanel } from './world'
+
 function sign(value: number): string {
   return value >= 0 ? `+${value}` : `${value}`
 }
@@ -92,6 +94,8 @@ export function Sheet({ campaign }: { campaign: Campaign }) {
           </ul>
         )}
       </section>
+
+      <WorldPanel campaign={campaign} />
 
       <section>
         <h3 className="font-label text-label-caps uppercase tracking-widest text-on-surface-variant">

--- a/src/app/dicebound/components/world.tsx
+++ b/src/app/dicebound/components/world.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+/**
+ * What the story has written down.
+ *
+ * Everything here has been recorded for a while — places, people and loose ends
+ * have been accumulating on the server since the world graph landed — and none
+ * of it was visible. This is the part of the sheet that says the game has been
+ * paying attention.
+ *
+ * Three rules shape it.
+ *
+ * Nothing renders until it exists. Every section returns null when it is empty,
+ * so a brand-new character sees a name, some numbers and a couple of skills,
+ * exactly as before. An empty "People you know" heading would advertise a system
+ * the player has not met yet and make the sheet feel like a form to fill in.
+ *
+ * No numbers where a relationship belongs. Disposition is rendered by
+ * `describeDisposition` as words and never as a value — a visible +2 turns a
+ * person into a stat to farm, and a player choosing dialogue for the increment
+ * has stopped playing the game.
+ *
+ * Loose ends come last and are the reason to come back. Pressure is shown
+ * because "urgent" is the difference between a list and a reason to open the
+ * tab; the fuse time behind it is not, because a countdown in minutes would
+ * turn the fiction into a timer.
+ */
+import type { Campaign } from '@/app/dicebound/domain/campaign'
+import {
+  type ActorEntity,
+  type Entity,
+  PLAYER_ID,
+  type ThreadEntity,
+  type World,
+  currentPlace,
+  describeClock,
+  describeDisposition,
+  openThreads,
+  relevanceWindow,
+} from '@/app/dicebound/domain/world'
+
+const PRESSURE_STYLE: Record<string, string> = {
+  urgent: 'text-ds-error',
+  pressing: 'text-ds-tertiary',
+  patient: 'text-on-surface-variant/70',
+}
+
+export function WorldPanel({ campaign }: { campaign: Campaign }) {
+  const world = campaign.world
+
+  // The same window the dungeon master is given, so the player sees the cast the
+  // DM is actually holding in mind rather than a different, longer list.
+  const { entities } = relevanceWindow(world)
+  const here = currentPlace(world)
+  const threads = openThreads(world)
+
+  const people = entities.filter(
+    (entity): entity is ActorEntity => entity.kind === 'actor' && entity.id !== PLAYER_ID
+  )
+  const things = entities.filter(
+    (entity): entity is Entity => entity.kind === 'thing' || entity.kind === 'place'
+  )
+  const elsewhere = things.filter(entity => entity.id !== here?.id)
+
+  // A world nobody has written to yet. The story is still just prose, which is
+  // a perfectly good state — say nothing rather than show empty headings.
+  if (!here && people.length === 0 && elsewhere.length === 0 && threads.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <Where world={world} here={here} />
+      <People people={people} />
+      <Around things={elsewhere} />
+      <LooseEnds threads={threads} />
+    </>
+  )
+}
+
+function Heading({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="font-label text-label-caps uppercase tracking-widest text-on-surface-variant">
+      {children}
+    </h3>
+  )
+}
+
+function Where({ world, here }: { world: World; here: Entity | null }) {
+  return (
+    <section>
+      <Heading>Where you are</Heading>
+      <p className="mt-2 text-body-md text-on-surface">
+        {here ? here.name : 'Somewhere the story has not named yet'}
+      </p>
+      {here?.state && <p className="mt-0.5 text-sm text-on-surface-variant">{here.state}</p>}
+      <p className="mt-1.5 text-xs uppercase tracking-wide text-on-surface-variant/70">
+        {describeClock(world.clock)}
+      </p>
+    </section>
+  )
+}
+
+function People({ people }: { people: ActorEntity[] }) {
+  if (people.length === 0) return null
+
+  return (
+    <section>
+      <Heading>People you know</Heading>
+      <ul className="mt-3 flex flex-col gap-2.5">
+        {people.map(person => {
+          const standing = describeDisposition(person.disposition)
+          return (
+            <li key={person.id}>
+              <p className="text-sm text-on-surface">{person.name}</p>
+              {(standing || person.state) && (
+                <p className="text-xs text-on-surface-variant">
+                  {[person.state, standing].filter(Boolean).join(' — ')}
+                </p>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}
+
+function Around({ things }: { things: Entity[] }) {
+  if (things.length === 0) return null
+
+  return (
+    <section>
+      <Heading>On record</Heading>
+      <ul className="mt-3 flex flex-col gap-2">
+        {things.map(thing => (
+          <li key={thing.id}>
+            <p className="text-sm text-on-surface">{thing.name}</p>
+            {thing.state && <p className="text-xs text-on-surface-variant">{thing.state}</p>}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function LooseEnds({ threads }: { threads: ThreadEntity[] }) {
+  if (threads.length === 0) return null
+
+  return (
+    <section>
+      <Heading>Loose ends</Heading>
+      <ul className="mt-3 flex flex-col gap-2.5">
+        {threads.map(thread => (
+          <li key={thread.id}>
+            <p className="text-sm text-on-surface">{thread.name}</p>
+            <p
+              className={`text-xs uppercase tracking-wide ${
+                PRESSURE_STYLE[thread.pressure] ?? 'text-on-surface-variant/70'
+              }`}
+            >
+              {thread.pressure}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/app/dicebound/domain/__tests__/world.test.ts
+++ b/src/app/dicebound/domain/__tests__/world.test.ts
@@ -21,6 +21,7 @@ import {
   applyWorldDelta,
   currentPlace,
   describeClock,
+  describeDisposition,
   emptyClock,
   emptyWorld,
   ensurePlayer,
@@ -764,5 +765,25 @@ describe('findEntities', () => {
 
   it('is not carried by common words alone', () => {
     expect(findEntities(world, 'the man from the place')).toEqual([])
+  })
+})
+
+describe('describeDisposition', () => {
+  it('says nothing at all about someone the story has no opinion of', () => {
+    // Not "neutral" — a label saying there is nothing to say is still a label,
+    // and it fills the sheet with rows that mean nothing.
+    expect(describeDisposition(0)).toBeNull()
+  })
+
+  it('gives words rather than a number, in both directions', () => {
+    // A visible +2 turns a person into a stat to farm: the player optimises the
+    // NPC instead of talking to them.
+    expect(describeDisposition(2)).toBe('on your side')
+    expect(describeDisposition(-2)).toBe('wants nothing to do with you')
+  })
+
+  it('holds at the ends rather than falling through to nothing', () => {
+    expect(describeDisposition(99)).toBe('would take a risk for you')
+    expect(describeDisposition(-99)).toBe('would see you suffer')
   })
 })

--- a/src/app/dicebound/domain/world.ts
+++ b/src/app/dicebound/domain/world.ts
@@ -618,6 +618,38 @@ export function reconcileWorld(world: World, now: number): World {
   return pruneWorld({ ...world, entities })
 }
 
+/**
+ * How a person stands toward the player, in words.
+ *
+ * Never a number, and this is the only function that is allowed to say it out
+ * loud. A visible +2 turns a person into a stat to farm: the player starts
+ * optimising an NPC instead of talking to one, and picks dialogue for the
+ * increment rather than because they mean it. Words keep it a relationship.
+ *
+ * Zero returns null rather than "neutral" — someone the story has no opinion
+ * about yet should have nothing written next to their name, not a label saying
+ * so.
+ */
+export function describeDisposition(value: number): string | null {
+  const level = boundedInt(value, MIN_DISPOSITION, MAX_DISPOSITION)
+  switch (level) {
+    case 3:
+      return 'would take a risk for you'
+    case 2:
+      return 'on your side'
+    case 1:
+      return 'warming to you'
+    case -1:
+      return 'wary of you'
+    case -2:
+      return 'wants nothing to do with you'
+    case -3:
+      return 'would see you suffer'
+    default:
+      return null
+  }
+}
+
 // ------------------------------------------------------ the relevance window
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       'src/app/micro-land/**/*.test.ts',
       'src/lib/micro-land/**/*.test.ts',
       'src/app/dicebound/**/*.test.ts',
+      'src/app/dicebound/**/*.test.tsx',
       'src/lib/dicebound/**/*.test.ts',
     ],
     coverage: {


### PR DESCRIPTION
Burst 1, UI lane. Closes most of **#3520** — the loose-ends surface it asks for.

The graph has been recording places, people and loose ends since it landed, and none of it reached the player. This is the half that says the game has been paying attention.

## What it looks like

Rendered from a real seeded campaign:

```
WHERE YOU ARE
  Saltmarket Quay
  tar and rain, nets drying
  DAY 2, MORNING

PEOPLE YOU KNOW
  Maren the harbourmaster    behind the counting-house desk — warming to you
  Pip                        mending nets, watching you — on your side
  Old Tace                   not seen since the equinox — wary of you

ON RECORD
  The Cormorant              the only sound boat in town
  Corrin Point light         dark for three weeks

LOOSE ENDS
  Find out what happened to the Gullwing        URGENT
  Bring Tace back, not the truth about Tace     PRESSING
  What you owe for the Cormorant                PATIENT
```

## Three rules it is built around

**Nothing renders until it exists.** Every section returns null when empty, and the whole panel returns null for a world nobody has written to. A character made a minute ago sees exactly what they saw before — an empty "People you know" heading would advertise a system they have not met and turn the sheet into a form waiting to be filled in.

**No numbers where a relationship belongs.** `describeDisposition` says *"on your side"*, never `+2`. A visible number turns a person into a stat to farm: the player starts choosing dialogue for the increment rather than because they mean it. Zero returns nothing at all rather than "neutral" — a label saying there is nothing to say is still a label.

**Loose ends carry pressure, not a countdown.** "Urgent" is the difference between a list and a reason to open the tab. The fuse time behind it stays hidden, because minutes remaining would turn the fiction into a timer. Settled threads are absent by construction — `openThreads` only returns open ones — so the list stays a set of things unfinished rather than a log.

It reads from the same `relevanceWindow` the DM is given, so the player sees the cast the DM is actually holding in mind rather than a longer list it has already forgotten.

## Verification

Six component tests — the first in this game's vitest suite. Adding them needed one line of config (`*.test.tsx` in the include glob); `jsdom` was already a dependency.

The one worth keeping is the empty case. *"Nothing renders until it exists"* is a stated rule with no other guard on it, and it is exactly the kind of rule a later change breaks without anyone noticing.

```
$ npx vitest run src/app/dicebound
 Test Files  8 passed (8)
      Tests  174 passed (174)          # 165 before: +3 describeDisposition, +6 WorldPanel

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint src/app/dicebound
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npm run build
✓ Compiled successfully
```

Markup was also rendered server-side against a seeded campaign to check structure and confirm it reuses the sheet's existing class vocabulary rather than inventing a second one.

## What I did not do

No new panel, tab or shell — the sheet is already "the game's second screen and its main reason to come back", and this belongs in it. No badge or tooltip on anything.

Branched off `main`, touches components only, so it does not contend with the server lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)