### PR TITLE
feat(dicebound): advantage, without the resolver learning that powers exist

### DIFF
--- a/src/app/dicebound/components/__tests__/die-card.test.tsx
+++ b/src/app/dicebound/components/__tests__/die-card.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { DieCard } from '@/app/dicebound/components/die-card'
+import type { CheckEntry } from '@/app/dicebound/domain/campaign'
+
+afterEach(cleanup)
+
+/**
+ * jsdom has no `matchMedia`, and the card reads it to decide whether to
+ * animate. Stubbing it as "reduce" is the honest default rather than a
+ * convenience: the reduced-motion card is the one that has to be legible
+ * without help, and it is also what a transcript scrolled back through shows.
+ */
+function stubReducedMotion(reduce: boolean) {
+  window.matchMedia = ((query: string) => ({
+    matches: reduce,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+}
+
+function check(overrides: Partial<CheckEntry> = {}): CheckEntry {
+  return {
+    kind: 'check',
+    attempt: 'vault the counter',
+    attribute: 'dexterity',
+    skill: 'balance',
+    dc: 12,
+    dcLabel: 'kinda hard',
+    roll: 17,
+    modifiers: [{ label: 'Dexterity', value: 2 }],
+    modifier: 2,
+    total: 19,
+    margin: 7,
+    band: 'strong-success',
+    ...overrides,
+  }
+}
+
+describe('DieCard', () => {
+  it('shows one die and no advantage line on an ordinary check', () => {
+    stubReducedMotion(true)
+    render(<DieCard entry={check()} />)
+
+    expect(screen.getByText('17')).toBeDefined()
+    expect(screen.queryByText(/Advantage/)).toBeNull()
+    expect(screen.queryByText(/Disadvantage/)).toBeNull()
+  })
+
+  it('shows the discarded die and why it was thrown, under reduced motion', () => {
+    // The two-dice layout must not depend on the roll animation to make sense —
+    // a transcript scrolled back through never animates, and neither does a
+    // card for a player who asked for less motion.
+    stubReducedMotion(true)
+    render(
+      <DieCard
+        entry={check({
+          twice: { direction: 'advantage', reason: 'the torch is lit', discarded: 4 },
+        })}
+        fresh
+      />
+    )
+
+    expect(screen.getByText('17')).toBeDefined()
+    expect(screen.getByText('4')).toBeDefined()
+    // Twice over: once on the visible label, once in the announcement. Both are
+    // supposed to say it, so matching exactly one would mean one of them lost it.
+    expect(screen.getAllByText(/the torch is lit/)).toHaveLength(2)
+  })
+
+  it('says the discarded die out loud, because the struck-through one is aria-hidden', () => {
+    // Otherwise the spoken card says less than the printed one: a screen reader
+    // user hears the 17 and never learns a 4 was thrown away.
+    stubReducedMotion(true)
+    render(
+      <DieCard
+        entry={check({
+          twice: { direction: 'advantage', reason: 'the torch is lit', discarded: 4 },
+        })}
+      />
+    )
+
+    expect(screen.getByText(/Rolled twice with advantage.*discarding 4/)).toBeDefined()
+  })
+})

--- a/src/app/dicebound/components/die-card.tsx
+++ b/src/app/dicebound/components/die-card.tsx
@@ -101,6 +101,12 @@ export function DieCard({ entry, fresh = false }: { entry: CheckEntry; fresh?: b
   const tone = TONE[entry.band]
   const shown = tumbling ?? entry.roll
   const skillName = entry.skill ? SKILLS[entry.skill].name : null
+  // The struck-through die is aria-hidden, so the announcement has to carry it
+  // in words — otherwise a screen reader user is told a 17 was rolled and never
+  // told a 3 was thrown away, and the sighted card says more than the spoken one.
+  const twiceSaid = entry.twice
+    ? ` Rolled twice with ${entry.twice.direction}${entry.twice.reason ? `, ${entry.twice.reason}` : ''}, discarding ${entry.twice.discarded}.`
+    : ''
 
   return (
     <div
@@ -117,12 +123,30 @@ export function DieCard({ entry, fresh = false }: { entry: CheckEntry; fresh?: b
 
       <div className="mt-3 flex items-center gap-4">
         {/* The die itself. aria-hidden while tumbling so a screen reader is
-            told the outcome once, at the end, rather than twenty times. */}
-        <div
-          aria-hidden={!settled}
-          className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-ds-sm border-2 bg-surface-container-high font-headline text-2xl font-extrabold tabular-nums ${tone.border} ${tone.text}`}
-        >
-          {shown}
+            told the outcome once, at the end, rather than twenty times.
+
+            When the die was thrown twice, the discarded one sits beside the
+            kept one, struck through and dimmed. It is laid out as a plain flex
+            row with no animation of its own, so it reads the same whether the
+            card just arrived or is being scrolled back through under
+            prefers-reduced-motion — the two-dice arrangement must not depend on
+            the roll animation to make sense. A discarded 17 is the most
+            interesting number on the card and it is never hidden. */}
+        <div className="flex shrink-0 items-center gap-2">
+          <div
+            aria-hidden={!settled}
+            className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-ds-sm border-2 bg-surface-container-high font-headline text-2xl font-extrabold tabular-nums ${tone.border} ${tone.text}`}
+          >
+            {shown}
+          </div>
+          {settled && entry.twice && (
+            <div
+              aria-hidden
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-ds-sm border border-outline-variant bg-surface-container font-headline text-base font-bold tabular-nums text-on-surface-variant line-through opacity-60"
+            >
+              {entry.twice.discarded}
+            </div>
+          )}
         </div>
 
         <div className="min-w-0 flex-1">
@@ -139,6 +163,17 @@ export function DieCard({ entry, fresh = false }: { entry: CheckEntry; fresh?: b
                 ({entry.margin >= 0 ? '+' : ''}
                 {entry.margin})
               </span>
+            </p>
+          )}
+          {/* Deliberately not a modifier chip. Advantage has no number, and
+              putting it in the row of ±values would invite the player — and the
+              next person editing this — to think of it as one. */}
+          {settled && entry.twice && (
+            <p className="mt-0.5 text-xs text-on-surface-variant">
+              <span className="font-semibold uppercase tracking-wide">
+                {entry.twice.direction === 'advantage' ? 'Advantage' : 'Disadvantage'}
+              </span>
+              {entry.twice.reason ? ` · ${entry.twice.reason}` : ''}
             </p>
           )}
         </div>
@@ -172,7 +207,7 @@ export function DieCard({ entry, fresh = false }: { entry: CheckEntry; fresh?: b
       {/* Announced once, after the die settles, as a single sentence. */}
       <p className="sr-only" aria-live="polite">
         {settled
-          ? `${entry.attempt}. ${skillName ?? ATTRIBUTES[entry.attribute].name} check, difficulty ${entry.dc}. Rolled ${entry.roll}, total ${entry.total}. ${BAND_LABEL[entry.band]}.`
+          ? `${entry.attempt}. ${skillName ?? ATTRIBUTES[entry.attribute].name} check, difficulty ${entry.dc}.${twiceSaid} Rolled ${entry.roll}, total ${entry.total}. ${BAND_LABEL[entry.band]}.`
           : ''}
       </p>
     </div>

--- a/src/app/dicebound/domain/__tests__/campaign.test.ts
+++ b/src/app/dicebound/domain/__tests__/campaign.test.ts
@@ -151,6 +151,46 @@ describe('validateCampaign', () => {
     expect(result?.character.skills.balance).not.toHaveProperty('seeded')
     expect(result?.character.skills.humor).not.toHaveProperty('seeded')
   })
+
+  it('round-trips a die that was thrown twice', () => {
+    const result = validateCampaign({
+      ...campaign(),
+      transcript: [
+        { ...check(), twice: { direction: 'advantage', reason: 'the torch', discarded: 4 } },
+      ],
+    })
+    const entry = result?.transcript[0]
+    expect(entry && 'twice' in entry && entry.twice).toEqual({
+      direction: 'advantage',
+      reason: 'the torch',
+      discarded: 4,
+    })
+  })
+
+  it('drops a malformed second die rather than inventing one', () => {
+    // There is no sensible default for "which die did we throw away". A repair
+    // would print a number on the die card that never came off a die — and
+    // `boundedInt` would happily turn a missing one into a 1, which reads as a
+    // real roll the player got lucky to escape.
+    const result = validateCampaign({
+      ...campaign(),
+      transcript: [
+        { ...check(), twice: { direction: 'advantage', reason: 'the torch' } },
+        { ...check(), twice: { direction: 'sideways', discarded: 4 } },
+        { ...check(), twice: 'advantage' },
+      ],
+    })
+    for (const entry of result?.transcript ?? []) {
+      expect(entry).not.toHaveProperty('twice')
+    }
+  })
+
+  it('leaves an ordinary check without the key at all', () => {
+    // Absent, not undefined — it keeps the field out of every stored blob, and
+    // nearly every check ever rolled is an ordinary one.
+    const result = validateCampaign({ ...campaign(), transcript: [check()] })
+    expect(result?.transcript[0]).not.toHaveProperty('twice')
+  })
 })
 
 describe('withVisit', () => {

--- a/src/app/dicebound/domain/__tests__/dice.test.ts
+++ b/src/app/dicebound/domain/__tests__/dice.test.ts
@@ -11,6 +11,7 @@ import {
   clampDc,
   clampSituational,
   difficultyLabel,
+  netAdvantage,
   resolveCheck,
   rollD20,
 } from '@/app/dicebound/domain/dice'
@@ -190,5 +191,125 @@ describe('the move list', () => {
     for (const move of HARD_MOVES) {
       expect(move.endsWith('.'), move).toBe(true)
     }
+  })
+})
+
+/** A d20 that shows each value in turn, so a two-die roll is exactly known. */
+function sequence(...values: number[]) {
+  let index = 0
+  return () => {
+    const value = values[Math.min(index++, values.length - 1)]
+    return (value - 1) / 20 + 0.001
+  }
+}
+
+describe('netAdvantage', () => {
+  it('is nothing when nothing is pulling', () => {
+    expect(netAdvantage([])).toBeNull()
+  })
+
+  it('advantage and disadvantage together are neither', () => {
+    // Not a tally. Two advantages against one disadvantage is still neither,
+    // because a flag that can be out-voted is a magnitude, and a magnitude is
+    // the thing this is built to not be.
+    expect(
+      netAdvantage([
+        { direction: 'advantage', reason: 'the fire is behind you' },
+        { direction: 'advantage', reason: 'you have the high ground' },
+        { direction: 'disadvantage', reason: 'your arm is broken' },
+      ])
+    ).toBeNull()
+  })
+
+  it('keeps every reason on the winning side, so the player is told all of them', () => {
+    const net = netAdvantage([
+      { direction: 'advantage', reason: 'the fire is behind you' },
+      { direction: 'advantage', reason: 'you have the high ground' },
+    ])
+    expect(net?.direction).toBe('advantage')
+    expect(net?.reason).toBe('the fire is behind you + you have the high ground')
+  })
+})
+
+describe('resolveCheck with advantage', () => {
+  it('advantage keeps the higher die and shows the one it threw away', () => {
+    const outcome = resolveCheck(
+      { dc: 10, modifiers: [], advantage: [{ direction: 'advantage', reason: 'the torch' }] },
+      sequence(4, 17)
+    )
+    expect(outcome.roll).toBe(17)
+    expect(outcome.twice).toEqual({ direction: 'advantage', reason: 'the torch', discarded: 4 })
+  })
+
+  it('disadvantage keeps the lower die', () => {
+    const outcome = resolveCheck(
+      { dc: 10, modifiers: [], advantage: [{ direction: 'disadvantage', reason: 'the dark' }] },
+      sequence(4, 17)
+    )
+    expect(outcome.roll).toBe(4)
+    expect(outcome.twice?.discarded).toBe(17)
+  })
+
+  it('a natural 1 on the kept die is still a critical failure', () => {
+    // Decided on the kept die, never on either die thrown. Reading the naturals
+    // off both would make advantage double a character's chance of a critical
+    // failure, which is the reverse of what advantage is for.
+    const outcome = resolveCheck(
+      {
+        dc: 5,
+        modifiers: [{ label: 'Dexterity', value: 3 }],
+        advantage: [{ direction: 'disadvantage', reason: 'the dark' }],
+      },
+      sequence(1, 20)
+    )
+    expect(outcome.roll).toBe(1)
+    expect(outcome.band).toBe('critical-failure')
+  })
+
+  it('a natural 20 discarded is not a critical success', () => {
+    const outcome = resolveCheck(
+      { dc: 30, modifiers: [], advantage: [{ direction: 'disadvantage', reason: 'the dark' }] },
+      sequence(20, 2)
+    )
+    expect(outcome.twice?.discarded).toBe(20)
+    expect(outcome.band).not.toBe('critical-success')
+  })
+
+  it('advantage does not touch the situational budget', () => {
+    // It moves the odds without moving a number, which is why it sits outside
+    // the ±6 total and the +3 kit ceiling. Nothing about the arithmetic changes.
+    const modifiers = [{ label: 'Dexterity', value: 2 }]
+    const plain = resolveCheck({ dc: 10, modifiers }, sequence(11))
+    const lucky = resolveCheck(
+      { dc: 10, modifiers, advantage: [{ direction: 'advantage', reason: 'the torch' }] },
+      sequence(11, 3)
+    )
+    expect(lucky.modifier).toBe(plain.modifier)
+    expect(lucky.modifiers).toEqual(plain.modifiers)
+    expect(lucky.total).toBe(plain.total)
+  })
+
+  it('throws one die when nothing is pulling, so an ordinary check is unchanged', () => {
+    // The second value in the sequence must never be reached. If it were, every
+    // seeded test in this file would silently start rolling something else.
+    const outcome = resolveCheck({ dc: 10, modifiers: [], advantage: [] }, sequence(11, 20))
+    expect(outcome.roll).toBe(11)
+    expect(outcome.twice).toBeNull()
+  })
+
+  it('cancelled sources throw one die, not two', () => {
+    const outcome = resolveCheck(
+      {
+        dc: 10,
+        modifiers: [],
+        advantage: [
+          { direction: 'advantage', reason: 'the torch' },
+          { direction: 'disadvantage', reason: 'the dark' },
+        ],
+      },
+      sequence(11, 20)
+    )
+    expect(outcome.roll).toBe(11)
+    expect(outcome.twice).toBeNull()
   })
 })

--- a/src/app/dicebound/domain/campaign.ts
+++ b/src/app/dicebound/domain/campaign.ts
@@ -27,7 +27,7 @@ import { type World, emptyWorld, validateWorld } from './world'
 
 import type { AttributeId, SkillId } from './attributes'
 import type { Character, SkillRecord } from './character'
-import type { Modifier, OutcomeBand } from './dice'
+import type { Modifier, OutcomeBand, RolledTwice } from './dice'
 
 /**
  * Bump only when an old campaign would be *misread* by the current code, not
@@ -70,6 +70,16 @@ export interface CheckEntry {
   total: number
   margin: number
   band: OutcomeBand
+  /**
+   * Present only when the die was thrown twice.
+   *
+   * Optional rather than nullable so that every check ever stored stays valid
+   * without a version bump — and because nothing can set it yet. Nothing in
+   * play grants advantage until `use_power` exists; the resolver and the card
+   * are built first so that when it does, there is nowhere for a magnitude to
+   * sneak in.
+   */
+  twice?: RolledTwice
 }
 
 /** The moment a skill becomes real. Rendered as a beat, not a toast. */
@@ -341,10 +351,41 @@ function validateEntry(value: unknown): TranscriptEntry | null {
         total: int(value.total),
         margin: int(value.margin),
         band: isBand(value.band) ? value.band : 'failure',
+        ...validateTwice(value.twice),
       }
     }
     default:
       return null
+  }
+}
+
+/**
+ * Read back the record of a die thrown twice, or nothing at all.
+ *
+ * Spread into the entry rather than assigned, so a check that was rolled once
+ * has no `twice` key rather than an explicit undefined — which keeps it out of
+ * every stored blob and out of the way of `toEqual` in the tests that already
+ * describe a plain check.
+ *
+ * A malformed one is dropped rather than repaired. There is no sensible default
+ * for "which die did we throw away": inventing one would put a number on the
+ * die card that never came off a die.
+ */
+function validateTwice(value: unknown): { twice: RolledTwice } | Record<string, never> {
+  if (!isPlainObject(value)) return {}
+  if (value.direction !== 'advantage' && value.direction !== 'disadvantage') return {}
+
+  // Checked before clamping rather than after: `boundedInt` would turn a
+  // missing die into a 1, and a 1 is a number a player would read as a real
+  // roll they got lucky to escape.
+  if (typeof value.discarded !== 'number' || !Number.isFinite(value.discarded)) return {}
+
+  return {
+    twice: {
+      direction: value.direction,
+      reason: str(value.reason, 120),
+      discarded: boundedInt(value.discarded, 1, 20),
+    },
   }
 }
 

--- a/src/app/dicebound/domain/dice.ts
+++ b/src/app/dicebound/domain/dice.ts
@@ -80,6 +80,62 @@ export interface Modifier {
   value: number
 }
 
+export type AdvantageDirection = 'advantage' | 'disadvantage'
+
+/**
+ * One reason the die gets thrown twice.
+ *
+ * Advantage is a **flag, not a number**, and that is the whole point of it. The
+ * alternative — the DM saying "give them +4 for the fire" — is the exact fudge
+ * this architecture exists to prevent, because a number can be argued up,
+ * scaled and stacked. This cannot: it is on or it is off, and only code turns
+ * it on. It also sits deliberately outside the ±6 situational budget and the +3
+ * kit ceiling, because it moves the odds without moving any number anyone can
+ * point at.
+ *
+ * A list rather than a tri-state field, because sources arrive independently —
+ * a power grants advantage while the scene imposes disadvantage, and neither
+ * knows about the other. Making the caller collapse that into one value would
+ * put the cancelling rule wherever the request happens to be assembled; here it
+ * is in `netAdvantage`, once.
+ */
+export interface AdvantageSource {
+  direction: AdvantageDirection
+  /** Why, in the fiction. Shown on the die card beside the discarded die. */
+  reason: string
+}
+
+/** What actually happened when a check was rolled twice. */
+export interface RolledTwice {
+  direction: AdvantageDirection
+  reason: string
+  /** The die that was thrown away — the most interesting number on the card. */
+  discarded: number
+}
+
+/**
+ * Collapse every source into the one thing that happens to the die.
+ *
+ * Pulled in both directions is *neither*, regardless of how many sources are on
+ * each side. Counting them and taking the difference would let a stack of small
+ * advantages out-vote a disadvantage, which is a magnitude — and the reason
+ * this is a flag is that it has no magnitude to argue about.
+ */
+export function netAdvantage(sources: readonly AdvantageSource[]): AdvantageSource | null {
+  const up = sources.filter(s => s.direction === 'advantage')
+  const down = sources.filter(s => s.direction === 'disadvantage')
+  if (up.length === 0 && down.length === 0) return null
+  if (up.length > 0 && down.length > 0) return null
+
+  const winning = up.length > 0 ? up : down
+  return {
+    direction: winning[0].direction,
+    // Every reason is kept. Two powers both granting advantage is one extra
+    // die, but the player is owed both of the reasons it happened.
+    reason: [...new Set(winning.map(s => s.reason).filter(Boolean))].join(' + '),
+  }
+}
+
 export interface CheckOutcome {
   roll: number
   /** Everything added to the roll, itemised, so the die card can show its work. */
@@ -92,11 +148,15 @@ export interface CheckOutcome {
   margin: number
   band: OutcomeBand
   succeeded: boolean
+  /** Null on an ordinary check, which is very nearly all of them. */
+  twice: RolledTwice | null
 }
 
 export interface CheckRequest {
   dc: number
   modifiers: Modifier[]
+  /** Everything pulling the die in either direction. See `netAdvantage`. */
+  advantage?: readonly AdvantageSource[]
 }
 
 export type Rng = () => number
@@ -154,9 +214,26 @@ export function clampSituational(modifiers: Modifier[]): Modifier[] {
  * still have the moment where it all goes wrong, and a character who cannot
  * mathematically reach the DC should still have the moment where it doesn't
  * matter. That is the part of the table people actually tell stories about.
+ *
+ * With advantage the naturals are decided on the **kept** die, not on either
+ * die that was thrown. Otherwise advantage would double a character's chance of
+ * a critical failure, which is the opposite of what it is for.
  */
 export function resolveCheck(request: CheckRequest, rng: Rng = Math.random): CheckOutcome {
-  const roll = rollD20(rng)
+  const net = netAdvantage(request.advantage ?? [])
+  const first = rollD20(rng)
+  // The second die is only thrown when something is actually pulling, so an
+  // ordinary check consumes exactly one value from the rng and every existing
+  // seeded test keeps rolling what it always rolled.
+  const second = net ? rollD20(rng) : null
+
+  const [roll, twice] =
+    net && second !== null
+      ? net.direction === 'advantage'
+        ? ([Math.max(first, second), { ...net, discarded: Math.min(first, second) }] as const)
+        : ([Math.min(first, second), { ...net, discarded: Math.max(first, second) }] as const)
+      : ([first, null] as const)
+
   const dc = clampDc(request.dc)
   // Modifiers are kept exactly as given, zeroes included: the die card shows
   // its work, and "Dexterity +0" is information the player wants — it tells
@@ -184,6 +261,7 @@ export function resolveCheck(request: CheckRequest, rng: Rng = Math.random): Che
     margin,
     band,
     succeeded: band.endsWith('success'),
+    twice,
   }
 }
 


### PR DESCRIPTION
Closes #3559. Kit lane — `domain/dice.ts` and `components/die-card.tsx`. Blocks `use_power` (#3561).

## Why a flag and not a number

Advantage is the currency this epic spends, and `dice.ts` could not express it — `resolveCheck` rolled one d20.

It has to be **a flag, not a number**. "Give them +4 for the fire" is the exact fudge vector the architecture exists to prevent, because a number can be argued up, scaled and stacked. This cannot: it is on or it is off, only code turns it on, and it sits deliberately outside both the ±6 situational budget and the +3 kit ceiling — it moves the odds without moving anything anyone can point at.

## A list of sources, not a tri-state

The issue offered either; this takes the list, and the reason is in a comment at the type. Sources arrive **independently** — a power grants advantage while the scene imposes disadvantage, and neither knows the other exists. A single tri-state field would force whoever assembles the request to do the cancelling, which scatters the rule across every call site. `netAdvantage` does it once.

Pulled in both directions is **neither**, regardless of how many sources sit on each side. Counting them and taking a difference would let a stack of small advantages out-vote one disadvantage — that is a magnitude, and having no magnitude is the whole point.

## Two things that would have been quietly wrong

**The naturals are decided on the kept die**, never on either die thrown. Reading them off both would make advantage *double* a character's chance of a critical failure, which is the reverse of what it is for. There is a test for the discarded natural 20 as well as the kept natural 1.

**The second die is only thrown when something is actually pulling.** An ordinary check still consumes exactly one value from the rng, so every existing seeded test in `dice.test.ts` rolls what it always rolled. Rolling twice and discarding unconditionally would have shifted all of them by one.

## Persistence and the card

`CheckEntry` gains an optional `twice`, so the card can show the die that lost. Optional means every check ever stored stays valid with **no version bump**. A malformed one is dropped rather than repaired — there is no sensible default for "which die did we throw away", and `boundedInt` would cheerfully turn a missing one into a `1`, which reads as a real roll the player got lucky to escape.

On the card the discarded die sits beside the kept one, struck through and dimmed, in a plain flex row with no animation of its own — so it reads identically fresh, scrolled-back-through, or under `prefers-reduced-motion`. The reason is a line of its own and deliberately **not** a modifier chip: putting it in the row of ±values invites both the player and the next editor to think of it as one. The struck-through die is `aria-hidden`, so the announcement carries it in words instead, or the spoken card would say less than the printed one.

## Nothing can trigger it

`roll_check` gains no advantage field and `turn/route.ts` is untouched. The model must never be able to ask for advantage; `use_power` is the only thing that will ever set one, and threading `twice` into the entry there is that issue's one line. Shipping the resolver and the card first is deliberate — when the trigger arrives there is nowhere for a magnitude to sneak in.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  9 passed (9)
      Tests  204 passed (204)      # 198 before; +10 advantage/netAdvantage, +3 validator, new die-card suite

$ npx tsc --noEmit 2>&1 | grep dicebound
                                    # empty

$ npx eslint src/app/dicebound src/lib/dicebound
eslint-exit=0

$ npm run lint:routes
check-route-slugs: ok

$ npx prettier --write <touched files>
```

No real-turn run, and it is not applicable: this touches no route, no prompt, no tool schema and no turn loop — and by design there is no way to reach advantage from play yet, so a live turn could not exercise it. The die card is covered by a new component test under stubbed reduced motion instead.