### PR TITLE
docs(dicebound): bring the skill back in line with the game

### DIFF
--- a/.claude/skills/dicebound/SKILL.md
+++ b/.claude/skills/dicebound/SKILL.md
@@ -16,8 +16,8 @@ it works. Everything lives under `src/app/dicebound`, plus three API routes
 
 - `references/architecture.md` — file map, the turn loop, data flow, what each
   domain module owns.
-- `references/workflow.md` — how to pick up and land a phase 2 issue, including
-  which issues may run in parallel.
+- `references/workflow.md` — where the issue tree stands, how lanes are drawn by
+  file ownership, and why PRs are never stacked.
 - `docs/dicebound-design.md` — phase 1's load-bearing decisions.
 - `docs/dicebound-phase-2.md` — the phase 2 spec. Every open issue points here.
 
@@ -28,16 +28,24 @@ repair, offer real options back rather than picking one — plain language, but
 each option has to change what actually gets built and say what the consequence
 is.
 
-Two things are still explicitly undecided and should not be quietly settled by a
-PR: **the name** ("Dicebound" is a placeholder now committed to routes, a
-lint-checked constant and two Firestore collections), and **the tier/level table**
-for powers (tier 2 at level 4 is a starting guess).
+Three things are still explicitly undecided and should not be quietly settled by
+a PR:
+
+- **The name.** "Dicebound" is a placeholder, now committed to a route, a
+  lint-checked constant and two Firestore collections. Renaming is cheap today
+  and a data migration later.
+- **The tier/level table** for powers. Tier 2 at level 4 is a starting guess and
+  it sets how long a campaign takes to feel powerful.
+- **How the player gets an item.** Granting is currently its own `grant_item`
+  tool rather than a field on `narrate`, on the reasoning that a field gets
+  filled in passing while a tool has to be reached for. That was decided in a PR
+  rather than by Nick, is flagged as such, and is one edit to reverse.
 
 ## The game in one paragraph
 
 Eight attributes, chosen once from a sentence a model reads. Forty skills
 beneath them, none of which exist on a new sheet — they are earned by being
-called on, at 3, 8 and 18 uses, and they advance on *use*, not on success. Each
+called on, at 3, 8 and 18 uses, and they advance on _use_, not on success. Each
 turn the player writes what they attempt; the DM decides whether it is uncertain,
 and if it is, names the attribute, the skill, a DC from a fixed table, and
 whatever in the scene helps or hurts. Then it stops, and code rolls a d20. Six
@@ -51,44 +59,56 @@ items, powers and species that all compile down to three primitives.
 ## Invariants
 
 1. **The model narrates; code owns every number.** This is the whole
-   architecture. `roll_check` exists so the DM commits to a DC *before* it learns
+   architecture. `roll_check` exists so the DM commits to a DC _before_ it learns
    the die, and then narrates around a fact it cannot edit. A model asked to set
    a difficulty and roll against it in the same breath will let the player win —
    not out of malice, out of helpfulness. Any change that lets the model see or
    choose an outcome before committing to its difficulty is wrong even if it
-   works. The same split governs everything phase 2 adds: the model may say *that
-   the rope applies*, never *what the rope is worth*.
+   works. The same split governs everything phase 2 adds: the model may say _that
+   the rope applies_, never _what the rope is worth_.
 
-2. **The turn loop must terminate.** `playTurn` runs at most `MAX_CHECKS` passes
+2. **Narration written before a fact it depends on is discarded, never kept.**
+   This started as one rule about dice and turned out to be three. A `narrate`
+   sent in the same message as a `roll_check` was written before the die existed.
+   A `narrate` sent alongside a `recall` was written before the lookup answered.
+   And on a turn that runs into a fuse, the model has already described the whole
+   span the player asked for — one live run read "dawn finds you still moving, by
+   the second afternoon" and then stopped the clock forty-five minutes in, which
+   would have given the player two days of walking followed by an ambush that
+   happened before breakfast. In every case the model could not have known, so it
+   does not get to describe it. Discard and ask again. Expect this rule to apply
+   to the next fact the model cannot see in advance, too.
+
+3. **The turn loop must terminate.** `playTurn` runs at most `MAX_CHECKS` passes
    and the final pass withdraws the tool (phase 1) or forces `narrate` (phase 2).
    A turn that never stops rolling is a turn that never comes back. There is also
    a fallback narration for the case where even the forced call returns nothing —
    the player is owed a turn either way.
 
-3. **`applicableSkill` is not optional.** A skill only adds its rank when it
+4. **`applicableSkill` is not optional.** A skill only adds its rank when it
    actually sits beneath the attribute being tested. Engineering must not help
    you jump a fence, however the DM labelled it. Mismatches are dropped, not
    rejected — the check still happens, it just runs on the attribute alone.
 
-4. **The DM cannot grant progression.** Ranks come from `RANK_THRESHOLDS`, level
+5. **The DM cannot grant progression.** Ranks come from `RANK_THRESHOLDS`, level
    from `levelFor(totalRanks(...))`, power charges from `TIER_CHARGES`. All in
    code, all the same for everyone. A generous model handing out +3s in the first
    ten minutes ends the game by the second session.
 
-5. **The clamps are load-bearing, and they scale rather than truncate.** ±4 per
+6. **The clamps are load-bearing, and they scale rather than truncate.** ±4 per
    situational modifier, ±6 across the set, and a separate +3 ceiling on kit and
    relationships. Three plausible +3s are how a DC 18 silently becomes a coin
    flip without anyone deciding it should. `clampSituational` scales the set so
-   every reason the player was *shown* still appears on the die card.
+   every reason the player was _shown_ still appears on the die card.
 
-6. **Negative ranks are legal and must survive every round-trip.** An innate Size
+7. **Negative ranks are legal and must survive every round-trip.** An innate Size
    of −2 is subtracted from every Size check. This has now been broken twice: once
    by four `rank > 0` filters, and once by `Math.max(0, …)` in `validateCharacter`,
    which repealed the first fix on the first save. Both produced the same
    symptom — the character is described as very small, the sheet says −2, and the
    die quietly disagrees with both. Filter on `!== 0`, clamp to `±MAX_SKILL_RANK`.
 
-7. **Validators never throw, and never refuse more than they must.**
+8. **Validators never throw, and never refuse more than they must.**
    `validateCampaign` reads a hostile wire: wrong types, missing keys, a
    transcript of a hundred thousand entries. It repairs what it can and refuses
    only a campaign missing something genuinely load-bearing. `validateWorld` never
@@ -96,53 +116,70 @@ items, powers and species that all compile down to three primitives.
    rebuilds it from the transcript. Losing the index must never cost the player
    the story.
 
-8. **Version bumps migrate, they do not refuse.** `SUPPORTED_VERSIONS` is the
+9. **Version bumps migrate, they do not refuse.** `SUPPORTED_VERSIONS` is the
    list of readable versions; a v1 campaign is read as valid with an empty world
    and a zeroed clock. The old behaviour — refuse on any mismatch — would have
    deleted every campaign in existence the moment the constant moved.
 
-9. **The world graph is an index of the transcript, not a replacement for it.**
-   The fiction stays authoritative. The DM does not maintain a simulation; it
-   touches the two or three things that mattered this turn, and `condense`
-   repairs the rest. If a change requires the DM to emit a full world state every
-   turn, it is the wrong change.
+10. **The world graph is an index of the transcript, not a replacement for it.**
+    The fiction stays authoritative. The DM does not maintain a simulation; it
+    touches the two or three things that mattered this turn, and `condense`
+    repairs the rest. If a change requires the DM to emit a full world state every
+    turn, it is the wrong change.
 
-10. **`Edge.since` is stamped by the server, never read from the model.** It is
+11. **`Edge.since` is stamped by the server, never read from the model.** It is
     what makes "an edge must predate this turn to grant a bonus" enforceable.
     Without it the DM could invent `owes(guard → you)` and cash it in the same
     breath, which is situational modifiers with extra steps.
 
-11. **`Power.source` is required, and provenance is checked.** A power must come
+12. **`Power.source` is required, and provenance is checked.** A power must come
     from an entity the world already knows about. `validatePower` drops a power
     with no source rather than repairing it with a placeholder — the whole point
     is that "nothing" fails a lookup.
 
-12. **A power never resolves an outcome, it only makes one available.** Fireball
+13. **A power never resolves an outcome, it only makes one available.** Fireball
     does not kill the guard; it turns "you cannot hurt him from here" into a Power
     check that can still miss. This is the only reason abilities can be added
     without touching `dice.ts`.
 
-13. **The clock stops at a fuse.** `advance` never steps over an open thread's
+14. **The clock stops at a fuse.** `advance` never steps over an open thread's
     due time. The player says "we travel for a week", and four hours in the thing
     they have been ignoring catches up. Time cannot be used to outrun
     consequences, and "it comes to find you" falls out of the model rather than
     needing to be prompted for.
 
-14. **Domain code is pure.** No `Math.random()`, no `Date.now()`, no `new Date()`
+15. **Domain code is pure.** No `Math.random()`, no `Date.now()`, no `new Date()`
     in `src/app/dicebound/domain/`. Pass them in — that is why `withVisit` takes
     `today` and `yesterday`, and why `advance` takes minutes rather than reading a
     clock. It is also an ESLint error in this repo.
 
-15. **Anonymous-first (CLAUDE.md #1).** `useAuth` mints an anonymous uid on
+16. **Anonymous-first (CLAUDE.md #1).** `useAuth` mints an anonymous uid on
     arrival. Play never blocks on an account, and never blocks on a model call:
     character creation falls back to a playable character rather than an error,
     and a safety refusal returns an in-voice narration rather than a policy
     notice. Being told "the cave could not imagine you" and dumped at an empty
     field is worse than a slightly generic hero.
 
-16. **Nothing renders until it exists.** No empty inventory grid, no zeroed quest
+17. **Nothing renders until it exists.** No empty inventory grid, no zeroed quest
     log, no greyed-out spell slots. A new character must not be able to tell that
-    five of these systems are there.
+    five of these systems are there. The world panel on the sheet returns null
+    section by section for this reason, and a component test guards it — it is a
+    rule with no other protection and exactly the kind a later change breaks
+    without anyone noticing.
+
+18. **Most items are +0.** A rope is a permission, not a bonus — it turns "you
+    cannot climb that" into a DC 15. A +0 trait is still _named on the die card_,
+    because the reason is real even when the number is nothing. If every item
+    carried a +1 a well-packed character would stop rolling, and the die is the
+    game. `QUALITY_BANDS` buys rarity mostly in extra traits rather than a bigger
+    number, for the same reason.
+
+19. **What the model is told about a number changes how it narrates.** A DM
+    handed a sword and told nothing calls it mighty; told the sword is plain and
+    worth nothing on the die, it describes a sword. So every tool result that
+    assigns a value says what the value is — `grant_item` reports the worth back,
+    `roll_check` reports the band and its move. Writing the number without
+    reporting it produces prose that quietly disagrees with the sheet.
 
 ## Verifying a change
 
@@ -172,6 +209,34 @@ a check resolve. Look at the die card — the modifiers on it are the contract
 between the fiction and the arithmetic, and a bug there is invisible in prose.
 
 ## Known hazards
+
+- **A damaged measurement looks exactly like a result.** A harness run reported a
+  check rate of 17%, in the expected direction, from a change that had just
+  targeted it — and it nearly got the change softened. That run had lost 8 of its
+  20 turns to `anthropic 529` overloads, and the survivors were not a
+  representative sample; the rerun read 50%. `npm run voice:dicebound` prints a
+  `turns that failed` row for exactly this, and it prints even at zero. Read it
+  before you read anything else in the table, and rerun rather than reasoning
+  about a run that lost turns.
+
+- **Two numbers in that table are not independent.** A turn with no check gets
+  the shorter word budget, so anything that lowers the check rate lowers the
+  median narration length as a side effect. Reporting both as if they were two
+  wins is double-counting one change.
+
+- **The DM invents a second id for something it already named.** Live runs have
+  produced `iron-spike` and `sconce-spike` for one spike, and this is the normal
+  case rather than a slip. The world graph survives it because `condense`
+  reconciles entities from the transcript; the **kit has no equivalent**, so a
+  pack accumulates duplicates. Anything new that the model gets to name needs an
+  answer to this before it ships.
+
+- **A tool can fail silently behind good prose.** The first `recall` searched for
+  `cassa,` with the comma attached, found nothing, and told the DM to invent
+  someone the story already contained. The narration read perfectly, because the
+  player had supplied the details in their own message. Instrument the call and
+  look at what it returned; do not infer that a tool worked from output that
+  reads correctly.
 
 - **Persistence fails silently by design.** Every error in `accountBackend` is
   swallowed, so a missing rules/index deploy, an expired token or a dropped
@@ -223,7 +288,7 @@ Prettier: no semicolons, single quotes, 2-space, 100 cols, `arrowParens: avoid`.
 ESLint enforces grouped + alphabetized imports and `@/…` aliases over `../…` —
 parent-relative imports are an error, including in tests.
 
-Comments in this codebase explain *why*, at length, and are load-bearing
+Comments in this codebase explain _why_, at length, and are load-bearing
 documentation — several are the only record of a bug that took a day to find.
 Match that register. Test names are prose that states the rule being protected
 ("advances on use, not on success — failing still teaches"), not

--- a/.claude/skills/dicebound/references/architecture.md
+++ b/.claude/skills/dicebound/references/architecture.md
@@ -39,19 +39,30 @@ is a loop rather than a single call.
 player action
       │
       ▼
-build prompt ── sheet + premise + synopsis + recent transcript (+ world window, phase 2)
+load campaign for the caller's uid   ← the body is a sentence, not a save file
       │
       ▼
-┌─► call model with [roll_check, …]        pass 0 … MAX_CHECKS-1
+build prompt ── sheet + world window + premise + synopsis + recent transcript
+      │
+      ▼
+┌─► call model with [roll_check, recall, grant_item, narrate]   pass 0 … MAX_CHECKS-1
 │         │
-│         ├── no tool call ──► narration, turn ends
+│         ├── narrate ──► apply world delta, save, turn ends
+│         │                 └─ unless a fuse fired: discard that narration and
+│         │                    give the DM a hard move to make (once per turn)
 │         │
-│         └── roll_check ──► rollFor(): look up attribute rank, applicableSkill rank,
-│                            clamp situational, resolveCheck() rolls the d20
+│         ├── roll_check ──► rollFor(): attribute rank, applicableSkill rank,
+│         │                  kitModifiers (capped separately), clamped situational,
+│         │                  resolveCheck() rolls the d20
+│         │
+│         ├── recall ──► findEntities(): searches dormant entities too
+│         │
+│         └── grant_item ──► itemFromGrant(): code prices it, and the reply
+│                            tells the DM what it turned out to be worth
 │                                  │
-└──────────────── tool_result ◄────┘   "Rolled 14, +3 = 17 against DC 15…"
+└──────────────── tool_result ◄────┘
 
-final pass: tool withdrawn (phase 1) / narrate forced (phase 2) — the model must finish
+final pass: only narrate is offered, and it is forced — the model must finish
 ```
 
 The model commits to the DC before it learns the number. That is the entire
@@ -99,7 +110,7 @@ a future home page or share card needs must become a scalar here.
 A campaign is its transcript. Past `CONDENSE_AT` (60) entries the oldest are
 compressed into `synopsis` and dropped, leaving `TRANSCRIPT_WINDOW` (40) behind.
 
-`condense` is asked for *continuity* rather than summary — names, debts,
+`condense` is asked for _continuity_ rather than summary — names, debts,
 promises, wounds, how things stand — because those are what a player notices
 going missing, and a synopsis that reads like a plot outline loses exactly them.
 
@@ -148,7 +159,7 @@ condition is the one the model cannot wave away.
 Three primitives, and everything else is a package of them with a name on it:
 
 - **Trait** — always-on, conditional, ±1 or ±2
-- **Item** — a carried thing holding 0–2 traits; *most items are +0*, because a
+- **Item** — a carried thing holding 0–2 traits; _most items are +0_, because a
   rope is a permission, not a bonus
 - **Power** — costs a charge, and either `permits` something or grants
   `advantage` (2d20 keep highest)

--- a/.claude/skills/dicebound/references/workflow.md
+++ b/.claude/skills/dicebound/references/workflow.md
@@ -1,20 +1,29 @@
 # Working through the phase 2 issues
 
 The tree is [#3516](https://github.com/nickolu/CometCave/issues/3516) — one
-parent, six sprint epics, eleven child issues. `docs/dicebound-phase-2.md` is the
-spec every issue points at.
+parent, six sprint epics. `docs/dicebound-phase-2.md` is the spec every issue
+points at.
 
-## Before anything: is Dicebound on `main`?
+## Where the tree stands
 
-```
-git ls-tree -r HEAD --name-only | grep -c dicebound
-```
+All eleven original child issues are merged, and four of the six sprint epics are
+closed: #3517 (GM moves and a word budget), #3518 (a sheet that isn't blank),
+#3519 (the world model, the clock, server-authoritative campaigns) and #3520
+(threads, fuses and loose ends).
 
-If that returns `0`, **stop**. The whole game lived only in a working tree at the
-time this skill was written, and every issue in the tree assumes code that is not
-there. Landing it is issue
-[#3529](https://github.com/nickolu/CometCave/issues/3529), and nothing else can
-start until it does.
+Two remain, and neither had child issues written for it, deliberately — their
+shape depended on what the graph looked like once real campaigns had run through
+it. That gate has now cleared: the graph populates from play, reconciles from
+prose, and survives a campaign deep enough to condense.
+
+- **#3521 inventory, species and traits.** Item granting and the kit ceiling have
+  landed. Species at creation and the inventory UI have not.
+- **#3522 powers, classes and levels.** Not started. Blocked on the tier/level
+  table, which is Nick's to settle.
+
+Two problems found by measurement rather than by reading are still open, and
+neither is fixed by anything above: run `gh issue list --search dicebound` before
+assuming a bug is new.
 
 ## Picking one up
 
@@ -30,18 +39,38 @@ plausible-looking broke the game once already.
 Check the epic's sub-issue list for ordering. Several issues say "depends on X";
 those are real, not advisory.
 
-## Lanes — what may run in parallel
+## Lanes — draw them by file, not by theme
 
-`src/app/api/v1/dicebound/turn/route.ts` is touched by seven of the eleven
-issues. Running those concurrently spends the parallelism on merge conflicts in
-the file where all the subtle logic lives.
+`src/app/api/v1/dicebound/turn/route.ts` is where nearly all the subtle logic
+lives, and nearly every server-side issue wants it. That file is the constraint,
+so lanes are drawn around **who owns which files** rather than around what the
+work is about.
 
-| Lane | Issues | Rule |
-| --- | --- | --- |
-| **A** | #3523, #3524, #3525, #3530, #3531, #3532, #3533 | strictly serial, in that order |
-| **B** | #3526 (voice harness), #3527 + #3528 (starting skills) | safe alongside lane A |
+| Lane        | Owns                                                    | Runs beside                                |
+| ----------- | ------------------------------------------------------- | ------------------------------------------ |
+| **UI**      | `components/*.tsx`, `DiceboundGame.tsx`                 | anything                                   |
+| **Turn**    | `turn/route.ts`, `domain/turn.ts`                       | UI only — one issue at a time              |
+| **Kit**     | `domain/kit.ts`, `domain/dice.ts`, `character/route.ts` | UI; contends with Turn when it adds a tool |
+| **Harness** | `scripts/`, `lib/dicebound/`                            | anything                                   |
 
-Lane B touches `scripts/`, `character/route.ts` and `sheet.tsx` only.
+The sustainable shape of a batch is therefore **two issues, not four**: one from
+the UI lane, one from whichever server lane is active.
+
+## Never stack PRs
+
+Branch every issue off `main`. Not off the branch before it, however tempting the
+dependency makes it look.
+
+Four stacked PRs were once merged seven seconds apart, which is faster than
+GitHub retargets a stacked PR's base after its base branch merges. All four
+reported MERGED; three had gone into intermediate branches and only the first
+reached `main`, so the game shipped without its narrate tool, its measurement
+harness or its word budget until someone noticed. Recovering it meant
+cherry-picking three commits and proving the result byte-identical to the
+reviewed stack tip.
+
+If two issues genuinely cannot be parallel, do them in sequence off `main` and
+merge each before starting the next. Waiting is cheaper than that recovery.
 
 ## Doing the work
 
@@ -51,7 +80,7 @@ Lane B touches `scripts/`, `character/route.ts` and `sheet.tsx` only.
   `src/app/dicebound/domain/`, pure and tested, before it is wired into a route
   or a component. The domain modules are where this game is actually specified.
 - **Write the test as a sentence about the rule.** `it('advances on use, not on
-  success — failing still teaches')`, not `it('works')`. Several existing tests
+success — failing still teaches')`, not `it('works')`. Several existing tests
   are the only record of why a number is what it is.
 - **If the issue contradicts the design doc, say so.** Do not silently pick one.
   An issue that fights an invariant is a bug in the issue.
@@ -111,12 +140,17 @@ And because `accountBackend` swallows every persistence error, a missing deploy
 looks exactly like a working game that has quietly stopped saving: confirm the
 write landed in Firestore rather than trusting the absence of an error.
 
-## Sprints 4–6
+## The two remaining sprints
 
-[#3520](https://github.com/nickolu/CometCave/issues/3520),
 [#3521](https://github.com/nickolu/CometCave/issues/3521) and
-[#3522](https://github.com/nickolu/CometCave/issues/3522) deliberately have **no
-child issues yet**. Their shape depends on what the world graph is like once real
-campaigns have run through it, and writing fifteen detailed issues against a
-schema that has never run produces fifteen issues that need rewriting. Do not
-start them. Do not invent children for them without Nick.
+[#3522](https://github.com/nickolu/CometCave/issues/3522) still have **no child
+issues**, and the original reason has expired — the graph has now run through
+real campaigns, so their shape is knowable.
+
+What has not expired is who writes them. Do not invent children for either
+without Nick, and #3522 in particular cannot start until the tier/level table is
+settled, because that number decides how long a campaign takes to feel powerful.
+
+#3520 closed without ever needing children: two of its three scope items arrived
+as a side effect of the world epic, and the third was a UI job. Check whether an
+epic is already built before writing issues for it.


### PR DESCRIPTION
The skill had drifted far enough to mislead a future reader. This fixes it.

## The worst of it

`workflow.md` opened by telling the reader to check whether Dicebound was on `main` and to **stop** if it was not. It has been on `main` for a while — so the first instruction a future agent read was one that would have halted it on a false premise.

## Lanes are now drawn by file, not by theme

The old table listed eleven issues, all now merged, split by subject matter. The actual constraint is `turn/route.ts`: it is where the subtle logic lives and nearly every server-side issue wants it.

| Lane | Owns | Runs beside |
| --- | --- | --- |
| UI | `components/*.tsx` | anything |
| Turn | `turn/route.ts`, `domain/turn.ts` | UI only — one at a time |
| Kit | `domain/kit.ts`, `domain/dice.ts`, `character/route.ts` | UI; contends with Turn when it adds a tool |
| Harness | `scripts/`, `lib/dicebound/` | anything |

So a batch is **two issues, not four**.

## Added: never stack PRs

Because it cost real recovery work. Four stacked PRs merged seven seconds apart — faster than GitHub retargets a stacked base — and three landed in intermediate branches while all four reported MERGED. The game shipped without its `narrate` tool, its measurement harness or its word budget until someone noticed.

## The invariant worth having is the generalised one

What began as a rule about dice turned out to be a rule about *facts*. Narration written before a roll resolves, before a `recall` answers, or before the clock stops at a fuse is written on a premise the model could not have checked. All three are now one invariant, with a note to expect a fourth.

Two more from the kit: **most items are +0** and a +0 trait is still named on the card; and **a tool result that assigns a value must report it back**, because a model told nothing about the sword it just handed over describes it as mighty.

## Four new hazards

The one to keep: **a damaged measurement looks exactly like a result.** A run reported a check rate of 17%, in the expected direction, from a change that had just targeted it — and nearly got that change softened. It had lost 8 of its 20 turns to `529`s. The rerun read 50%.

Also recorded: two numbers in the harness table are not independent (a no-check turn gets the shorter budget, so lowering the check rate lowers the median for free); the DM routinely invents a second id for something it already named, and the kit has no reconciliation to repair it the way the world graph does; and a tool can fail silently behind good prose — the first `recall` searched for `cassa,` with the comma attached, found nothing, and the narration still read perfectly because the player had supplied the details.

## Also

- The turn loop diagram showed one tool. There are four.
- The undecided list grew to three: the name, the tier/level table, and **how a player gets an item** — flagged because I decided it in a PR rather than Nick deciding it, and it is one edit to reverse.
- The "sprints 4–6, do not start" section is corrected: #3520 is closed, and the reason the other two lacked children has expired now that the graph has run. Who writes them has not changed.

Docs only — no source touched. Suite still green at 188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)