### PR TITLE
feat(dicebound): things you can actually carry

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -66,6 +66,16 @@ import {
   resolveCheck,
 } from '@/app/dicebound/domain/dice'
 import {
+  type Kit,
+  MAX_ITEMS,
+  QUALITIES,
+  type Quality,
+  addItem,
+  itemFromGrant,
+  kitModifiers,
+} from '@/app/dicebound/domain/kit'
+import {
+  GRANT_ITEM_TOOL,
   NARRATE_TOOL,
   RECALL_TOOL,
   ROLL_CHECK_TOOL,
@@ -229,6 +239,12 @@ Every narrate call also reports what changed. This is an index of the story, not
 - touch: the two or three things that changed or first appeared. Reuse the same id for the same thing forever — "harbour-guard" stays "harbour-guard". Do not restate what did not change.
 - edges: connections that formed or changed. Both ends must be things you registered in touch.
 - threads: loose ends that moved. Close one only when the story is genuinely finished with it.
+WHAT THEY CARRY
+- When the fiction actually hands something over — they pick it up, are given it, take it — call grant_item. Not for scenery, and not for things they merely saw.
+- Almost everything is plain. A rope is a permission, not a bonus: it turns "you cannot climb that" into a roll you can make. Reserve the better bands for things the story made a moment of.
+- You say what a thing is. The game says what it is worth, and the answer is usually nothing. Do not describe an ordinary object as though it improved them.
+- When something they carry genuinely bears on an attempt, name it in roll_check's items. Name it because it is true, not to help — most named items add nothing to the number and appear on the card anyway.
+
 REMEMBERING
 What you are shown is a window on the story, not the whole of it. Places, people and promises that have gone quiet are still there and are not listed.
 - If the player refers to someone or something you cannot see in the list, call recall BEFORE you answer. Do not decide it is new because it is not in front of you.
@@ -261,6 +277,13 @@ const RollCheckSchema = z.object({
     .string()
     .describe(
       'What could actually go wrong here, in a clause, and why that failure would be interesting. "The rope is old and he is heavier than he looks." If you cannot fill this in without straining, do not call this tool — narrate it happening instead.'
+    ),
+  items: z
+    .array(z.string())
+    .max(4)
+    .optional()
+    .describe(
+      'Ids of things the character is carrying that genuinely bear on THIS attempt. Name them and the game decides what they are worth — most are worth nothing, and are named on the card anyway because the reason is real even when the number is not.'
     ),
   dc: z.number().int().min(0).max(30).describe('The difficulty, from the table. Be honest.'),
   situational: z
@@ -411,6 +434,51 @@ const RECALL: ToolDef = {
   description:
     'Look something up that is not in front of you. Use this when the player refers to a person, place or promise you cannot see listed — the story may well contain it. Returns nothing if there is genuinely no match, and nothing means it is new.',
   input_schema: toolSchema(RecallSchema),
+}
+
+const GrantItemSchema = z.object({
+  id: z.string().describe('Stable lowercase slug. Reuse it if the character already has this.'),
+  name: z.string().describe('What the player would call it.'),
+  note: z.string().optional().describe('One line: what it is and where it came from.'),
+  quality: z
+    .enum(QUALITIES as unknown as [Quality, ...Quality[]])
+    .describe(
+      'How good it is. Almost everything is plain — a rope is a permission, not a bonus. Reserve storied for things the story made a moment of.'
+    ),
+  origin: z
+    .string()
+    .optional()
+    .describe('The id of the person, place or thing it came from, if the world knows one.'),
+  consumable: z.boolean().optional().describe('True if using it uses it up.'),
+  uses: z.number().int().min(1).max(9).optional().describe('For a consumable, how many.'),
+  traits: z
+    .array(
+      z.object({
+        label: z
+          .string()
+          .describe(
+            'What is true because they have it, as the player would say it: "you have rope".'
+          ),
+        applies: z
+          .object({
+            attributes: z.array(AttributeEnum).optional(),
+            skills: z.array(SkillEnum).optional(),
+          })
+          .optional()
+          .describe(
+            'Leave empty when it bears on everything. Name attributes or skills to narrow it.'
+          ),
+      })
+    )
+    .max(2)
+    .optional(),
+})
+
+const GRANT_ITEM: ToolDef = {
+  name: GRANT_ITEM_TOOL,
+  description:
+    'Give the character something to carry. Call this only when the fiction actually hands it over — they picked it up, were given it, took it. Do not call it to describe scenery. The game decides what the thing is worth; you decide what it is.',
+  input_schema: toolSchema(GrantItemSchema),
 }
 
 const OpeningSchema = z.object({
@@ -693,6 +761,7 @@ Resolve it, then call narrate with what happens.`,
   // thread that fires on the interruption's own elapsed minutes could keep
   // reopening it, and a turn that never stops is a turn that never comes back.
   let fuseAnswered = false
+  let kit = campaign.kit
 
   for (let step = 0; step <= MAX_CHECKS; step++) {
     const lastStep = step === MAX_CHECKS
@@ -713,11 +782,11 @@ Resolve it, then call narrate with what happens.`,
       // which is a harder guarantee than asking nicely for prose. There is no
       // fourth roll available to reach for, and finishing is the only move
       // left on the board.
-      tools: lastStep ? [narrate] : [ROLL_CHECK, RECALL, narrate],
+      tools: lastStep ? [narrate] : [ROLL_CHECK, RECALL, GRANT_ITEM, narrate],
       toolChoice: lastStep ? { type: 'tool', name: NARRATE_TOOL } : { type: 'auto' },
     })
 
-    const { rolls, recalls, ending, premature } = partitionTurnCalls(toolUses(data))
+    const { rolls, recalls, grants, ending, premature } = partitionTurnCalls(toolUses(data))
 
     if (ending) {
       const text = narrationOf(ending.input)
@@ -764,7 +833,12 @@ Resolve it, then call narrate with what happens.`,
       break
     }
 
-    if (rolls.length === 0 && recalls.length === 0 && premature.length === 0) {
+    if (
+      rolls.length === 0 &&
+      recalls.length === 0 &&
+      grants.length === 0 &&
+      premature.length === 0
+    ) {
       // The model answered in prose instead of declaring the end of the turn.
       // Take it anyway. The turn is over either way, and spending a round trip
       // teaching the model the ceremony would cost the player fifteen seconds
@@ -777,9 +851,14 @@ Resolve it, then call narrate with what happens.`,
 
     const results: ContentBlock[] = []
     for (const call of rolls) {
-      const { entry, brief } = rollFor(campaign, call.input)
+      const { entry, brief } = rollFor(campaign, kit, call.input)
       entries.push(entry)
       results.push({ type: 'tool_result', tool_use_id: call.id, content: brief })
+    }
+    for (const call of grants) {
+      const { kit: next, note } = grantFor(kit, world.clock.elapsed, call.input)
+      kit = next
+      results.push({ type: 'tool_result', tool_use_id: call.id, content: note })
     }
     // A lookup costs a pass but not a check: it is the DM checking its notes,
     // not the story moving. `MAX_CHECKS` still bounds the loop, so a model that
@@ -807,7 +886,7 @@ Resolve it, then call narrate with what happens.`,
   }
 
   entries.push({ kind: 'narration', text: narration })
-  return { entries, synopsis, dropped, world, chapters }
+  return { entries, synopsis, dropped, world, chapters, kit }
 }
 
 /**
@@ -874,14 +953,49 @@ function recallFor(world: World, input: unknown): string {
     .join('\n')
 }
 
+/**
+ * Hand something over, and tell the DM what it turned out to be worth.
+ *
+ * The reply matters as much as the write. A model that grants a sword and is
+ * told nothing will describe it as mighty; told the sword is plain and worth
+ * nothing on the die, it describes a sword. That is the same loop `roll_check`
+ * runs — commit first, then narrate around a number you did not choose.
+ */
+function grantFor(kit: Kit, now: number, input: unknown): { kit: Kit; note: string } {
+  const item = itemFromGrant((input ?? {}) as Record<string, unknown>, now)
+  if (!item)
+    return { kit, note: 'That did not describe a thing anyone could pick up. Nothing was added.' }
+
+  const { kit: next, added } = addItem(kit, item)
+  if (!added) {
+    return {
+      kit,
+      note: `They are carrying ${MAX_ITEMS} things already and cannot take ${item.name} as well. Say so in the fiction and let them choose what to put down.`,
+    }
+  }
+
+  const worth = item.traits.filter(trait => trait.bonus !== 0)
+  return {
+    kit: next,
+    note: worth.length
+      ? `${item.name} is theirs. On the die it is worth ${worth.map(t => `${t.label} ${t.bonus > 0 ? '+' : ''}${t.bonus}`).join(', ')} — no more than that. Narrate it as the thing it is, not as an upgrade.`
+      : `${item.name} is theirs, and it is worth nothing on the die. That is the common case: it is a permission, not a bonus. It may make things possible that were not; it does not make them easier.`,
+  }
+}
+
 /** Resolve one `roll_check` call into a transcript entry and a model briefing. */
-function rollFor(campaign: Campaign, input: unknown): { entry: CheckEntry; brief: string } {
+function rollFor(
+  campaign: Campaign,
+  kit: Kit,
+  input: unknown
+): { entry: CheckEntry; brief: string } {
   const raw = (input ?? {}) as {
     attempt?: unknown
     attribute?: unknown
     skill?: unknown
     dc?: unknown
     situational?: unknown
+    items?: unknown
   }
 
   const attribute: AttributeId = isAttributeId(raw.attribute) ? raw.attribute : 'wisdom'
@@ -911,6 +1025,9 @@ function rollFor(campaign: Campaign, input: unknown): { entry: CheckEntry; brief
   // though they were average. A rank of 0 is left off because an unearned
   // skill has nothing to say — the attribute row already covers it.
   if (skill && rank !== 0) modifiers.push({ label: SKILLS[skill].name, value: rank })
+  // Kit is capped on its own, before the situational set is added, so a full
+  // pack cannot eat the ±6 budget the scene is entitled to.
+  modifiers.push(...kitModifiers(kit, raw.items, attribute, skill))
   modifiers.push(...situational)
 
   const outcome = resolveCheck({ dc, modifiers })

--- a/src/app/dicebound/domain/__tests__/kit.test.ts
+++ b/src/app/dicebound/domain/__tests__/kit.test.ts
@@ -6,10 +6,14 @@ import {
   MAX_LEVEL,
   MAX_POWERS,
   MAX_TRAIT,
+  QUALITY_BANDS,
   REST_MINUTES,
   TIER_CHARGES,
+  addItem,
   emptyKit,
   isRest,
+  itemFromGrant,
+  kitModifiers,
   levelFor,
   maxPowersAt,
   maxTierAt,
@@ -168,5 +172,169 @@ describe('validateKit', () => {
     // And even two maxed traits cannot outrun the kit ceiling.
     const total = (item?.traits ?? []).reduce((sum, t) => sum + t.bonus, 0)
     expect(total).toBeLessThanOrEqual(KIT_BONUS_CAP)
+  })
+})
+
+describe('itemFromGrant', () => {
+  const rope = {
+    id: 'coil-of-rope',
+    name: 'Coil of rope',
+    quality: 'plain',
+    traits: [{ label: 'you have rope' }],
+  }
+
+  it('prices the item from the band, never from the proposal', () => {
+    // An item is permanent, so a model allowed to write its own bonus is a
+    // model writing a bonus onto every future roll.
+    const item = itemFromGrant({ ...rope, traits: [{ label: 'you have rope', bonus: 2 }] }, 100)
+    expect(item?.traits[0].bonus).toBe(QUALITY_BANDS.plain.bonus)
+    expect(item?.traits[0].bonus).toBe(0)
+  })
+
+  it('gives a plain thing a named trait worth nothing — a permission, not a bonus', () => {
+    const item = itemFromGrant(rope, 100)
+    expect(item?.traits).toHaveLength(1)
+    expect(item?.traits[0].label).toBe('you have rope')
+    expect(item?.traits[0].bonus).toBe(0)
+  })
+
+  it('buys extra traits with rarity rather than a bigger number', () => {
+    const storied = itemFromGrant(
+      {
+        id: 'lamp',
+        name: 'The Lamp',
+        quality: 'storied',
+        traits: [{ label: 'lit' }, { label: 'warm' }, { label: 'third' }],
+      },
+      0
+    )
+    expect(storied?.traits).toHaveLength(QUALITY_BANDS.storied.traits)
+    expect(storied?.traits[0].bonus).toBe(2)
+  })
+
+  it('refuses a thing with no name — an item nobody can call on again', () => {
+    expect(itemFromGrant({ id: '!!!', name: 'Ghost' }, 0)).toBeNull()
+    expect(itemFromGrant({ id: 'thing', name: '  ' }, 0)).toBeNull()
+  })
+
+  it('gives a consumable its uses and stamps when it was gained', () => {
+    const item = itemFromGrant({ id: 'draught', name: 'Draught', consumable: true, uses: 3 }, 480)
+    expect(item?.charges).toEqual({ now: 3, max: 3 })
+    expect(item?.gainedAt).toBe(480)
+  })
+})
+
+describe('addItem', () => {
+  const make = (id: string) => itemFromGrant({ id, name: id }, 0)!
+
+  it('refuses a full pack rather than dropping something you were carrying', () => {
+    // Being told "you have no room" hands the decision back. Waking up to find
+    // your rope gone is a bug as far as anyone at the table can tell.
+    let kit = emptyKit()
+    for (let i = 0; i < MAX_ITEMS; i++) kit = addItem(kit, make(`item-${i}`)).kit
+
+    const { kit: after, added } = addItem(kit, make('one-too-many'))
+    expect(added).toBe(false)
+    expect(after.items).toHaveLength(MAX_ITEMS)
+  })
+
+  it('replaces rather than duplicates when the same thing is granted twice', () => {
+    const kit = addItem(addItem(emptyKit(), make('rope')).kit, make('rope')).kit
+    expect(kit.items).toHaveLength(1)
+  })
+})
+
+describe('kitModifiers', () => {
+  function kitWith(...grants: Parameters<typeof itemFromGrant>[0][]) {
+    let kit = emptyKit()
+    for (const g of grants) kit = addItem(kit, itemFromGrant(g, 0)!).kit
+    return kit
+  }
+
+  it('says what the rope is worth, which is usually nothing', () => {
+    const kit = kitWith({
+      id: 'rope',
+      name: 'Rope',
+      quality: 'plain',
+      traits: [{ label: 'you have rope' }],
+    })
+    // A +0 trait is real in the fiction and adds no row to the die card.
+    expect(kitModifiers(kit, ['rope'], 'dexterity', null)).toEqual([])
+  })
+
+  it('only counts a trait where it claims to count', () => {
+    // An item good at seeing does not help you lift — the same discipline
+    // applicableSkill enforces for skills.
+    const kit = kitWith({
+      id: 'lantern',
+      name: 'Lantern',
+      quality: 'fine',
+      traits: [{ label: 'the lantern is lit', applies: { attributes: ['wisdom'] } }],
+    })
+    expect(kitModifiers(kit, ['lantern'], 'wisdom', null)).toEqual([
+      { label: 'the lantern is lit', value: 1 },
+    ])
+    expect(kitModifiers(kit, ['lantern'], 'strength', null)).toEqual([])
+  })
+
+  it('lets a trait that claims nothing apply anywhere', () => {
+    const kit = kitWith({
+      id: 'boots',
+      name: 'Boots',
+      quality: 'fine',
+      traits: [{ label: 'good boots' }],
+    })
+    expect(kitModifiers(kit, ['boots'], 'strength', null)).toHaveLength(1)
+  })
+
+  it('ignores an item the DM did not name', () => {
+    const kit = kitWith({
+      id: 'boots',
+      name: 'Boots',
+      quality: 'fine',
+      traits: [{ label: 'good boots' }],
+    })
+    expect(kitModifiers(kit, ['rope'], 'strength', null)).toEqual([])
+    expect(kitModifiers(kit, undefined, 'strength', null)).toEqual([])
+  })
+
+  it('stops a spent consumable helping, without taking it off you', () => {
+    let kit = kitWith({
+      id: 'draught',
+      name: 'Draught',
+      quality: 'storied',
+      consumable: true,
+      uses: 1,
+      traits: [{ label: 'the draught burns' }],
+    })
+    kit = {
+      ...kit,
+      items: kit.items.map(i => ({ ...i, charges: { now: 0, max: 1 } })),
+    }
+    expect(kitModifiers(kit, ['draught'], 'strength', null)).toEqual([])
+    expect(kit.items).toHaveLength(1)
+  })
+
+  it('holds a well-packed character under the ceiling', () => {
+    // Kit is permanent, so without its own cap a well-equipped character simply
+    // stops rolling.
+    const kit = kitWith(
+      { id: 'a', name: 'A', quality: 'storied', traits: [{ label: 'a' }, { label: 'a2' }] },
+      { id: 'b', name: 'B', quality: 'storied', traits: [{ label: 'b' }, { label: 'b2' }] }
+    )
+    const mods = kitModifiers(kit, ['a', 'b'], 'strength', null)
+    const total = mods.reduce((sum, m) => sum + m.value, 0)
+    expect(total).toBeLessThanOrEqual(KIT_BONUS_CAP)
+  })
+
+  it('trims the smallest first, so the thing that helped most still shows', () => {
+    const kit = kitWith(
+      { id: 'big', name: 'Big', quality: 'storied', traits: [{ label: 'the great sword' }] },
+      { id: 'small', name: 'Small', quality: 'fine', traits: [{ label: 'a good grip' }] },
+      { id: 'small2', name: 'Small2', quality: 'fine', traits: [{ label: 'dry hands' }] }
+    )
+    const mods = kitModifiers(kit, ['big', 'small', 'small2'], 'strength', null)
+    expect(mods.map(m => m.label)).toContain('the great sword')
+    expect(mods.reduce((sum, m) => sum + m.value, 0)).toBeLessThanOrEqual(KIT_BONUS_CAP)
   })
 })

--- a/src/app/dicebound/domain/kit.ts
+++ b/src/app/dicebound/domain/kit.ts
@@ -143,6 +143,37 @@ export function emptyKit(): Kit {
  */
 export const KIT_BONUS_CAP = 3
 
+/**
+ * How good a thing is, and what that is worth.
+ *
+ * The model picks the band; this decides the numbers. That is the same split
+ * `roll_check` runs on, and it matters more here than it looks: an item is
+ * permanent, so a model allowed to write its own bonus is a model writing a
+ * bonus onto every future roll.
+ *
+ * Adapted from `tap-tap-adventure`'s rarity table, which has the right instinct
+ * — common is 55% of drops and its multiplier is 1.0 — but the wrong vocabulary.
+ * "Epic" and "legendary" are loot-game words and this is a game about a story,
+ * so the bands are named the way a person at the table would describe a thing
+ * they were handed.
+ *
+ * **Most items are +0.** A rope is not a bonus, it is a permission: it turns
+ * "you cannot climb that" into a DC 15. If every item were +1 then a
+ * well-packed character would stop rolling, which is the failure this whole
+ * table exists to prevent. Rarity mostly buys *more traits* — more situations
+ * the thing is good in — rather than a bigger number in any one of them.
+ */
+export type Quality = 'plain' | 'fine' | 'remarkable' | 'storied'
+
+export const QUALITIES: readonly Quality[] = ['plain', 'fine', 'remarkable', 'storied']
+
+export const QUALITY_BANDS: Record<Quality, { bonus: number; traits: number }> = {
+  plain: { bonus: 0, traits: 1 },
+  fine: { bonus: 1, traits: 1 },
+  remarkable: { bonus: 1, traits: 2 },
+  storied: { bonus: 2, traits: 2 },
+}
+
 /** Levels. `1 + earned ranks / 3` — ranks are earned on use, so level cannot be granted. */
 export const RANKS_PER_LEVEL = 3
 export const MAX_LEVEL = 10
@@ -318,4 +349,178 @@ export function validateKit(value: unknown): Kit {
     species: validateSpecies(value.species),
     className: str(value.className, 60).trim() || null,
   }
+}
+
+// ------------------------------------------------------------ carrying things
+
+/** One item as the dungeon master proposes it, before code prices it. */
+export interface ItemGrant {
+  id?: unknown
+  name?: unknown
+  note?: unknown
+  quality?: unknown
+  origin?: unknown
+  consumable?: unknown
+  uses?: unknown
+  traits?: unknown
+}
+
+/**
+ * Turn a proposed item into a carried one.
+ *
+ * The model says what the thing is, what it is good for, and roughly how good.
+ * Every number comes from here: the bonus off the quality band, how many traits
+ * survive, how many uses a consumable gets. A model that wrote its own bonus
+ * would be writing a modifier onto every future roll, which is the one thing
+ * the whole architecture is arranged to prevent.
+ *
+ * `now` is the clock minute, passed in rather than read, so this stays pure.
+ */
+export function itemFromGrant(grant: ItemGrant, now: number): Item | null {
+  const id = slug(grant.id)
+  const name = str(grant.name, 80).trim()
+  // No id and no name is not an item, it is a sentence. Dropped rather than
+  // repaired: an item nobody can name is one the DM can never call on again.
+  if (!id || !name) return null
+
+  const quality = oneOf(grant.quality, QUALITIES, 'plain')
+  const band = QUALITY_BANDS[quality]
+
+  const proposed = Array.isArray(grant.traits) ? grant.traits : []
+  const traits: Trait[] = proposed
+    .filter(isPlainObject)
+    .slice(0, band.traits)
+    .map(raw => ({
+      label: str(raw.label, 80).trim() || name,
+      // The band decides, not the proposal. A trait the model wanted at +2 on a
+      // plain item is worth +0, and the player still sees it named on the die
+      // card — the reason is real even when the number is nothing.
+      bonus: band.bonus,
+      applies: validateApplicability(raw.applies),
+    }))
+    .filter(trait => trait.label.length > 0)
+
+  const consumable = bool(grant.consumable)
+  const uses = boundedInt(grant.uses, 1, 9, 1)
+
+  return {
+    id,
+    name,
+    note: str(grant.note, 240),
+    traits,
+    ...(consumable ? { charges: { now: uses, max: uses } } : {}),
+    consumable,
+    origin: slug(grant.origin) || null,
+    gainedAt: Math.max(0, now),
+  }
+}
+
+/**
+ * Add an item to a pack that may already be full.
+ *
+ * Slots, not weight: twelve, because a limit that forces a choice makes a story
+ * and a limit that requires arithmetic does not. A full pack refuses the new
+ * thing rather than silently dropping something the player was carrying — being
+ * told "you have no room" is a decision handed back to them, and waking up to
+ * find your rope gone is a bug as far as anyone at the table can tell.
+ */
+export function addItem(kit: Kit, item: Item): { kit: Kit; added: boolean } {
+  const existing = kit.items.findIndex(held => held.id === item.id)
+  if (existing !== -1) {
+    const items = [...kit.items]
+    items[existing] = item
+    return { kit: { ...kit, items }, added: true }
+  }
+
+  if (kit.items.length >= MAX_ITEMS) return { kit, added: false }
+  return { kit: { ...kit, items: [...kit.items, item] }, added: true }
+}
+
+/**
+ * What the named items are worth on this particular check.
+ *
+ * The DM says *that the rope applies*; this says what the rope is worth, which
+ * is usually nothing. Three rules do the work.
+ *
+ * A trait only counts where it claims to count. An item good at seeing does not
+ * help you lift, and the applicability check here is the same discipline
+ * `applicableSkill` enforces for skills — a mismatch is dropped silently rather
+ * than refused, because the check should still happen.
+ *
+ * A trait with an empty applicability applies to everything. That is deliberate
+ * and it is why `plain` exists: a rope that is good in general is good for +0.
+ *
+ * The total is capped at `KIT_BONUS_CAP`, separately from the ±6 situational
+ * budget. Situational modifiers come and go with the scene; a pack is
+ * permanent, so without its own ceiling a well-equipped character stops rolling
+ * altogether.
+ */
+export function kitModifiers(
+  kit: Kit,
+  named: unknown,
+  attribute: AttributeId,
+  skill: SkillId | null
+): { label: string; value: number }[] {
+  if (!Array.isArray(named)) return []
+
+  const wanted = new Set(named.map(id => slug(id)).filter(Boolean))
+  const out: { label: string; value: number }[] = []
+
+  for (const item of kit.items) {
+    if (!wanted.has(item.id)) continue
+    // A consumable with nothing left is a thing you are still carrying and can
+    // no longer use. It stays in the pack; it just stops helping.
+    if (item.charges && item.charges.now <= 0) continue
+
+    for (const trait of item.traits) {
+      if (trait.bonus === 0) continue
+      if (!traitApplies(trait, attribute, skill)) continue
+      out.push({ label: trait.label, value: trait.bonus })
+    }
+  }
+
+  return capKit(out)
+}
+
+function traitApplies(trait: Trait, attribute: AttributeId, skill: SkillId | null): boolean {
+  const { attributes, skills } = trait.applies
+  const claimsSomething = (attributes?.length ?? 0) > 0 || (skills?.length ?? 0) > 0
+  if (!claimsSomething) return true
+
+  if (attributes?.includes(attribute)) return true
+  if (skill && skills?.includes(skill)) return true
+  return false
+}
+
+/**
+ * Hold the set under the ceiling without hiding any of it.
+ *
+ * Trimmed from the smallest upward rather than truncated, so the thing the
+ * player thought was helping most still appears on the die card. A card that
+ * silently omits a reason teaches the player that the fiction does not affect
+ * the odds, which is the opposite of what it is for.
+ */
+function capKit(modifiers: { label: string; value: number }[]): { label: string; value: number }[] {
+  const total = modifiers.reduce((sum, m) => sum + m.value, 0)
+  if (Math.abs(total) <= KIT_BONUS_CAP) return modifiers
+
+  const ordered = [...modifiers].sort((a, b) => Math.abs(b.value) - Math.abs(a.value))
+  const kept: { label: string; value: number }[] = []
+  let running = 0
+
+  for (const modifier of ordered) {
+    const next = running + modifier.value
+    if (Math.abs(next) > KIT_BONUS_CAP) {
+      const room = KIT_BONUS_CAP - Math.abs(running)
+      if (room <= 0) break
+      const trimmed = modifier.value > 0 ? room : -room
+      kept.push({ label: modifier.label, value: trimmed })
+      running += trimmed
+      break
+    }
+    kept.push(modifier)
+    running = next
+  }
+
+  return kept
 }

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -9,6 +9,7 @@
 import { type Character, recordSkillUse } from './character'
 
 import type { Campaign, CampaignStats, CheckEntry, TranscriptEntry } from './campaign'
+import type { Kit } from './kit'
 import type { World } from './world'
 
 /** A tool call as the turn loop sees it: a name, and whatever the model sent. */
@@ -20,6 +21,7 @@ export interface ToolCall {
 export const ROLL_CHECK_TOOL = 'roll_check'
 export const NARRATE_TOOL = 'narrate'
 export const RECALL_TOOL = 'recall'
+export const GRANT_ITEM_TOOL = 'grant_item'
 
 /** One pass's tool calls, sorted into what the loop does with each. */
 export interface TurnCalls<T extends ToolCall> {
@@ -30,6 +32,8 @@ export interface TurnCalls<T extends ToolCall> {
    * so it neither ends the turn nor spends one of its checks.
    */
   recalls: T[]
+  /** `grant_item` calls. Like a lookup: answered, and the turn carries on. */
+  grants: T[]
   /** The `narrate` call that ends the turn, or null while the turn continues. */
   ending: T | null
   /**
@@ -59,18 +63,19 @@ export interface TurnCalls<T extends ToolCall> {
 export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T> {
   const rolls = calls.filter(call => call.name === ROLL_CHECK_TOOL)
   const recalls = calls.filter(call => call.name === RECALL_TOOL)
+  const grants = calls.filter(call => call.name === GRANT_ITEM_TOOL)
   const narrations = calls.filter(call => call.name === NARRATE_TOOL)
 
   // A narration sent alongside a lookup is as blind as one sent alongside a
   // roll: it was written before the answer came back, so whatever the DM asked
   // for cannot be in it.
-  if (rolls.length > 0 || recalls.length > 0) {
-    return { rolls, recalls, ending: null, premature: narrations }
+  if (rolls.length > 0 || recalls.length > 0 || grants.length > 0) {
+    return { rolls, recalls, grants, ending: null, premature: narrations }
   }
 
   // Only the first narration ends the turn. A second one is a duplicate, not a
   // continuation, and appending both would read as the DM saying it twice.
-  return { rolls, recalls, ending: narrations[0] ?? null, premature: narrations.slice(1) }
+  return { rolls, recalls, grants, ending: narrations[0] ?? null, premature: narrations.slice(1) }
 }
 
 /** What a turn produced, before it has been written down anywhere. */
@@ -90,6 +95,8 @@ export interface TurnResult {
    * treating a missing field as an emptied graph.
    */
   world?: World
+  /** The pack after anything the turn handed over. */
+  kit?: Kit
   /**
    * The chapter counter after an archive. Set only on a turn that condensed and
    * successfully wrote what it dropped — a failed archive leaves the counter
@@ -156,6 +163,7 @@ export function applyTurn(campaign: Campaign, result: TurnResult, now: number): 
     title: result.title ?? campaign.title,
     synopsis: result.synopsis ?? campaign.synopsis,
     world: result.world ?? campaign.world,
+    kit: result.kit ?? campaign.kit,
     chapters: result.chapters ?? campaign.chapters,
     character,
     transcript: [...kept, ...entries],


### PR DESCRIPTION
Part of #3521. Burst 3, server lane.

The `Item` model has existed since the models landed and nothing ever wrote to it. This gives the fiction a way to hand something over, and gives a carried thing a way to reach the die.

## Granting is its own tool, not a field on `narrate`

A field gets filled in passing; a tool has to be reached for, and reaching for it is the brake. This was the open decision from the plan — flagging that I picked it rather than waiting, and it is one edit to reverse.

## Most items are +0, and that is the load-bearing part

A rope is a permission, not a bonus: it turns *"you cannot climb that"* into a DC 15. A +0 trait is still **named on the die card**, because the reason is real even when the number is nothing. If every item carried a +1, a well-packed character would stop rolling — which is the failure the whole table exists to prevent.

Quality bands are adapted from `tap-tap-adventure`'s rarity table, which has the right instinct (common is 55% of drops, multiplier 1.0) and the wrong vocabulary — "epic" and "legendary" are loot-game words. Rarity mostly buys **more traits** rather than a bigger number:

```
plain       +0, 1 trait     ← almost everything
fine        +1, 1 trait
remarkable  +1, 2 traits
storied     +2, 2 traits
```

**The reply to a grant matters as much as the write.** A model told nothing describes the sword it just handed over as mighty. Told the sword is plain and worth nothing on the die, it describes a sword. Same loop `roll_check` runs: commit first, then narrate around a number you did not choose.

## Live

```
PACK (3): good-rope="Coil of good rope" [you have rope +0]
       || iron-spike="Iron wall-spike" [no traits]
       || sconce-spike="Iron sconce spike" [no traits]
STORED PACK: good-rope, iron-spike, sconce-spike
```

Items persist across turns and survive the round-trip through Firestore.

## Two things the live run exposed, neither fixed here

**The DM grants the same object twice under different ids.** `iron-spike="Iron wall-spike"` and `sconce-spike="Iron sconce spike"` are the same spike. `addItem` dedupes by id, so different slugs for one object both land, and a pack fills with duplicates. This is the same class of drift the world graph has — and the world graph has reconciliation to repair it, while the kit has nothing. Wants its own issue; the fix is probably to let `condense` reconcile the pack the way it reconciles entities.

**The DM used an item in the fiction without naming it in `items`.** The narration reads *"the spike hooked through your…"* and the die card shows only `Dexterity +2 | Balance +1`. No harm done — the spike was +0 and would have added nothing — but it means the card is not yet telling the player the whole reason. Worth watching once there are items worth more than nothing.

## Verification

```
$ npx vitest run src/app/dicebound src/lib/dicebound
      Tests  188 passed (188)          # 180 before, +14 for inventory

$ npx tsc --noEmit 2>&1 | grep -i dicebound      (empty)
$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound   (clean)
$ npm run lint:routes                            check-route-slugs: ok
$ npm run build                                  ✓ Compiled successfully
```

Species and the inventory UI are the rest of #3521 and are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)