### PR TITLE
feat(dicebound): level counts only the ranks you earned in play

### DIFF
--- a/src/app/dicebound/domain/__tests__/campaign.test.ts
+++ b/src/app/dicebound/domain/__tests__/campaign.test.ts
@@ -114,6 +114,43 @@ describe('validateCampaign', () => {
     expect(result?.character.attributes.strength).toBeLessThanOrEqual(3)
     expect(result?.character.skills.balance?.rank).toBe(3)
   })
+
+  it('round-trips the seeded marker, so a head start stays a head start', () => {
+    // Losing it on the wire would hand every stored character a level the
+    // moment their campaign was loaded.
+    const result = validateCampaign({
+      ...campaign(),
+      character: {
+        name: 'Ilda',
+        concept: '',
+        reading: '',
+        attributes: {},
+        skills: { balance: { uses: 3, rank: 1, seeded: true } },
+      },
+    })
+    expect(result?.character.skills.balance?.seeded).toBe(true)
+  })
+
+  it('leaves a pre-marker record unmarked rather than inventing an answer', () => {
+    // Absent means earned, deliberately — see earnedRanks. A campaign stored
+    // before the marker existed must not lose a level on deploy, and a stray
+    // `seeded: 'yes'` from a hostile wire must not gain one.
+    const result = validateCampaign({
+      ...campaign(),
+      character: {
+        name: 'Ilda',
+        concept: '',
+        reading: '',
+        attributes: {},
+        skills: {
+          balance: { uses: 3, rank: 1 },
+          humor: { uses: 3, rank: 1, seeded: 'yes' },
+        },
+      },
+    })
+    expect(result?.character.skills.balance).not.toHaveProperty('seeded')
+    expect(result?.character.skills.humor).not.toHaveProperty('seeded')
+  })
 })
 
 describe('withVisit', () => {

--- a/src/app/dicebound/domain/__tests__/character.test.ts
+++ b/src/app/dicebound/domain/__tests__/character.test.ts
@@ -9,6 +9,7 @@ import {
   MIN_ATTRIBUTE,
   RANK_THRESHOLDS,
   blankAttributes,
+  earnedRanks,
   earnedSkills,
   normalizeAttributes,
   rankFor,
@@ -16,6 +17,7 @@ import {
   startingSkills,
   usesToNextRank,
 } from '@/app/dicebound/domain/character'
+import { levelFor } from '@/app/dicebound/domain/kit'
 
 function character(overrides: Partial<Character> = {}): Character {
   return {
@@ -191,7 +193,7 @@ describe('startingSkills', () => {
     // and the first time the skill came up it would silently correct itself
     // downward — the player would watch a skill they started with get worse.
     const skills = startingSkills(['hand-eye'])
-    expect(skills['hand-eye']).toEqual({ uses: RANK_THRESHOLDS[0], rank: 1 })
+    expect(skills['hand-eye']).toEqual({ uses: RANK_THRESHOLDS[0], rank: 1, seeded: true })
     expect(rankFor(skills['hand-eye']!.uses)).toBe(1)
   })
 
@@ -204,7 +206,19 @@ describe('startingSkills', () => {
     for (let i = 0; i < needed; i++) {
       sheet = recordSkillUse(sheet, 'hand-eye').character
     }
-    expect(sheet.skills['hand-eye']).toEqual({ uses: RANK_THRESHOLDS[1], rank: 2 })
+    expect(sheet.skills['hand-eye']).toEqual({
+      uses: RANK_THRESHOLDS[1],
+      rank: 2,
+      seeded: true,
+    })
+  })
+
+  it('keeps the seeded marker through a use — a head start does not become an achievement', () => {
+    // recordSkillUse used to rebuild the record from `{ uses, rank }`, which
+    // would clear the marker on the first check and hand the player a level for
+    // touching a skill they were given.
+    const sheet = recordSkillUse(character({ skills: startingSkills(['hand-eye']) }), 'hand-eye')
+    expect(sheet.character.skills['hand-eye']?.seeded).toBe(true)
   })
 
   it('grants three when a model proposes six — the model proposes, code decides how many', () => {
@@ -240,5 +254,55 @@ describe('startingSkills', () => {
     expect(startingSkills(undefined)).toEqual({})
     expect(startingSkills('hand-eye')).toEqual({})
     expect(startingSkills([null, 42, {}])).toEqual({})
+  })
+})
+
+describe('earnedRanks', () => {
+  it('a character who has only written a sentence is level 1', () => {
+    // The bug this function exists for: three seeded ranks made levelFor
+    // return 2 before the first die, which made a tier 1 power grantable on
+    // turn 1 and fired class discovery on a histogram of skills nobody used.
+    const sheet = character({ skills: startingSkills(['hand-eye', 'humor', 'observation']) })
+    expect(earnedRanks(sheet)).toBe(0)
+    expect(levelFor(earnedRanks(sheet))).toBe(1)
+  })
+
+  it('a seeded skill that reaches rank 2 in play has earned one rank', () => {
+    let sheet = character({ skills: startingSkills(['hand-eye']) })
+    for (let i = 0; i < RANK_THRESHOLDS[1] - RANK_THRESHOLDS[0]; i++) {
+      sheet = recordSkillUse(sheet, 'hand-eye').character
+    }
+    expect(sheet.skills['hand-eye']?.rank).toBe(2)
+    expect(earnedRanks(sheet)).toBe(1)
+  })
+
+  it('counts a rank nobody handed over in full', () => {
+    // Rank 1 on a skill the player ground out is worth the same as rank 2 on a
+    // skill they were given — the head start is subtracted once, not taxed.
+    const granted = character({ skills: startingSkills(['hand-eye']) })
+    const ground = character({ skills: { balance: { uses: RANK_THRESHOLDS[0], rank: 1 } } })
+    expect(earnedRanks(ground) - earnedRanks(granted)).toBe(1)
+  })
+
+  it('an innate −2 is not a rank and does not move the level', () => {
+    // Size is something the character is. It is subtracted from every Size
+    // check and it must not also slow their levelling for being described.
+    const sheet = character({ skills: { size: { uses: 0, rank: -2 } } })
+    expect(earnedRanks(sheet)).toBe(0)
+    expect(levelFor(earnedRanks(sheet))).toBe(1)
+  })
+
+  it('a character saved before the marker existed keeps the level they had', () => {
+    // Deliberately generous to live campaigns. An unmarked rank reads as
+    // earned, so nobody drops a level on deploy.
+    const legacy = character({
+      skills: {
+        'hand-eye': { uses: RANK_THRESHOLDS[0], rank: 1 },
+        humor: { uses: RANK_THRESHOLDS[0], rank: 1 },
+        observation: { uses: RANK_THRESHOLDS[0], rank: 1 },
+      },
+    })
+    expect(earnedRanks(legacy)).toBe(3)
+    expect(levelFor(earnedRanks(legacy))).toBe(2)
   })
 })

--- a/src/app/dicebound/domain/campaign.ts
+++ b/src/app/dicebound/domain/campaign.ts
@@ -281,6 +281,12 @@ export function validateCharacter(value: unknown): Character | null {
         // the character was still described as very small, the sheet still said
         // so, and the die stopped agreeing with both of them.
         rank: boundedInt(record.rank, -MAX_SKILL_RANK, MAX_SKILL_RANK),
+        // Absent stays absent rather than becoming `seeded: false`. A character
+        // saved before this marker existed has to keep the level they already
+        // had, so unmarked reads as earned — see `earnedRanks`. Writing the key
+        // only when it is true also keeps it out of every campaign blob that
+        // has no seeded skills.
+        ...(record.seeded === true ? { seeded: true as const } : {}),
       }
     }
   }

--- a/src/app/dicebound/domain/character.ts
+++ b/src/app/dicebound/domain/character.ts
@@ -45,6 +45,17 @@ export const RANK_THRESHOLDS: readonly number[] = [3, 8, 18]
 export interface SkillRecord {
   uses: number
   rank: number
+  /**
+   * True when this rank was handed over at creation rather than earned in play.
+   *
+   * `startingSkills` seeds up to three skills at rank 1 for writing a sentence,
+   * and level is meant to be a record of what the character actually did — so
+   * the seeded rank has to be distinguishable from the identical-looking rank
+   * the next character ground out over three real checks. Optional rather than
+   * always-present because a character saved before this marker existed has to
+   * keep reading as valid; see `earnedRanks` for what absent means.
+   */
+  seeded?: true
 }
 
 export interface Character {
@@ -134,7 +145,11 @@ export function startingSkills(proposed: unknown): Partial<Record<SkillId, Skill
     if (out[value]) continue
     if (Object.keys(out).length >= MAX_STARTING_SKILLS) break
 
-    out[value] = { uses: RANK_THRESHOLDS[0], rank: 1 }
+    // Marked as seeded, permanently. The rank is real — it adds to every check
+    // from turn one — but it is not an achievement, and `earnedRanks` subtracts
+    // it back out so that a character who has written a sentence and nothing
+    // else is level 1.
+    out[value] = { uses: RANK_THRESHOLDS[0], rank: 1, seeded: true }
   }
 
   return out
@@ -188,25 +203,48 @@ export function recordSkillUse(
   return {
     character: {
       ...character,
-      skills: { ...character.skills, [skill]: { uses, rank } },
+      // `before` is spread rather than rebuilt so the seeded marker survives
+      // being used. Rebuilding the record from `{ uses, rank }` would clear it
+      // on the first check, and the head start would quietly become an
+      // achievement the moment the player touched the skill.
+      skills: { ...character.skills, [skill]: { ...before, uses, rank } },
     },
     earned: rank > before.rank ? { skill, rank } : null,
   }
 }
 
 /**
- * Total earned skill ranks — the number that level is computed from.
+ * Ranks the character earned by playing — the number level is computed from.
  *
- * Only positive ranks count. An innate Size of −2 is mechanically real on every
- * Size check, but it is something the character *is*, not something they have
- * achieved, and letting it subtract from level would mean a small character
- * levelled more slowly for being described accurately at creation.
+ * Three things are deliberately excluded, and each was a way of being handed a
+ * level rather than reaching one.
+ *
+ * Negative ranks do not subtract. An innate Size of −2 is mechanically real on
+ * every Size check, but it is something the character *is*, not something they
+ * failed to achieve, and letting it drag on level would mean a small character
+ * levelled more slowly for having been described accurately at creation.
+ *
+ * Seeded ranks do not count. `startingSkills` grants up to three of them for
+ * writing a sentence, and counting them made `levelFor` return 2 for a
+ * character who had not yet rolled a die — which made tier 1 powers grantable
+ * on turn 1 and fired class discovery on a histogram containing nothing but
+ * the three skills the player was handed at the door.
+ *
+ * A seeded skill that grows in play earns the difference: rank 2 on a seeded
+ * skill is one earned rank, the same as rank 1 on a skill nobody gave you. The
+ * head start is not taxed twice.
+ *
+ * **Migration.** A record saved before the marker existed has no `seeded`, and
+ * is read as earned. That is knowingly generous to the handful of live
+ * campaigns — the alternative is every existing player losing a level on
+ * deploy, which is a worse thing to be right about.
  */
-export function totalRanks(character: Character): number {
-  return Object.values(character.skills).reduce(
-    (sum, record) => sum + Math.max(0, record?.rank ?? 0),
-    0
-  )
+export function earnedRanks(character: Character): number {
+  return Object.values(character.skills).reduce((sum, record) => {
+    if (!record) return sum
+    const rank = Math.max(0, record.rank)
+    return sum + Math.max(0, rank - (record.seeded ? 1 : 0))
+  }, 0)
 }
 
 /** Every skill the character has actually earned, best first. */

--- a/src/app/dicebound/domain/kit.ts
+++ b/src/app/dicebound/domain/kit.ts
@@ -174,7 +174,13 @@ export const QUALITY_BANDS: Record<Quality, { bonus: number; traits: number }> =
   storied: { bonus: 2, traits: 2 },
 }
 
-/** Levels. `1 + earned ranks / 3` — ranks are earned on use, so level cannot be granted. */
+/**
+ * Levels. `1 + earned ranks / 3` — ranks are earned on use, so level cannot be
+ * granted. Feed this `earnedRanks(character)` and nothing else: it counts only
+ * ranks reached in play, and the three a sentence buys at creation do not
+ * count. Summing raw ranks instead makes a character level 2 before their
+ * first roll, which makes a tier 1 power grantable on turn 1.
+ */
 export const RANKS_PER_LEVEL = 3
 export const MAX_LEVEL = 10
 

--- a/src/lib/dicebound/campaign-store.ts
+++ b/src/lib/dicebound/campaign-store.ts
@@ -31,7 +31,7 @@ import {
   validateCampaign,
   validateChapter,
 } from '@/app/dicebound/domain/campaign'
-import { totalRanks } from '@/app/dicebound/domain/character'
+import { earnedRanks } from '@/app/dicebound/domain/character'
 import { levelFor } from '@/app/dicebound/domain/kit'
 import { dayOf } from '@/app/dicebound/domain/world'
 import { getFirestoreDb } from '@/lib/firebase/server'
@@ -79,7 +79,7 @@ export async function saveCampaign(uid: string, campaign: Campaign): Promise<voi
     currentStreak: campaign.currentStreak,
     // Readable phase 2 state. Cheap to write, and the alternative is parsing
     // every blob in the collection to ask how far anyone has got.
-    level: levelFor(totalRanks(campaign.character)),
+    level: levelFor(earnedRanks(campaign.character)),
     className: campaign.kit.className ?? null,
     species: campaign.kit.species?.name ?? null,
     storyDay: dayOf(campaign.world.clock),


### PR DESCRIPTION
Closes #3558. First in #3522 — three issues in that epic gate on `levelFor` telling the truth, and today it does not.

## Why

`startingSkills` seeds up to `MAX_STARTING_SKILLS` skills at rank 1 for writing a sentence, and `totalRanks` counted them. So `levelFor` returned **2 for a character who had not yet rolled a die**, and two things followed:

- `maxTierAt(2) === 1`, so a tier 1 power was grantable on turn 1
- class discovery at level 2 would fire on a skill-use histogram containing nothing but the three skills the player was handed at the door

Level is meant to be a record of what the character actually did. Three ranks they were given is not that.

## What changed

`SkillRecord` gains an optional `seeded` marker; `startingSkills` sets it; `earnedRanks(character)` subtracts one rank back out per marked skill. A seeded skill that climbs to rank 2 in play has earned exactly one rank — the same as rank 1 on a skill nobody gave you. The head start is subtracted once, not taxed twice.

**The seeding itself stays.** A stored rank that `rankFor` disagrees with silently corrects itself downward the first time the skill comes up, and the player watches a skill they started with get worse.

`recordSkillUse` now spreads the previous record rather than rebuilding it from `{ uses, rank }` — otherwise the marker cleared on the first check and the head start quietly became an achievement.

`totalRanks` is **folded into** `earnedRanks` rather than kept beside it. It had exactly one call site (`campaign-store.ts`), and two functions one letter apart that answer different questions is how the next reader picks the wrong one.

Invariant 7 was left alone on the way past: `rank` still uses `boundedInt(…, -MAX_SKILL_RANK, MAX_SKILL_RANK)`, and an innate −2 still does not drag on level (it is something the character *is*, not something they failed at).

## Migration

Deliberately generous to live campaigns. A record saved before the marker existed has no `seeded` key and reads as **earned**, so nobody drops a level on deploy. The validator writes the key only when it is literally `true`, so absent stays absent across the round-trip and a hostile `seeded: 'yes'` cannot mark anything. Both directions are commented at the code and covered by tests.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  8 passed (8)
      Tests  196 passed (196)          # 194 before; +2 validator round-trip, +5 earnedRanks, 2 updated

$ npx tsc --noEmit 2>&1 | grep dicebound
                                        # empty
$ npx tsc --noEmit 2>&1 | grep -c 'error TS'
11                                      # the pre-existing micro-land/scripts errors, unchanged

$ npx eslint src/app/dicebound src/lib/dicebound
                                        # clean

$ npm run lint:routes
check-route-slugs: ok

$ npx prettier --write <touched files>
                                        # all unchanged
```

No real-turn run: this touches no route, no prompt, no tool schema and no turn loop — `domain/character.ts`, `domain/campaign.ts`'s validator, one line of `campaign-store.ts`, and a doc comment on `levelFor`.