### PR TITLE
fix(dicebound): retry the model when the failure was about the moment

### DIFF
--- a/src/lib/dicebound/__tests__/anthropic.test.ts
+++ b/src/lib/dicebound/__tests__/anthropic.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { RefusedError, callModel } from '@/lib/dicebound/anthropic'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+function reply(status: number, body: unknown = {}, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), { status, headers })
+}
+
+function call(signal?: AbortSignal) {
+  return callModel({
+    apiKey: 'k',
+    system: 's',
+    messages: [{ role: 'user', content: 'hello' }],
+    maxTokens: 10,
+    signal,
+  })
+}
+
+describe('callModel', () => {
+  it('tries again when the model is briefly overloaded', async () => {
+    // The failure that was actually costing turns: a 20-turn run lost 8 of them
+    // to overloaded_error, and every one reached the player as "The telling
+    // faltered."
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(reply(529, { error: 'overloaded' }))
+      .mockResolvedValueOnce(reply(200, { content: [{ type: 'text', text: 'ok' }] }))
+
+    const data = await call()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(data.content?.[0]).toMatchObject({ text: 'ok' })
+  })
+
+  it('gives up after a bounded number of attempts rather than hammering', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => reply(529, {}))
+    await expect(call()).rejects.toThrow(/529/)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not retry a request that was wrong the first time', async () => {
+    // 400 is a fact about the request. Sending it again is a slower failure.
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => reply(400, {}))
+    await expect(call()).rejects.toThrow(/400/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry a refusal — asking again gets the same answer, slower', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => reply(200, { stop_reason: 'refusal' }))
+
+    await expect(call()).rejects.toBeInstanceOf(RefusedError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops retrying the moment the turn is abandoned', async () => {
+    // A turn has a hard deadline. A retry that lands after it is worse than no
+    // retry: the player has stopped waiting and the answer arrives to nobody.
+    const controller = new AbortController()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      controller.abort()
+      return reply(529, {})
+    })
+
+    await expect(call(controller.signal)).rejects.toThrow(/abort/i)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits as long as the server asked, but not longer than a turn can bear', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(reply(429, {}, { 'retry-after': '600' }))
+      .mockResolvedValueOnce(reply(200, { content: [] }))
+
+    const started = Date.now()
+    await call()
+    // A 600-second hint is honest and unusable inside a turn that aborts at
+    // 105, so it is capped rather than obeyed.
+    expect(Date.now() - started).toBeLessThan(3_000)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/lib/dicebound/anthropic.ts
+++ b/src/lib/dicebound/anthropic.ts
@@ -94,33 +94,113 @@ export interface CallOptions {
   signal?: AbortSignal
 }
 
-export async function callModel(options: CallOptions): Promise<ModelResponse> {
-  const response = await fetch(API_URL, {
-    method: 'POST',
-    signal: options.signal,
-    headers: {
-      'x-api-key': options.apiKey,
-      'anthropic-version': '2023-06-01',
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: options.model ?? DM_MODEL,
-      max_tokens: options.maxTokens,
-      system: options.system,
-      messages: options.messages,
-      ...(options.tools ? { tools: options.tools } : {}),
-      ...(options.toolChoice ? { tool_choice: options.toolChoice } : {}),
-    }),
-  })
+/**
+ * Statuses worth trying again.
+ *
+ * 529 is the one that actually bites: a 20-turn measured run lost 8 of its
+ * turns to `overloaded_error` in a single afternoon, and each one reached the
+ * player as "The telling faltered." Overload is a statement about the next few
+ * seconds, not about the request, so the request is still good.
+ *
+ * 429 is here because a rate limit answers the same way, and the 5xx family
+ * because a gateway that could not reach the model has told us nothing about
+ * whether the model would have answered. Everything else — 400, 401, 403 — is
+ * a fact about the request, and sending it again is just a slower failure.
+ */
+const RETRY_STATUSES = new Set([429, 500, 502, 503, 504, 529])
 
-  if (!response.ok) {
+/** Attempts in total, not retries after the first. */
+const MAX_ATTEMPTS = 3
+
+/** Doubling from here. Short, because a turn is already the slowest thing here. */
+const RETRY_BASE_MS = 600
+
+/** The longest any single wait may be, however long the server asks for. */
+const RETRY_CAP_MS = 2_000
+
+function retryDelay(attempt: number, header: string | null): number {
+  // `retry-after` is the server saying how long it actually needs. Prefer it
+  // over guessing, but cap it hard. A turn can make several model calls, each
+  // of which may retry, inside a 105-second deadline — so an honest 600-second
+  // hint is simply not usable here, and waiting even five would eat the budget
+  // the player is actually waiting on.
+  const advised = Number(header)
+  if (Number.isFinite(advised) && advised > 0) return Math.min(advised * 1000, RETRY_CAP_MS)
+  return RETRY_BASE_MS * 2 ** attempt
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'))
+      return
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    function onAbort() {
+      clearTimeout(timer)
+      reject(new DOMException('Aborted', 'AbortError'))
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * One call to the model, retried when the failure was about the moment rather
+ * than the request.
+ *
+ * Retrying lives here rather than in the turn loop because every path through
+ * the game funnels through this function — a turn, a condense, a
+ * reconciliation, building a character — and a transient failure in any of them
+ * is equally recoverable and equally invisible to the player. The alternative
+ * was four call sites each deciding for themselves.
+ *
+ * The caller's abort signal still bounds the whole thing. A turn has a hard
+ * deadline, and a retry that would land after it is worse than no retry: the
+ * player has already been waiting, and the answer would arrive to nobody.
+ */
+export async function callModel(options: CallOptions): Promise<ModelResponse> {
+  let lastError: Error | undefined
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const response = await fetch(API_URL, {
+      method: 'POST',
+      signal: options.signal,
+      headers: {
+        'x-api-key': options.apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: options.model ?? DM_MODEL,
+        max_tokens: options.maxTokens,
+        system: options.system,
+        messages: options.messages,
+        ...(options.tools ? { tools: options.tools } : {}),
+        ...(options.toolChoice ? { tool_choice: options.toolChoice } : {}),
+      }),
+    })
+
+    if (response.ok) {
+      const data = (await response.json()) as ModelResponse
+      // A refusal is a decision, not a hiccup. Asking again would get the same
+      // answer more slowly, and the caller already answers it in voice.
+      if (data.stop_reason === 'refusal') throw new RefusedError()
+      return data
+    }
+
     const detail = await response.text()
-    throw new Error(`anthropic ${response.status}: ${detail.slice(0, 300)}`)
+    lastError = new Error(`anthropic ${response.status}: ${detail.slice(0, 300)}`)
+
+    const last = attempt === MAX_ATTEMPTS - 1
+    if (!RETRY_STATUSES.has(response.status) || last) break
+
+    await sleep(retryDelay(attempt, response.headers.get('retry-after')), options.signal)
   }
 
-  const data = (await response.json()) as ModelResponse
-  if (data.stop_reason === 'refusal') throw new RefusedError()
-  return data
+  throw lastError ?? new Error('anthropic call failed')
 }
 
 /** Force one tool call and hand back its input verbatim. */


### PR DESCRIPTION
Closes #3536. Burst 2, server lane.

## The issue was about a different bug by the time it came up

I filed #3536 about the 105-second abort. Re-measuring before starting it, the failure mode had moved: recent runs show **zero AbortErrors** and every failure as `anthropic 529: overloaded_error`.

The issue itself predicted this — *"Land #3525 and re-measure. If a word budget pulls the median down far enough, this may simply go away."* The word budget plus the drop in checks per turn shrank both the prompt and the number of model calls, and took the timeout with them.

So this fixes what is actually failing.

## What retries, and what does not

| | |
| --- | --- |
| **529, 429, 5xx** | retried — overload is a statement about the next few seconds, not about the request |
| **400, 401, 403** | not retried — a fact about the request; sending it again is a slower failure |
| **refusal** | not retried — a decision, not a hiccup. The caller already answers it in voice |
| **abort** | stops immediately — see below |

Retrying lives in `callModel` rather than the turn loop because every path funnels through it — a turn, a condense, a reconciliation, building a character — and a transient failure in any of them is equally recoverable and equally invisible to the player. The alternative was four call sites each deciding for themselves.

**The abort signal still bounds everything.** A retry that would land after the deadline is worse than no retry: the player has stopped waiting, and the answer arrives to nobody.

## The tests caught a real mistake

I had capped `retry-after` at 5 seconds. A turn can make several model calls that each retry, inside a 105-second budget — 5s was eating the thing the player is actually waiting on. It is 2s now. That was a design error the test surfaced, not a test bug.

Six tests, including the two that matter most: a refusal is not retried, and an abort mid-flight stops immediately rather than sleeping through the deadline.

## Live

```
turns that failed             0/20
```

Against **8/20** and **2/20** in the two runs before it.

That is suggestive rather than proof — overload is a condition of the moment and may simply not have arisen during this run. The unit tests are what establish the retry behaves; the live run establishes it did not make anything worse.

Same run, incidentally: `share with a check 40%`, so #3541's change reads 50% and 40% across two clean runs. Model variance around the intended half.

## Verification

```
$ npx vitest run src/app/dicebound src/lib/dicebound
 Test Files  9 passed (9)
      Tests  180 passed (180)          # 174 before, +6 for callModel

$ npx tsc --noEmit 2>&1 | grep -i dicebound
(empty)

$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npm run build
✓ Compiled successfully
```

First tests in `src/lib/dicebound` — the glob was already in the vitest include list, waiting for them.

## Left alone deliberately

`TRANSCRIPT_WINDOW` and `CONDENSE_AT` are untouched. Both were candidates in the issue, and both change how much the DM remembers — a real behaviour change to fix a symptom that has stopped appearing. If timeouts return, they are the next lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)