### PR TITLE
feat(dicebound): `grant_power`, gated on the slot, the tier and where it came from

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -51,7 +51,12 @@ import {
   trimToFit,
   validateCampaign,
 } from '@/app/dicebound/domain/campaign'
-import { attributeRank, earnedSkills, skillRank } from '@/app/dicebound/domain/character'
+import {
+  attributeRank,
+  earnedRanks,
+  earnedSkills,
+  skillRank,
+} from '@/app/dicebound/domain/character'
 import {
   BAND_BRIEF,
   BAND_LABEL,
@@ -68,14 +73,23 @@ import {
 import {
   type Kit,
   MAX_ITEMS,
+  MAX_TIER,
+  MIN_TIER,
+  POWER_SHAPES,
+  type PowerShape,
   QUALITIES,
   type Quality,
   addItem,
+  addPower,
+  canGrantPower,
   itemFromGrant,
   kitModifiers,
+  levelFor,
+  powerFromGrant,
 } from '@/app/dicebound/domain/kit'
 import {
   GRANT_ITEM_TOOL,
+  GRANT_POWER_TOOL,
   NARRATE_TOOL,
   RECALL_TOOL,
   ROLL_CHECK_TOOL,
@@ -244,6 +258,12 @@ WHAT THEY CARRY
 - Almost everything is plain. A rope is a permission, not a bonus: it turns "you cannot climb that" into a roll you can make. Reserve the better bands for things the story made a moment of.
 - You say what a thing is. The game says what it is worth, and the answer is usually nothing. Do not describe an ordinary object as though it improved them.
 - When something they carry genuinely bears on an attempt, name it in roll_check's items. Name it because it is true, not to help — most named items add nothing to the number and appear on the card anyway.
+
+WHAT THEY CAN DO
+- A power is rare and it is earned. Somebody taught it, something changed them, a place left a mark. Call grant_power only when the story has actually spent a scene on that, and never more than once in a long while.
+- It has to come from something already in the story — name that thing's id in source. Someone you invented this turn does not count. If the teacher is new, introduce them properly first and let them teach it later.
+- A power never decides an outcome. It makes one available: it turns "you cannot hurt him from here" into a roll that can still miss. Write it as a permission, not as a result.
+- You say what it is and what it costs. The game says how strong it is and how often it comes back. You may be told the character is not ready, or that the source does not count — that is a normal answer. Narrate the moment without the power and carry on; do not mention that anything was refused.
 
 REMEMBERING
 What you are shown is a window on the story, not the whole of it. Places, people and promises that have gone quiet are still there and are not listed.
@@ -479,6 +499,59 @@ const GRANT_ITEM: ToolDef = {
   description:
     'Give the character something to carry. Call this only when the fiction actually hands it over — they picked it up, were given it, took it. Do not call it to describe scenery. The game decides what the thing is worth; you decide what it is.',
   input_schema: toolSchema(GrantItemSchema),
+}
+
+/**
+ * Note what is absent: charges, refresh, and any way to say how strong this is.
+ *
+ * `tier` is the only magnitude the model may touch and it is a request, not a
+ * setting — `canGrantPower` clamps it down to what the level allows and never
+ * up. Everything else that turns into a number comes from `TIER_CHARGES`.
+ */
+const GrantPowerSchema = z.object({
+  id: z.string().describe('Stable lowercase slug. Never reuse one they already have.'),
+  name: z.string().describe('What the player would call it.'),
+  note: z.string().optional().describe('One line: what it looks like when they use it.'),
+  source: z
+    .string()
+    .describe(
+      'The id of the person, place or thing this came from. It must already exist in the story — someone you introduce this turn does not count.'
+    ),
+  shape: z
+    .enum(POWER_SHAPES as unknown as [PowerShape, ...PowerShape[]])
+    .describe(
+      'permits: it makes something possible that was not, and they still roll for it. advantage: they roll twice and keep the better die, in the situations you name.'
+    ),
+  permits: z
+    .string()
+    .optional()
+    .describe('For permits: the capability in plain language. "throw fire, at range".'),
+  applies: z
+    .object({
+      attributes: z.array(AttributeEnum).optional(),
+      skills: z.array(SkillEnum).optional(),
+    })
+    .optional()
+    .describe(
+      'For advantage: where it applies. Narrow it — advantage on everything is not a power.'
+    ),
+  cost: z.string().optional().describe('What using it costs them, in the fiction, if anything.'),
+  tier: z
+    .number()
+    .int()
+    .min(MIN_TIER)
+    .max(MAX_TIER)
+    .optional()
+    .describe(
+      'How significant this is, 1 to 3. A request only — if they are not far enough along, they get a lesser version rather than this one.'
+    ),
+})
+
+const GRANT_POWER: ToolDef = {
+  name: GRANT_POWER_TOOL,
+  description:
+    'Give the character something they can do. Only when the story has earned it and only from a source it already contains. The game decides how strong it is, how many charges it has, and whether they are ready for it at all — and it may say no, which is a normal answer and not a problem to mention.',
+  input_schema: toolSchema(GrantPowerSchema),
 }
 
 const OpeningSchema = z.object({
@@ -762,6 +835,19 @@ Resolve it, then call narrate with what happens.`,
   // reopening it, and a turn that never stops is a turn that never comes back.
   let fuseAnswered = false
   let kit = campaign.kit
+  // Both fixed for the whole turn, on purpose.
+  //
+  // `level` is read once so a skill that ranks up mid-turn cannot also unlock a
+  // power on the same turn. Levelling is a beat the player should get to read
+  // before it starts changing what they are allowed to be handed.
+  //
+  // `turnStartedAt` is where the clock stood before this turn touched anything,
+  // and it is what the provenance gate measures against. Using the live clock
+  // would mean a fuse-interrupted turn — which advances time and then comes
+  // back for another pass — started accepting entities it had minted moments
+  // earlier as things the player had "already met".
+  const level = levelFor(earnedRanks(campaign.character))
+  const turnStartedAt = world.clock.elapsed
 
   for (let step = 0; step <= MAX_CHECKS; step++) {
     const lastStep = step === MAX_CHECKS
@@ -782,11 +868,13 @@ Resolve it, then call narrate with what happens.`,
       // which is a harder guarantee than asking nicely for prose. There is no
       // fourth roll available to reach for, and finishing is the only move
       // left on the board.
-      tools: lastStep ? [narrate] : [ROLL_CHECK, RECALL, GRANT_ITEM, narrate],
+      tools: lastStep ? [narrate] : [ROLL_CHECK, RECALL, GRANT_ITEM, GRANT_POWER, narrate],
       toolChoice: lastStep ? { type: 'tool', name: NARRATE_TOOL } : { type: 'auto' },
     })
 
-    const { rolls, recalls, grants, ending, premature } = partitionTurnCalls(toolUses(data))
+    const { rolls, recalls, grants, powerGrants, ending, premature } = partitionTurnCalls(
+      toolUses(data)
+    )
 
     if (ending) {
       const text = narrationOf(ending.input)
@@ -837,6 +925,7 @@ Resolve it, then call narrate with what happens.`,
       rolls.length === 0 &&
       recalls.length === 0 &&
       grants.length === 0 &&
+      powerGrants.length === 0 &&
       premature.length === 0
     ) {
       // The model answered in prose instead of declaring the end of the turn.
@@ -857,6 +946,17 @@ Resolve it, then call narrate with what happens.`,
     }
     for (const call of grants) {
       const { kit: next, note } = grantFor(kit, world.clock.elapsed, call.input)
+      kit = next
+      results.push({ type: 'tool_result', tool_use_id: call.id, content: note })
+    }
+    for (const call of powerGrants) {
+      // `turnStartedAt` rather than the live clock. The provenance gate asks
+      // whether the source predates *this turn*, so it has to be measured
+      // against where the clock stood before the turn touched anything —
+      // otherwise a fuse-interrupted turn, which advances the clock and then
+      // comes back for another pass, would start accepting entities it minted
+      // moments ago.
+      const { kit: next, note } = grantPowerFor(kit, world, level, turnStartedAt, call.input)
       kit = next
       results.push({ type: 'tool_result', tool_use_id: call.id, content: note })
     }
@@ -980,6 +1080,66 @@ function grantFor(kit: Kit, now: number, input: unknown): { kit: Kit; note: stri
     note: worth.length
       ? `${item.name} is theirs. On the die it is worth ${worth.map(t => `${t.label} ${t.bonus > 0 ? '+' : ''}${t.bonus}`).join(', ')} — no more than that. Narrate it as the thing it is, not as an upgrade.`
       : `${item.name} is theirs, and it is worth nothing on the die. That is the common case: it is a permission, not a bonus. It may make things possible that were not; it does not make them easier.`,
+  }
+}
+
+/**
+ * Answer a `grant_power`, and say what it turned out to be.
+ *
+ * Every refusal here is a thing that happens in ordinary play — the character
+ * is not far enough along, the teacher was invented this turn, the trick has
+ * already been granted under another name — so none of them is an error. The
+ * turn continues, the DM narrates around the answer, and the player never
+ * learns a tool call was rejected. That is the same contract `grant_item` has
+ * for a full pack.
+ *
+ * The reply carries the tier and the charges for the reason `roll_check` and
+ * `grant_item` carry theirs: a model told nothing about a number narrates as
+ * though the number were enormous. A tier 1 power described as though it were
+ * tier 3 is a sheet and a story that disagree, and the player believes the
+ * story until the charges run out a scene early.
+ */
+function grantPowerFor(
+  kit: Kit,
+  world: World,
+  level: number,
+  turnStartedAt: number,
+  input: unknown
+): { kit: Kit; note: string } {
+  const grant = (input ?? {}) as Record<string, unknown>
+  const verdict = canGrantPower(
+    kit,
+    world,
+    level,
+    {
+      id: typeof grant.id === 'string' ? grant.id : '',
+      source: typeof grant.source === 'string' ? grant.source : '',
+      tier: grant.tier,
+    },
+    turnStartedAt
+  )
+
+  if (!verdict.granted) return { kit, note: verdict.reason }
+
+  const power = powerFromGrant(grant, verdict.tier, world.clock.elapsed)
+  if (!power) {
+    return { kit, note: 'That did not describe something anyone could do. Nothing was added.' }
+  }
+
+  const { kit: next, added } = addPower(kit, power)
+  if (!added) {
+    return { kit, note: `They cannot hold any more than the powers they already have.` }
+  }
+
+  const asked = typeof grant.tier === 'number' ? Math.round(grant.tier) : power.tier
+  const lowered =
+    asked > power.tier
+      ? ` You asked for tier ${asked}; they are not far enough along for that yet, so this is the lesser version of it.`
+      : ''
+
+  return {
+    kit: next,
+    note: `${power.name} is theirs, at tier ${power.tier} of ${MAX_TIER}.${lowered} It has ${power.charges.max} ${power.charges.max === 1 ? 'charge' : 'charges'} and they come back ${power.refresh === 'rest' ? 'after a real rest' : 'once a chapter'}. Narrate it as what it is at that size — it opens a door, it does not settle anything, and they still roll.`,
   }
 }
 

--- a/src/app/dicebound/domain/__tests__/kit.test.ts
+++ b/src/app/dicebound/domain/__tests__/kit.test.ts
@@ -10,6 +10,8 @@ import {
   REST_MINUTES,
   TIER_CHARGES,
   addItem,
+  addPower,
+  canGrantPower,
   emptyKit,
   isRest,
   itemFromGrant,
@@ -17,6 +19,7 @@ import {
   levelFor,
   maxPowersAt,
   maxTierAt,
+  powerFromGrant,
   restore,
   validateItem,
   validateKit,
@@ -24,6 +27,7 @@ import {
   validateSpecies,
   validateTrait,
 } from '@/app/dicebound/domain/kit'
+import { type Entity, type World, emptyWorld } from '@/app/dicebound/domain/world'
 
 describe('levels', () => {
   it('starts at 1 and advances every three earned ranks', () => {
@@ -336,5 +340,176 @@ describe('kitModifiers', () => {
     const mods = kitModifiers(kit, ['big', 'small', 'small2'], 'strength', null)
     expect(mods.map(m => m.label)).toContain('the great sword')
     expect(mods.reduce((sum, m) => sum + m.value, 0)).toBeLessThanOrEqual(KIT_BONUS_CAP)
+  })
+})
+
+/** A world holding one actor the player met an hour into the story. */
+function worldWith(entities: Record<string, Partial<Entity>> = {}, elapsed = 600): World {
+  const base = emptyWorld()
+  const built: Record<string, Entity> = {}
+  for (const [id, over] of Object.entries(entities)) {
+    built[id] = {
+      id,
+      kind: 'actor',
+      name: id,
+      note: '',
+      state: '',
+      status: 'active',
+      firstSeen: 60,
+      lastSeen: 60,
+      disposition: 0,
+      scale: 'person',
+      ...over,
+    } as Entity
+  }
+  return { ...base, clock: { ...base.clock, elapsed }, entities: built }
+}
+
+const grant = (over: Record<string, unknown> = {}) => ({
+  id: 'ember-hand',
+  name: 'Ember Hand',
+  source: 'maren',
+  shape: 'permits',
+  permits: 'throw fire, at short range',
+  ...over,
+})
+
+describe('canGrantPower', () => {
+  it('a power with a source the world has never heard of is refused', () => {
+    // Invariant 12 in one line: "nothing" fails a lookup. The DM cannot conjure
+    // fireball out of a teacher the story never contained.
+    const verdict = canGrantPower(
+      emptyKit(),
+      worldWith({ maren: {} }),
+      4,
+      { id: 'ember-hand', source: 'the-mountain', tier: 1 },
+      600
+    )
+    expect(verdict.granted).toBe(false)
+    expect(verdict.reason).toContain('the-mountain')
+  })
+
+  it('a source invented this turn does not count as an entity the player has met', () => {
+    // The same rule Edge.since enforces. Without it the DM introduces a
+    // mysterious stranger and has them teach fireball in the same breath, which
+    // is granting a power to yourself with extra steps.
+    const world = worldWith({ stranger: { firstSeen: 600 } }, 600)
+    const verdict = canGrantPower(
+      emptyKit(),
+      world,
+      4,
+      { id: 'ember-hand', source: 'stranger', tier: 1 },
+      600
+    )
+    expect(verdict.granted).toBe(false)
+  })
+
+  it('refuses a source the story has finished with', () => {
+    const world = worldWith({ maren: { status: 'gone' } })
+    expect(
+      canGrantPower(emptyKit(), world, 4, { id: 'ember-hand', source: 'maren', tier: 1 }, 600)
+        .granted
+    ).toBe(false)
+  })
+
+  it('refuses the player as their own provenance', () => {
+    // A power sourced from `you` is a power with no provenance wearing an id
+    // that happens to resolve.
+    const world = worldWith({ you: { firstSeen: 0 } })
+    expect(
+      canGrantPower(emptyKit(), world, 4, { id: 'ember-hand', source: 'you', tier: 1 }, 600).granted
+    ).toBe(false)
+  })
+
+  it('refuses outright below the level where powers exist at all', () => {
+    // maxTierAt(1) is 0 — they are not yet someone who has powers.
+    const verdict = canGrantPower(
+      emptyKit(),
+      worldWith({ maren: {} }),
+      1,
+      { id: 'ember-hand', source: 'maren', tier: 1 },
+      600
+    )
+    expect(verdict.granted).toBe(false)
+    expect(verdict.tier).toBe(0)
+  })
+
+  it('a tier the level cannot reach is clamped down, never up', () => {
+    const world = worldWith({ maren: {} })
+    // Level 4 reaches tier 2. Asking for 3 gets 2.
+    expect(
+      canGrantPower(emptyKit(), world, 4, { id: 'ember-hand', source: 'maren', tier: 3 }, 600).tier
+    ).toBe(2)
+    // Asking for 1 gets 1 — the clamp is a ceiling, not a floor that promotes.
+    expect(
+      canGrantPower(emptyKit(), world, 4, { id: 'ember-hand', source: 'maren', tier: 1 }, 600).tier
+    ).toBe(1)
+  })
+
+  it('the same power cannot be granted twice under the same id', () => {
+    const world = worldWith({ maren: {} })
+    const power = powerFromGrant(grant(), 1, 600)!
+    const { kit } = addPower(emptyKit(), power)
+    const verdict = canGrantPower(
+      kit,
+      world,
+      4,
+      { id: 'ember-hand', source: 'maren', tier: 1 },
+      600
+    )
+    expect(verdict.granted).toBe(false)
+    expect(verdict.reason).toContain('already')
+  })
+
+  it('refuses once the slots the level allows are full', () => {
+    const world = worldWith({ maren: {} })
+    // Level 4 allows maxPowersAt(4) = 3.
+    let kit = emptyKit()
+    for (const id of ['a', 'b', 'c']) {
+      kit = addPower(kit, powerFromGrant(grant({ id }), 1, 600)!).kit
+    }
+    expect(kit.powers).toHaveLength(maxPowersAt(4))
+    expect(
+      canGrantPower(kit, world, 4, { id: 'ember-hand', source: 'maren', tier: 1 }, 600).granted
+    ).toBe(false)
+  })
+})
+
+describe('powerFromGrant', () => {
+  it('charges come from the tier table, not from the model', () => {
+    const power = powerFromGrant({ ...grant(), charges: { now: 99, max: 99 }, tier: 3 }, 2, 600)!
+    expect(power.tier).toBe(2)
+    expect(power.charges).toEqual({ now: TIER_CHARGES[2], max: TIER_CHARGES[2] })
+  })
+
+  it('refuses a power with no provenance rather than repairing it', () => {
+    // A placeholder source would defeat the entire point of the field.
+    expect(powerFromGrant({ ...grant(), source: '' }, 1, 600)).toBeNull()
+    expect(powerFromGrant({ ...grant(), source: '  ' }, 1, 600)).toBeNull()
+  })
+
+  it('takes the clock for gainedAt rather than anything the model sent', () => {
+    const power = powerFromGrant({ ...grant(), gainedAt: 0 }, 1, 600)!
+    expect(power.gainedAt).toBe(600)
+  })
+})
+
+describe('addPower', () => {
+  it('refuses a duplicate rather than replacing it, so charges cannot be refilled by re-granting', () => {
+    // Unlike addItem, which replaces. Re-granting a power would silently
+    // restore its charges — a rest the player never took.
+    const spent = { ...powerFromGrant(grant(), 1, 600)!, charges: { now: 0, max: 3 } }
+    const kit = { ...emptyKit(), powers: [spent] }
+    const { kit: after, added } = addPower(kit, powerFromGrant(grant(), 1, 600)!)
+    expect(added).toBe(false)
+    expect(after.powers[0].charges.now).toBe(0)
+  })
+
+  it('never exceeds the hard ceiling, whatever the level says', () => {
+    let kit = emptyKit()
+    for (let i = 0; i < MAX_POWERS + 3; i++) {
+      kit = addPower(kit, powerFromGrant(grant({ id: `p${i}` }), 1, 600)!).kit
+    }
+    expect(kit.powers).toHaveLength(MAX_POWERS)
   })
 })

--- a/src/app/dicebound/domain/__tests__/turn.test.ts
+++ b/src/app/dicebound/domain/__tests__/turn.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  GRANT_POWER_TOOL,
   NARRATE_TOOL,
   RECALL_TOOL,
   ROLL_CHECK_TOOL,
@@ -114,5 +115,34 @@ describe('recall in the turn loop', () => {
     const { recalls, ending } = partitionTurnCalls([narrate('a')])
     expect(recalls).toEqual([])
     expect(ending?.id).toBe('a')
+  })
+})
+
+const grantPower = (id: string): ToolCall & { id: string } => ({
+  id,
+  name: GRANT_POWER_TOOL,
+  input: { id: 'ember-hand', source: 'maren' },
+})
+
+describe('partitionTurnCalls and grant_power', () => {
+  it('does not end the turn, so the DM narrates after learning what it got', () => {
+    const { powerGrants, ending } = partitionTurnCalls([grantPower('a')])
+
+    expect(powerGrants.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+  })
+
+  it('discards narration sent beside a power grant — the grant can be refused', () => {
+    // Sharper than the roll case. A grant may come back "they are not far
+    // enough along for that", and narration composed in the same breath
+    // describes a character learning something they did not get.
+    const { powerGrants, ending, premature } = partitionTurnCalls([
+      grantPower('a'),
+      narrate('b', 'Maren presses the ember into your palm and it takes.'),
+    ])
+
+    expect(powerGrants.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+    expect(premature.map(c => c.id)).toEqual(['b'])
   })
 })

--- a/src/app/dicebound/domain/kit.ts
+++ b/src/app/dicebound/domain/kit.ts
@@ -22,9 +22,10 @@
  */
 import { isAttributeId, isSkillId } from './attributes'
 import { bool, boundedInt, isPlainObject, oneOf, slug, str } from './validate'
+import { PLAYER_ID } from './world'
 
 import type { AttributeId, SkillId } from './attributes'
-import type { EntityId } from './world'
+import type { EntityId, World } from './world'
 
 /** When a trait or power applies. Empty means "the DM decides, in the fiction". */
 export interface Applicability {
@@ -529,4 +530,173 @@ function capKit(modifiers: { label: string; value: number }[]): { label: string;
   }
 
   return kept
+}
+
+/**
+ * Whether the fiction may hand this power over, and what it is actually worth.
+ *
+ * A verdict rather than a throw, and a *reason* rather than a boolean, because
+ * every one of these refusals happens in ordinary play. The DM asks for
+ * something the character is not ready for, or names a teacher the story has
+ * not introduced, or grants the same trick twice under a second name. None of
+ * that is an error — the turn carries on, the DM narrates around it, and the
+ * player never learns a tool call was rejected.
+ *
+ * The reason is written to be read by the model, because a refusal it cannot
+ * understand is a refusal it will simply repeat next turn.
+ */
+export interface PowerVerdict {
+  granted: boolean
+  /** Addressed to the DM. Always set, on a grant as well as a refusal. */
+  reason: string
+  /** The tier it may actually have — clamped down, never up. Zero when refused. */
+  tier: number
+}
+
+/**
+ * Has the player actually encountered this?
+ *
+ * The gate with judgement in it, so it is written down rather than left to the
+ * next reader to infer. Three conditions, and each one closes a different door:
+ *
+ * The entity must **exist in the graph**. That is invariant 12 doing its work —
+ * a power must come from something the world already knows about, and "nothing"
+ * fails a lookup. An id the model minted while writing this turn is not in the
+ * graph, so it fails here without needing a rule of its own.
+ *
+ * It must not be `gone`. A teacher who is dead and a vault that has collapsed
+ * are both still in the graph, deliberately, because the story remembers them —
+ * but neither can hand anything over now.
+ *
+ * It must **predate this turn**. This is the same rule `Edge.since` enforces for
+ * relationship bonuses, and for the same reason: without it the DM could
+ * introduce a mysterious stranger and have them teach fireball in the same
+ * breath, which is granting a power to yourself with extra steps. `firstSeen`
+ * is a clock minute, and `turnStartedAt` is the clock as it stood before this
+ * turn touched anything.
+ *
+ * `you` is excluded on purpose. A power sourced from the player is a power with
+ * no provenance wearing an id that happens to resolve.
+ */
+export function hasMet(world: World, id: EntityId, turnStartedAt: number): boolean {
+  if (!id || id === PLAYER_ID) return false
+  const entity = world.entities[id]
+  if (!entity) return false
+  if (entity.status === 'gone') return false
+  return entity.firstSeen < turnStartedAt
+}
+
+export function canGrantPower(
+  kit: Kit,
+  world: World,
+  level: number,
+  proposal: { id: string; source: string; tier: unknown },
+  turnStartedAt: number
+): PowerVerdict {
+  const id = slug(proposal.id)
+  const source = slug(proposal.source)
+
+  if (!id) {
+    return {
+      granted: false,
+      reason: 'That did not name a power anyone could call on again.',
+      tier: 0,
+    }
+  }
+
+  // Checked before the slot, so a power they already have reads as "they
+  // already have it" rather than as "the pack is full".
+  if (kit.powers.some(power => power.id === id)) {
+    return {
+      granted: false,
+      reason: `They already have ${id}. If this is meant to be something new, it needs a different name and a different id.`,
+      tier: 0,
+    }
+  }
+
+  const ceiling = maxTierAt(level)
+  if (ceiling === 0) {
+    return {
+      granted: false,
+      reason: `At level ${level} they are not yet someone who has powers. Let the moment happen in the fiction without one — they will be ready sooner than you think.`,
+      tier: 0,
+    }
+  }
+
+  if (!hasMet(world, source, turnStartedAt)) {
+    return {
+      granted: false,
+      reason: `A power has to come from something the story already contains, and "${source || 'nothing'}" is not something they have met. Introduce it first, in its own scene, and it can hand this over later.`,
+      tier: 0,
+    }
+  }
+
+  const slots = Math.min(maxPowersAt(level), MAX_POWERS)
+  if (kit.powers.length >= slots) {
+    return {
+      granted: false,
+      reason: `They are holding ${kit.powers.length} powers, which is all a level ${level} character may carry. Nothing is added.`,
+      tier: 0,
+    }
+  }
+
+  // Clamped down, never up. That is the whole difference between the model
+  // describing something impressive and the model pricing it: a DM that wants
+  // the player to have a tier 3 power says "tier 3", and the answer is the tier
+  // their level actually allows.
+  const tier = Math.min(boundedInt(proposal.tier, MIN_TIER, MAX_TIER, MIN_TIER), ceiling)
+  return { granted: true, reason: '', tier }
+}
+
+/**
+ * Build the power, with every number coming from here.
+ *
+ * The model supplies the name, the note, the shape, what it permits or where it
+ * applies, the cost and the source. It supplies no magnitudes at all: the tier
+ * arrives already clamped by `canGrantPower`, the charges come from
+ * `TIER_CHARGES`, and `gainedAt` comes from the clock.
+ */
+export function powerFromGrant(
+  grant: Record<string, unknown>,
+  tier: number,
+  now: number
+): Power | null {
+  const id = slug(grant.id)
+  const name = str(grant.name, 80).trim()
+  const source = slug(grant.source)
+  if (!id || !name || !source) return null
+
+  const max = TIER_CHARGES[tier] ?? 1
+
+  return {
+    id,
+    name,
+    note: str(grant.note, 240),
+    tier,
+    shape: oneOf(grant.shape, POWER_SHAPES, 'permits'),
+    permits: str(grant.permits, 160),
+    applies: validateApplicability(grant.applies),
+    charges: { now: max, max },
+    // Fixed by tier, not chosen. A model asked how often its own power should
+    // come back has one answer, and it is "often".
+    refresh: tier >= MAX_TIER ? 'chapter' : 'rest',
+    cost: str(grant.cost, 160),
+    source,
+    gainedAt: Math.max(0, now),
+  }
+}
+
+/**
+ * Add a power to a character who has room for it.
+ *
+ * Deliberately dumber than `addItem`, which replaces a held item of the same id
+ * so a re-granted rope is refreshed rather than duplicated. A power is not a
+ * thing you can be handed twice — re-granting one would silently restore its
+ * charges, which is a rest the player did not take. `canGrantPower` refuses the
+ * duplicate before it reaches here; this is the second lock on the same door.
+ */
+export function addPower(kit: Kit, power: Power): { kit: Kit; added: boolean } {
+  if (kit.powers.some(held => held.id === power.id)) return { kit, added: false }
+  if (kit.powers.length >= MAX_POWERS) return { kit, added: false }
+  return { kit: { ...kit, powers: [...kit.powers, power] }, added: true }
 }

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -22,6 +22,7 @@ export const ROLL_CHECK_TOOL = 'roll_check'
 export const NARRATE_TOOL = 'narrate'
 export const RECALL_TOOL = 'recall'
 export const GRANT_ITEM_TOOL = 'grant_item'
+export const GRANT_POWER_TOOL = 'grant_power'
 
 /** One pass's tool calls, sorted into what the loop does with each. */
 export interface TurnCalls<T extends ToolCall> {
@@ -34,6 +35,13 @@ export interface TurnCalls<T extends ToolCall> {
   recalls: T[]
   /** `grant_item` calls. Like a lookup: answered, and the turn carries on. */
   grants: T[]
+  /**
+   * `grant_power` calls. Same shape as an item grant, and separate from it
+   * because the answer is different: an item grant reports what the thing is
+   * worth, a power grant reports the tier it actually got — or the reason it
+   * got nothing, which is a normal outcome rather than an error.
+   */
+  powerGrants: T[]
   /** The `narrate` call that ends the turn, or null while the turn continues. */
   ending: T | null
   /**
@@ -64,18 +72,28 @@ export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T>
   const rolls = calls.filter(call => call.name === ROLL_CHECK_TOOL)
   const recalls = calls.filter(call => call.name === RECALL_TOOL)
   const grants = calls.filter(call => call.name === GRANT_ITEM_TOOL)
+  const powerGrants = calls.filter(call => call.name === GRANT_POWER_TOOL)
   const narrations = calls.filter(call => call.name === NARRATE_TOOL)
 
   // A narration sent alongside a lookup is as blind as one sent alongside a
   // roll: it was written before the answer came back, so whatever the DM asked
-  // for cannot be in it.
-  if (rolls.length > 0 || recalls.length > 0 || grants.length > 0) {
-    return { rolls, recalls, grants, ending: null, premature: narrations }
+  // for cannot be in it. A power grant belongs in this list for a sharper
+  // reason than the others — the grant can be *refused*, and narration written
+  // beside it describes the character learning something they did not get.
+  if (rolls.length > 0 || recalls.length > 0 || grants.length > 0 || powerGrants.length > 0) {
+    return { rolls, recalls, grants, powerGrants, ending: null, premature: narrations }
   }
 
   // Only the first narration ends the turn. A second one is a duplicate, not a
   // continuation, and appending both would read as the DM saying it twice.
-  return { rolls, recalls, grants, ending: narrations[0] ?? null, premature: narrations.slice(1) }
+  return {
+    rolls,
+    recalls,
+    grants,
+    powerGrants,
+    ending: narrations[0] ?? null,
+    premature: narrations.slice(1),
+  }
 }
 
 /** What a turn produced, before it has been written down anywhere. */


### PR DESCRIPTION
Closes #3560. Turn lane — `turn/route.ts`, `domain/turn.ts`, `domain/kit.ts`. Depends on #3558, which is merged.

## The split

The model supplies the name, the note, the shape, what it permits or where it applies, the cost, and the source. Code supplies **every number**. `tier` is the only magnitude the model may touch and it is a *request*, not a setting — clamped **down** to what the level allows and never up. Charges and refresh come from `TIER_CHARGES`, `gainedAt` from the clock.

That clamp turned out to be load-bearing rather than theoretical. In live runs the DM asked for **tier 2 on a level 2 character both times it granted anything.**

## Four gates, each returning a reason

Not a throw and not a boolean, because every one of these happens in ordinary play: a duplicate id, a level with no tier yet, a source the world never heard of, no slots left. **A refusal is not an error** — the turn continues, the DM narrates around it, and the player never learns a tool call was rejected.

`hasMet` is the gate with judgement in it, so it is written down at the code rather than left to be inferred. Three conditions:

- **It must exist in the graph.** Invariant 12 — "nothing" fails a lookup. An id the model minted while writing this turn is not in the graph, so it fails here without needing a rule of its own.
- **It must not be `gone`.** A dead teacher and a collapsed vault are both still in the graph on purpose, because the story remembers them. Neither can hand anything over now.
- **It must predate this turn.** The same rule `Edge.since` enforces. Without it the DM introduces a mysterious stranger and has them teach fireball in the same breath.

`you` is excluded: a power sourced from the player is a power with no provenance wearing an id that happens to resolve.

## Two things fixed for the whole turn

`level` is read once, so a skill that ranks up mid-turn cannot also unlock a power on the same turn — levelling is a beat the player should get to read before it changes what they may be handed.

`turnStartedAt` is the clock *before* the turn touched anything. Using the live clock would mean a fuse-interrupted turn — which advances time and comes back for another pass — started accepting entities it had minted moments earlier as things the player had "already met".

## On the duplicate gate

The issue asked me to say plainly if id collision is unsolvable here. **It is not solved, and it cannot be by this issue** — the gate catches a repeated *id*, not a repeated *thing*. The DM minting `ember-hand` and `coal-hand` for one power is the same drift that produced `iron-spike` and `sconce-spike` for one spike, and the kit still has no reconciliation. What this does add is `addPower` refusing a duplicate rather than replacing it, unlike `addItem` which replaces so a re-granted rope is refreshed: re-granting a *power* would silently restore its charges, which is a rest the player never took. Powers are rare enough that the collision is much less likely than for items, but the hole is real and belongs to whatever issue gives the kit reconciliation.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  8 passed (8)
      Tests  211 passed (211)      # 196 before; +13 gates/powerFromGrant/addPower, +2 partition

$ npx tsc --noEmit 2>&1 | grep dicebound          # empty
$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
eslint=0
$ npm run lint:routes
check-route-slugs: ok
$ npx prettier --check src/app/api/v1/dicebound/turn/route.ts
All matched files use Prettier code style!
```

### Real turns

This touches the prompt, a tool schema and the turn loop, so it got real ones.

`npm run voice:dicebound -- --turns 6` — **0/6 turns failed**, so the API accepts the new `input_schema` and the loop still terminates. (Check rate reads 0% there and is *not* comparable to the 20-turn figure: `--turns 6` takes the first six actions, which are deliberately the no-roll half — look, call out, ask, wait.)

Then a seeded scenario at level 2 with a teacher in the graph, driven through the real route, instrumented temporarily to read the tool result the model actually receives. **Refusal path** — teacher removed from the world:

```
in  {"id":"ember-hands","source":"maren","tier":2, ...}
out A power has to come from something the story already contains, and "maren" is not
    something they have met. Introduce it first, in its own scene, and it can hand this
    over later.
powers granted: 0
```

**Grant path** — teacher present:

```
in  {"id":"coal-hand","source":"maren","shape":"permits","tier":2, ...}
out Coal-Hand is theirs, at tier 1 of 3. You asked for tier 2; they are not far enough
    along for that yet, so this is the lesser version of it. It has 3 charges and they
    come back after a real rest. Narrate it as what it is at that size — it opens a door,
    it does not settle anything, and they still roll.
powers granted: 1
```

The narration in both cases carried on normally and never mentioned that anything had been refused. The instrumentation was removed before committing.

Worth noting for whoever picks up `use_power`: across four seeded runs on a scene practically engineered for a grant, the DM reached for the tool **twice**. It is not eager, which is the right direction.