### PR TITLE
feat(dicebound): stop the dungeon master reaching for dice by default

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -182,8 +182,11 @@ THE LOOP
 You describe the situation. The player says what their character attempts. You describe what happens. Then you stop and wait. That is the entire game.
 
 DECIDING OUTCOMES
-- If the attempt is trivial, or success is guaranteed for this character, it simply works. Describe it happening and move on. Do NOT call for a roll. Walking through an open door is not a Dexterity check, and asking for one is the fastest way to make a game feel like paperwork.
-- If the attempt is uncertain — if it could plausibly fail, and failing would be interesting — call roll_check. Then narrate the result you are given.
+Most turns are not checks. The commonest move you have is IT SIMPLY WORKS: the thing happens, you say what the player now sees, and you hand the ball back. That is a real move and it is the one to reach for first.
+- Looking, listening, asking, waiting, walking somewhere safe, picking something up, talking to someone who has no reason to refuse — these are not checks. They just happen. Say what they find and move on.
+- A check needs BOTH halves: it could plausibly fail for this character, AND the failure would make the story more interesting. Only one half is not enough. "They might not notice" is not a check if not noticing changes nothing.
+- Before you call roll_check you must state what could go wrong. If you cannot say it in a clause, there is nothing at stake and this is not a check.
+- Two or three checks in a scene is a lot. A turn where nothing is rolled is not a turn you got wrong — it is most turns.
 - Narrate by DEGREE. The tool tells you which band you got, and the band tells you which move to make. You do not get to pick the band.
 
 WHEN THE DICE HAVE SPOKEN
@@ -253,6 +256,11 @@ const RollCheckSchema = z.object({
     .optional()
     .describe(
       'The specific sub-skill, when one genuinely applies. Null when the plain attribute is what is being tested.'
+    ),
+  uncertain: z
+    .string()
+    .describe(
+      'What could actually go wrong here, in a clause, and why that failure would be interesting. "The rope is old and he is heavier than he looks." If you cannot fill this in without straining, do not call this tool — narrate it happening instead.'
     ),
   dc: z.number().int().min(0).max(30).describe('The difficulty, from the table. Be honest.'),
   situational: z


### PR DESCRIPTION
Closes #3541. Burst 1, server lane.

The DM called for a roll on **65–90% of turns** across five measured runs, including *"I look around"* and *"I stay perfectly still and listen"*. The prompt already told it not to — the `trivial` row of the DC table exists for exactly this — and it was ignored. A firmer instruction was not going to work.

## Two structural changes instead

**Not rolling now has a name.** The move list gives the DM something concrete to do with every band the dice can produce, and *nothing at all* to do when the dice aren't involved. The only fully specified path through a turn ran through a check. `IT SIMPLY WORKS` is now the first move in the section, named as the commonest one, with the actual observed failures listed as examples:

> Looking, listening, asking, waiting, walking somewhere safe, picking something up, talking to someone who has no reason to refuse — these are not checks.

**`roll_check` requires the stake to be stated before it can roll.** A new required `uncertain` field: what could go wrong, in a clause, and why the failure would be interesting. Same shape as every other rule in this file — it doesn't discourage a real check, it refuses one nobody can articulate. And it stays inside the split the game rests on: the model supplies prose, code still owns every number.

## Measured, not asserted

| run | prompt state | share with a check |
| --- | --- | --- |
| baseline | before any voice work | 90% |
| after word budget | #3525 | 65% / 70% |
| with move list | #3524 | 80% |
| **this change** | | **50%** |

50% is where the harness was designed to land — its action list was written so that roughly half of those actions would not need a roll.

## A measurement that lied, and nearly cost the change

The first run reported **17%**, and I was ready to soften the prompt on the strength of it. That run had lost **8 of its 20 turns** to `anthropic 529: overloaded_error`, and the twelve that survived were not a representative sample. The rerun lost 2 and read 50%.

Recording it because the failure looked like a result: a plausible number, in the expected direction, from a run that had quietly thrown away 40% of its data. The `turns that failed` row added in #3526 is the only reason it was visible at all.

## One number that is not an independent finding

Narration median moved to 82 words. That is not a second win — half the turns now have no check, and a no-check turn gets the shorter budget, so the median moved because the *mix* moved. The turns that do roll are unchanged: p90 167 against 164, max 185 against 201.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  8 passed (8)
      Tests  174 passed (174)

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npm run build
✓ Compiled successfully
```

Two 20-turn runs against the live API.

## Not done here

`uncertain` is required of the model but not stored or shown. Putting the stake on the die card — *"the rope is old and he is heavier than he looks"* — would tell the player why this moment was a roll at all, and that is a good idea for its own issue rather than a schema change smuggled into a feel fix.

Branched off `main`, touches `turn/route.ts` only, so it does not contend with #3547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)