### PR TITLE
feat(dicebound): powers, level and class on the sheet — and only once they exist

### DIFF
--- a/src/app/dicebound/components/__tests__/kit.test.tsx
+++ b/src/app/dicebound/components/__tests__/kit.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Powers, Standing } from '@/app/dicebound/components/kit'
+import { type Campaign, newCampaign } from '@/app/dicebound/domain/campaign'
+import { RANK_THRESHOLDS, blankAttributes } from '@/app/dicebound/domain/character'
+import type { Power } from '@/app/dicebound/domain/kit'
+import type { Entity } from '@/app/dicebound/domain/world'
+
+afterEach(cleanup)
+
+function campaignWith(over: Partial<Campaign> = {}): Campaign {
+  const base = newCampaign(
+    'a forge town',
+    { name: 'Ilda', concept: 'a smith', reading: '', attributes: blankAttributes(), skills: {} },
+    0,
+    null
+  )
+  return { ...base, ...over }
+}
+
+/** Three ranks earned in play, which is exactly level 2. */
+const LEVEL_2_SKILLS = {
+  engineering: { uses: RANK_THRESHOLDS[1], rank: 2 },
+  observation: { uses: RANK_THRESHOLDS[0], rank: 1 },
+}
+
+const imra: Entity = {
+  id: 'keeper-imra',
+  kind: 'actor',
+  name: 'Keeper Imra',
+  note: '',
+  state: '',
+  status: 'active',
+  disposition: 2,
+  scale: 'person',
+  firstSeen: 0,
+  lastSeen: 0,
+}
+
+const power = (over: Partial<Power> = {}): Power => ({
+  id: 'ember-word',
+  name: 'Ember Word',
+  note: 'You say the word and the fire leans toward you.',
+  tier: 1,
+  shape: 'permits',
+  permits: 'ask a fire to move',
+  applies: {},
+  charges: { now: 3, max: 3 },
+  refresh: 'rest',
+  cost: '',
+  source: 'keeper-imra',
+  gainedAt: 60,
+  ...over,
+})
+
+describe('Standing', () => {
+  it('renders nothing for a character who has just been made', () => {
+    // Invariant 17. Level 1 is where everyone starts, so printing it says
+    // nothing about this character and everything about there being a ladder.
+    const { container } = render(<Standing campaign={campaignWith()} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows the level only once it means something', () => {
+    render(
+      <Standing
+        campaign={campaignWith({
+          character: { ...campaignWith().character, skills: LEVEL_2_SKILLS },
+        })}
+      />
+    )
+    expect(screen.getByText('Level 2')).toBeDefined()
+  })
+
+  it('shows a class once the story has discovered one, and not before', () => {
+    const before = render(<Standing campaign={campaignWith()} />)
+    expect(before.container.innerHTML).toBe('')
+    cleanup()
+
+    render(
+      <Standing
+        campaign={campaignWith({
+          kit: { ...campaignWith().kit, className: 'Ember-Keeper' },
+        })}
+      />
+    )
+    expect(screen.getByText('Ember-Keeper')).toBeDefined()
+  })
+})
+
+describe('Powers', () => {
+  it('renders nothing at all for a character who has never been granted one', () => {
+    // No greyed-out slots and no heading hinting at what unlocks them. This is
+    // the rule with almost no protection other than this test.
+    const { container } = render(<Powers campaign={campaignWith()} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('names the power, what it looks like, and where it came from', () => {
+    render(
+      <Powers
+        campaign={campaignWith({
+          kit: { ...campaignWith().kit, powers: [power()] },
+          world: { ...campaignWith().world, entities: { 'keeper-imra': imra } },
+        })}
+      />
+    )
+    expect(screen.getByText('Ember Word')).toBeDefined()
+    expect(screen.getByText(/the fire leans toward you/)).toBeDefined()
+    // Provenance is the part that makes it feel like something that happened.
+    expect(screen.getByText('From Keeper Imra')).toBeDefined()
+  })
+
+  it('drops the provenance line rather than printing a slug the player never agreed to read', () => {
+    // The source has aged out of the graph. A missing sentence beats
+    // "keeper-imra" on the sheet.
+    render(
+      <Powers campaign={campaignWith({ kit: { ...campaignWith().kit, powers: [power()] } })} />
+    )
+    expect(screen.queryByText(/keeper-imra/)).toBeNull()
+    expect(screen.getByText('Ember Word')).toBeDefined()
+  })
+
+  it('says the charges in words as well as pips, so they are not carried by shape alone', () => {
+    render(
+      <Powers
+        campaign={campaignWith({
+          kit: { ...campaignWith().kit, powers: [power({ charges: { now: 1, max: 3 } })] },
+        })}
+      />
+    )
+    expect(screen.getByText('1/3')).toBeDefined()
+    expect(screen.getByText('1 of 3 charges left')).toBeDefined()
+  })
+
+  it('a spent power still reads as a power, not as a disabled row', () => {
+    // Zero of three is a fact about tonight, not about the character.
+    render(
+      <Powers
+        campaign={campaignWith({
+          kit: { ...campaignWith().kit, powers: [power({ charges: { now: 0, max: 3 } })] },
+        })}
+      />
+    )
+    expect(screen.getByText('Ember Word')).toBeDefined()
+    expect(screen.getByText('no charges left')).toBeDefined()
+    expect(screen.getByText('Back after you rest')).toBeDefined()
+  })
+})

--- a/src/app/dicebound/components/kit.tsx
+++ b/src/app/dicebound/components/kit.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+/**
+ * What the character has become, and what they can do.
+ *
+ * Level, class and powers — the three things the sheet did not show once they
+ * became real. It lives beside `world.tsx` rather than inside `sheet.tsx` for
+ * the same reason that file does: the sheet is a layout, and the panels that
+ * fill it each have their own rule about when to say nothing.
+ *
+ * That rule is invariant 17, and it is the whole design here. **Nothing renders
+ * until it exists.** No greyed-out power slots, no "Class: —", no locked panel
+ * hinting at what unlocks it. A character who has never been granted a power
+ * must not be able to tell the system is there — because five systems all
+ * announcing themselves as empty is how a hand-made thing starts feeling like a
+ * form to fill in. Almost nothing else protects this rule; the component test
+ * beside it is the protection.
+ *
+ * Two smaller decisions worth keeping:
+ *
+ * A spent power still reads as a power. Zero of three charges is a fact about
+ * tonight, not about the character, so it is never a disabled row — the name
+ * stays at full contrast and only the pips go hollow.
+ *
+ * Provenance is the point. "Taught by Keeper Imra" is what makes a power feel
+ * like something that happened rather than something that was awarded, and it
+ * is the world graph earning its keep somewhere the player can actually see.
+ */
+import type { Campaign } from '@/app/dicebound/domain/campaign'
+import { earnedRanks } from '@/app/dicebound/domain/character'
+import { type Power, levelFor } from '@/app/dicebound/domain/kit'
+import type { World } from '@/app/dicebound/domain/world'
+
+function Heading({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="font-label text-label-caps uppercase tracking-widest text-on-surface-variant">
+      {children}
+    </h3>
+  )
+}
+
+/**
+ * Level and class, as one quiet line under the concept.
+ *
+ * Level 1 is not shown. Everyone starts there, so printing it says nothing
+ * about this character and everything about there being a ladder — which is
+ * precisely the framing the game does not want on turn one. It appears the
+ * moment it means something, which is also the moment it is worth noticing.
+ */
+export function Standing({ campaign }: { campaign: Campaign }) {
+  const level = levelFor(earnedRanks(campaign.character))
+  const className = campaign.kit.className
+
+  if (level <= 1 && !className) return null
+
+  return (
+    <p className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm">
+      {level > 1 && (
+        <span className="font-headline font-extrabold tabular-nums text-ds-tertiary">
+          Level {level}
+        </span>
+      )}
+      {className && <span className="text-on-surface">{className}</span>}
+    </p>
+  )
+}
+
+export function Powers({ campaign }: { campaign: Campaign }) {
+  const powers = campaign.kit.powers
+  if (powers.length === 0) return null
+
+  return (
+    <section>
+      <Heading>What you can do</Heading>
+      <ul className="mt-3 flex flex-col gap-3">
+        {powers.map(power => (
+          <PowerRow key={power.id} power={power} world={campaign.world} />
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function PowerRow({ power, world }: { power: Power; world: World }) {
+  const spent = power.charges.now <= 0
+  const from = provenance(power, world)
+
+  return (
+    <li className="border-l-2 border-ds-tertiary/40 pl-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+        {/* Full contrast whether or not it is spent. A power you have used up
+            tonight is still a power you have. */}
+        <p className="text-sm font-semibold text-on-surface">{power.name}</p>
+        <Charges now={power.charges.now} max={power.charges.max} />
+      </div>
+
+      {power.note && <p className="mt-0.5 text-xs text-on-surface-variant">{power.note}</p>}
+
+      <p className="mt-1 flex flex-wrap gap-x-2 text-xs text-on-surface-variant/70">
+        {from && <span>{from}</span>}
+        <span>
+          {spent
+            ? power.refresh === 'rest'
+              ? 'Back after you rest'
+              : 'Back next chapter'
+            : power.refresh === 'rest'
+              ? 'Refreshes on a rest'
+              : 'Refreshes each chapter'}
+        </span>
+        {power.cost && <span>Costs: {power.cost}</span>}
+      </p>
+    </li>
+  )
+}
+
+/**
+ * Where it came from, in words, or nothing.
+ *
+ * The id is looked up in the graph rather than printed. `keeper-imra` is a
+ * database key and the player never agreed to read one; if the entity has aged
+ * out of the world the line is simply dropped, because a slug on the sheet is
+ * worse than a missing sentence.
+ */
+function provenance(power: Power, world: World): string | null {
+  const from = world.entities[power.source]
+  return from ? `From ${from.name}` : null
+}
+
+/**
+ * Charges as pips, plus the same fact in words.
+ *
+ * The pips are decorative and `aria-hidden`; the sentence beside them is what a
+ * screen reader gets, and it is also the fallback for anyone who cannot tell
+ * the filled pip from the hollow one. Charges must not be carried by colour or
+ * shape alone (CLAUDE.md #8), and a row of dots is exactly the kind of thing
+ * that quietly becomes colour-only when someone restyles it later.
+ */
+function Charges({ now, max }: { now: number; max: number }) {
+  return (
+    <span className="flex shrink-0 items-center gap-1.5">
+      <span aria-hidden className="flex items-center gap-1">
+        {Array.from({ length: max }, (_, index) => (
+          <span
+            key={index}
+            className={`h-2 w-2 rounded-full ${
+              index < now ? 'bg-ds-tertiary' : 'border border-outline-variant bg-transparent'
+            }`}
+          />
+        ))}
+      </span>
+      <span className="tabular-nums text-xs text-on-surface-variant">
+        {now}/{max}
+      </span>
+      <span className="sr-only">
+        {now === 0 ? 'no charges left' : `${now} of ${max} charges left`}
+      </span>
+    </span>
+  )
+}

--- a/src/app/dicebound/components/sheet.tsx
+++ b/src/app/dicebound/components/sheet.tsx
@@ -25,6 +25,7 @@ import {
 import type { Campaign } from '@/app/dicebound/domain/campaign'
 import { RANK_THRESHOLDS, type SkillRecord, usesToNextRank } from '@/app/dicebound/domain/character'
 
+import { Powers, Standing } from './kit'
 import { WorldPanel } from './world'
 
 function sign(value: number): string {
@@ -43,6 +44,7 @@ export function Sheet({ campaign }: { campaign: Campaign }) {
       <header>
         <h2 className="font-headline text-headline-md text-on-surface">{character.name}</h2>
         <p className="mt-1 text-body-md text-on-surface-variant">{character.concept}</p>
+        <Standing campaign={campaign} />
         {character.reading && (
           <p className="mt-3 border-l-2 border-ds-tertiary/50 pl-3 text-sm italic text-on-surface-variant">
             {character.reading}
@@ -94,6 +96,8 @@ export function Sheet({ campaign }: { campaign: Campaign }) {
           </ul>
         )}
       </section>
+
+      <Powers campaign={campaign} />
 
       <WorldPanel campaign={campaign} />
 


### PR DESCRIPTION
Closes #3565. UI lane — `components/kit.tsx` (new), `components/sheet.tsx`.

## The rule doing all the work

Invariant 17: **nothing renders until it exists.** No greyed-out power slots, no `Class: —`, no locked panel hinting at what unlocks it. A character who has never been granted a power must not be able to tell the system is there — five systems all announcing themselves as empty is how a hand-made thing starts feeling like a form to fill in.

This rule has almost no protection other than a test, so the test is the deliverable as much as the panel is. `Standing` and `Powers` each return `null` section by section, and `kit.test.tsx` asserts `container.innerHTML === ''` for a fresh character on both.

## Decisions

**Level 1 is not shown.** Everyone starts there, so printing it says nothing about this character and everything about there being a ladder — which is exactly the framing the game does not want on turn one. It appears the moment it means something.

**A spent power still reads as a power.** Zero of three charges is a fact about tonight, not about the character, so it is never a disabled row: the name stays at full contrast and only the pips go hollow. The refresh line changes voice instead — "Refreshes on a rest" becomes "Back after you rest".

**Provenance is resolved, not printed.** `From Keeper Imra`, looked up in the graph. If the entity has aged out of the world the line is dropped rather than falling back to `keeper-imra` — a slug on the sheet is worse than a missing sentence, and the player never agreed to read a database key.

## Accessibility (CLAUDE.md #8)

Charges are pips *plus* `1/3` *plus* an `sr-only` "1 of 3 charges left". The pips are `aria-hidden` and decorative. A row of dots is precisely the thing that quietly becomes colour-and-shape-only when someone restyles it later, so the text equivalent is asserted by a test rather than left to review. The panel is flex-wrap throughout and has no fixed widths, so it holds at mobile width.

## On the collision with #3556

This lands in a **new `components/kit.tsx`** rather than growing `sheet.tsx`, so the pack has somewhere to go. I have deliberately **not** built a shared "kit panel" abstraction — the issue warned against inventing one from whichever side arrives first, and a pack of items and a list of powers do not obviously want the same row. What #3556 gets is a file with a local `Heading`, a section-returns-null convention to follow, and `Charges` already written, since a consumable's uses want exactly the same treatment. Reuse `Charges`; do not mirror it.

`Kit.className` is a bare string, so the "class name **and its line**" in the issue renders as the name only. There is no description field on the model to render, and inventing one is a domain change this issue does not own.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  9 passed (9)
      Tests  204 passed (204)      # +8, a new component suite

$ npx tsc --noEmit 2>&1 | grep dicebound          # empty
$ npx eslint src/app/dicebound src/lib/dicebound
eslint=0
$ npx prettier --write <touched files>            # all unchanged
```

No real-turn run, and it is not applicable — no route, no prompt, no tool schema, no turn loop. The rendering paths that matter are the ones a live campaign takes weeks to reach, which is why they are driven directly in the component test instead.