### PR TITLE
feat(dicebound): `use_power` spends the charge, and then you still roll

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -58,6 +58,7 @@ import {
   skillRank,
 } from '@/app/dicebound/domain/character'
 import {
+  type AdvantageSource,
   BAND_BRIEF,
   BAND_LABEL,
   BAND_MOVE,
@@ -71,6 +72,7 @@ import {
   resolveCheck,
 } from '@/app/dicebound/domain/dice'
 import {
+  type Applicability,
   type Kit,
   MAX_ITEMS,
   MAX_TIER,
@@ -81,11 +83,14 @@ import {
   type Quality,
   addItem,
   addPower,
+  appliesTo,
   canGrantPower,
   itemFromGrant,
   kitModifiers,
   levelFor,
+  powerEffect,
   powerFromGrant,
+  spendPower,
 } from '@/app/dicebound/domain/kit'
 import {
   GRANT_ITEM_TOOL,
@@ -94,6 +99,7 @@ import {
   RECALL_TOOL,
   ROLL_CHECK_TOOL,
   type TurnResult,
+  USE_POWER_TOOL,
   applyTurn,
   partitionTurnCalls,
 } from '@/app/dicebound/domain/turn'
@@ -264,6 +270,8 @@ WHAT THEY CAN DO
 - It has to come from something already in the story — name that thing's id in source. Someone you invented this turn does not count. If the teacher is new, introduce them properly first and let them teach it later.
 - A power never decides an outcome. It makes one available: it turns "you cannot hurt him from here" into a roll that can still miss. Write it as a permission, not as a result.
 - You say what it is and what it costs. The game says how strong it is and how often it comes back. You may be told the character is not ready, or that the source does not count — that is a normal answer. Narrate the moment without the power and carry on; do not mention that anything was refused.
+- When they reach for a power they have, call use_power. The charge is spent the moment they reach, whether or not it works — so do not call it to decorate a description, and do not call it twice for one action.
+- A power never settles anything. It makes something possible that was not, and then you still call roll_check for whatever is uncertain about it. Fire in your hand does not kill the guard; it means you can try.
 
 REMEMBERING
 What you are shown is a window on the story, not the whole of it. Places, people and promises that have gone quiet are still there and are not listed.
@@ -552,6 +560,25 @@ const GRANT_POWER: ToolDef = {
   description:
     'Give the character something they can do. Only when the story has earned it and only from a source it already contains. The game decides how strong it is, how many charges it has, and whether they are ready for it at all — and it may say no, which is a normal answer and not a problem to mention.',
   input_schema: toolSchema(GrantPowerSchema),
+}
+
+/**
+ * Note that there is nothing here to say what the power *does* this time.
+ *
+ * The power already said that when it was granted. Letting the model restate
+ * it at the moment of use is letting it restate it larger, and a power whose
+ * effect is re-described every time it is spent is a power the model is
+ * pricing.
+ */
+const UsePowerSchema = z.object({
+  id: z.string().describe('The id of a power they already have.'),
+})
+
+const USE_POWER: ToolDef = {
+  name: USE_POWER_TOOL,
+  description:
+    'Spend one charge of a power the character has. The charge goes whether or not anything comes of it. This does not decide what happens — it tells you what is now possible, and you still call roll_check for anything uncertain.',
+  input_schema: toolSchema(UsePowerSchema),
 }
 
 const OpeningSchema = z.object({
@@ -848,6 +875,9 @@ Resolve it, then call narrate with what happens.`,
   // earlier as things the player had "already met".
   const level = levelFor(earnedRanks(campaign.character))
   const turnStartedAt = world.clock.elapsed
+  // Spent powers, held for the length of the turn. Anything still pending when
+  // the turn ends is discarded with its charge already gone.
+  const powers: TurnPowers = { permissions: [], pending: [], spent: new Set() }
 
   for (let step = 0; step <= MAX_CHECKS; step++) {
     const lastStep = step === MAX_CHECKS
@@ -868,13 +898,14 @@ Resolve it, then call narrate with what happens.`,
       // which is a harder guarantee than asking nicely for prose. There is no
       // fourth roll available to reach for, and finishing is the only move
       // left on the board.
-      tools: lastStep ? [narrate] : [ROLL_CHECK, RECALL, GRANT_ITEM, GRANT_POWER, narrate],
+      tools: lastStep
+        ? [narrate]
+        : [ROLL_CHECK, RECALL, GRANT_ITEM, GRANT_POWER, USE_POWER, narrate],
       toolChoice: lastStep ? { type: 'tool', name: NARRATE_TOOL } : { type: 'auto' },
     })
 
-    const { rolls, recalls, grants, powerGrants, ending, premature } = partitionTurnCalls(
-      toolUses(data)
-    )
+    const { rolls, recalls, grants, powerGrants, powerUses, ending, premature } =
+      partitionTurnCalls(toolUses(data))
 
     if (ending) {
       const text = narrationOf(ending.input)
@@ -926,6 +957,7 @@ Resolve it, then call narrate with what happens.`,
       recalls.length === 0 &&
       grants.length === 0 &&
       powerGrants.length === 0 &&
+      powerUses.length === 0 &&
       premature.length === 0
     ) {
       // The model answered in prose instead of declaring the end of the turn.
@@ -939,8 +971,16 @@ Resolve it, then call narrate with what happens.`,
     messages.push({ role: 'assistant', content: data.content ?? [] })
 
     const results: ContentBlock[] = []
+    // Spends run before rolls. A model that sends `use_power` and `roll_check`
+    // in one message meant them in that order, and resolving the roll first
+    // would drop the permission off its own die card.
+    for (const call of powerUses) {
+      const { kit: next, note } = spendPowerFor(kit, powers, call.input)
+      kit = next
+      results.push({ type: 'tool_result', tool_use_id: call.id, content: note })
+    }
     for (const call of rolls) {
-      const { entry, brief } = rollFor(campaign, kit, call.input)
+      const { entry, brief } = rollFor(campaign, kit, powers, call.input)
       entries.push(entry)
       results.push({ type: 'tool_result', tool_use_id: call.id, content: brief })
     }
@@ -1084,6 +1124,81 @@ function grantFor(kit: Kit, now: number, input: unknown): { kit: Kit; note: stri
 }
 
 /**
+ * What a spent power left lying on the table for the rest of this turn.
+ *
+ * Neither of these is a number and neither of them decides anything. A
+ * permission becomes a +0 row on the die card — named, because the reason is
+ * real even when the value is nothing (invariant 18) — and an advantage becomes
+ * a flag the next matching check picks up.
+ */
+interface TurnPowers {
+  /** `permits` powers spent this turn, as die-card rows worth nothing. */
+  permissions: Modifier[]
+  /**
+   * `advantage` powers spent this turn and not yet claimed by a check.
+   *
+   * Held rather than applied because the check that matches has not happened
+   * yet — and if none ever does, these are simply thrown away at the end of the
+   * turn with the charges already gone. That is the point: the player spent it
+   * on the wrong moment, which is a real decision, and refunding it would make
+   * it a free one.
+   */
+  pending: { source: AdvantageSource; applies: Applicability }[]
+  /** Ids spent this turn, so one power cannot be paid for once and used twice. */
+  spent: Set<string>
+}
+
+/**
+ * Spend a charge and report what it made available — never what it did.
+ *
+ * The ordering is the whole rule. The charge is gone before any check is
+ * rolled and without knowing whether one will land, because a power that only
+ * costs you something when it works is not a choice.
+ *
+ * The reply is written to stop the model treating the spend as the outcome. It
+ * says what is now possible and then says, in as many words, that a roll is
+ * still owed — a DM handed "you may now throw fire" and nothing else will write
+ * the guard's death in the next sentence.
+ */
+function spendPowerFor(
+  kit: Kit,
+  powers: TurnPowers,
+  input: unknown
+): { kit: Kit; powers: TurnPowers; note: string } {
+  const raw = (input ?? {}) as { id?: unknown }
+  const { kit: next, power, reason } = spendPower(kit, raw.id, powers.spent)
+
+  if (!power) return { kit, powers, note: reason }
+
+  powers.spent.add(power.id)
+  const left = `${power.charges.now} of ${power.charges.max} left`
+  const effect = powerEffect(power)
+
+  if (effect.advantage) {
+    powers.pending.push(effect.advantage)
+    return {
+      kit: next,
+      powers,
+      note: `${power.name} is spent — ${left}. The next roll it bears on is made twice, keeping the better die. It changes the odds and nothing else: no number moves, and the roll can still fail. If nothing this turn is the kind of thing it helps with, the charge is gone anyway.`,
+    }
+  }
+
+  if (effect.permission) powers.permissions.push(effect.permission)
+  return {
+    kit: next,
+    powers,
+    // Deliberately blunter than the other tool results. Live runs showed the DM
+    // spending the charge and then narrating the result outright — fire thrown,
+    // guard down, no die — which is precisely the failure this whole shape
+    // exists to prevent. The usual "most turns are not checks" guidance is
+    // right about most turns and wrong about this one: reaching for a power is
+    // the character betting something scarce on a moment, and a bet that cannot
+    // fail is not a bet.
+    note: `${power.name} is spent — ${left}.${power.permits ? ` They can now ${power.permits}.` : ''} That is a permission, not a result. Do NOT narrate whether it worked. Call roll_check now, for the thing they were trying to achieve with it, at a difficulty the fiction sets — spending a charge is the character betting something scarce on a moment, and it has to be able to fail. If you narrate this without rolling, the power has decided the outcome, and it must not.`,
+  }
+}
+
+/**
  * Answer a `grant_power`, and say what it turned out to be.
  *
  * Every refusal here is a thing that happens in ordinary play — the character
@@ -1143,10 +1258,18 @@ function grantPowerFor(
   }
 }
 
-/** Resolve one `roll_check` call into a transcript entry and a model briefing. */
+/**
+ * Resolve one `roll_check` call into a transcript entry and a model briefing.
+ *
+ * `powers` is mutated: a pending advantage is *claimed* by the first check it
+ * bears on, and claiming it has to be visible to the next check in the same
+ * pass. Threading it back through a return value would work too, and would be
+ * one more thing to forget at the second call site.
+ */
 function rollFor(
   campaign: Campaign,
   kit: Kit,
+  powers: TurnPowers,
   input: unknown
 ): { entry: CheckEntry; brief: string } {
   const raw = (input ?? {}) as {
@@ -1189,8 +1312,20 @@ function rollFor(
   // pack cannot eat the ±6 budget the scene is entitled to.
   modifiers.push(...kitModifiers(kit, raw.items, attribute, skill))
   modifiers.push(...situational)
+  // Permissions ride along at +0 and are not clamped with the situational set,
+  // because there is nothing to clamp. They are on the card so the player can
+  // see *why* a thing they could not do a moment ago is suddenly a roll — the
+  // same reason a +0 item trait is named (invariant 18).
+  modifiers.push(...powers.permissions)
 
-  const outcome = resolveCheck({ dc, modifiers })
+  // The first check a spent advantage bears on claims it. Anything left over at
+  // the end of the turn is simply gone, charge included.
+  const claimed = powers.pending.filter(entry => appliesTo(entry.applies, attribute, skill))
+  if (claimed.length > 0) {
+    powers.pending = powers.pending.filter(entry => !claimed.includes(entry))
+  }
+
+  const outcome = resolveCheck({ dc, modifiers, advantage: claimed.map(entry => entry.source) })
 
   const entry: CheckEntry = {
     kind: 'check',
@@ -1205,10 +1340,14 @@ function rollFor(
     total: outcome.total,
     margin: outcome.margin,
     band: outcome.band,
+    ...(outcome.twice ? { twice: outcome.twice } : {}),
   }
 
   const sign = outcome.margin >= 0 ? '+' : ''
   const brief = [
+    outcome.twice
+      ? `Rolled twice for ${outcome.twice.reason}, keeping the ${outcome.twice.direction === 'advantage' ? 'better' : 'worse'} of ${outcome.roll} and ${outcome.twice.discarded}.`
+      : '',
     `Rolled ${outcome.roll} on a d20, ${outcome.modifier >= 0 ? '+' : ''}${outcome.modifier} = ${outcome.total} against DC ${outcome.dc}.`,
     `Margin ${sign}${outcome.margin}.`,
     `${BAND_LABEL[outcome.band]}. ${BAND_BRIEF[outcome.band]}`,
@@ -1218,7 +1357,9 @@ function rollFor(
     // time a roll comes back; the move quoted next to the number does not.
     `YOUR MOVE: ${BAND_MOVE[outcome.band]}`,
     'Narrate this outcome. Do not restate the numbers — the player can already see them.',
-  ].join(' ')
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   return { entry, brief }
 }
@@ -1304,7 +1445,40 @@ function sheetBlock(campaign: Campaign): string {
   return `THE CHARACTER
 ${c.name} — ${c.concept}
 Attributes: ${attributes}
-Earned skills: ${skills}`
+Earned skills: ${skills}${powersBlock(campaign.kit)}`
+}
+
+/**
+ * The powers the character actually has, by id, or nothing.
+ *
+ * Without this `use_power` is a tool the model cannot reach: it is asked for
+ * the id of a power the kit holds and never told what the kit holds. Live runs
+ * bore that out exactly — a power the player named in their own message got
+ * spent, because the model could guess the id from their words, and a power
+ * they referred to by name got ignored every single time.
+ *
+ * Charges are shown because "you have this" and "you have this, twice more" are
+ * different pieces of advice, and a DM that cannot see the counter will reach
+ * for a spent power and have to be refused.
+ *
+ * Nothing is printed when there are no powers. The prompt is the DM's version
+ * of the sheet, and invariant 17 applies to it for the same reason it applies
+ * to the player's: a heading with nothing under it is an invitation to invent
+ * something to put there.
+ */
+function powersBlock(kit: Kit): string {
+  if (kit.powers.length === 0) return ''
+
+  const lines = kit.powers.map(power => {
+    const what =
+      power.shape === 'permits'
+        ? `lets them ${power.permits || 'do something they otherwise could not'}`
+        : 'makes one roll it bears on come up twice, keeping the better die'
+    const spent = power.charges.now <= 0 ? ' — SPENT, they cannot use this now' : ''
+    return `  ${power.id} "${power.name}" — ${what}. ${power.charges.now}/${power.charges.max} charges${spent}.`
+  })
+
+  return `\nThings they can do (call use_power with the id, and they still roll afterwards):\n${lines.join('\n')}`
 }
 
 function format(value: number): string {

--- a/src/app/dicebound/domain/__tests__/kit.test.ts
+++ b/src/app/dicebound/domain/__tests__/kit.test.ts
@@ -11,6 +11,7 @@ import {
   TIER_CHARGES,
   addItem,
   addPower,
+  appliesTo,
   canGrantPower,
   emptyKit,
   isRest,
@@ -19,8 +20,10 @@ import {
   levelFor,
   maxPowersAt,
   maxTierAt,
+  powerEffect,
   powerFromGrant,
   restore,
+  spendPower,
   validateItem,
   validateKit,
   validatePower,
@@ -511,5 +514,133 @@ describe('addPower', () => {
       kit = addPower(kit, powerFromGrant(grant({ id: `p${i}` }), 1, 600)!).kit
     }
     expect(kit.powers).toHaveLength(MAX_POWERS)
+  })
+})
+
+describe('spendPower', () => {
+  const kitWith = (over: Partial<Parameters<typeof powerFromGrant>[0]> = {}, tier = 1) => {
+    const power = powerFromGrant({ ...grant(), ...over }, tier, 600)!
+    return { ...emptyKit(), powers: [power] }
+  }
+
+  it('spends the charge and returns the power, and decides nothing else', () => {
+    // The whole rule as an ordering: the charge is gone before any check is
+    // rolled and without knowing whether one will land.
+    const { kit, power, reason } = spendPower(kitWith(), 'ember-hand')
+    expect(reason).toBe('')
+    expect(power?.charges.now).toBe(TIER_CHARGES[1] - 1)
+    expect(kit.powers[0].charges.now).toBe(TIER_CHARGES[1] - 1)
+    // Nothing resembling an outcome comes back — no modifier, no roll, no band.
+    expect(Object.keys(power ?? {})).not.toContain('bonus')
+  })
+
+  it('a power with no charges left cannot be spent into the negative', () => {
+    const spent = {
+      ...emptyKit(),
+      powers: [{ ...powerFromGrant(grant(), 1, 600)!, charges: { now: 0, max: 3 } }],
+    }
+    const result = spendPower(spent, 'ember-hand')
+    expect(result.power).toBeNull()
+    expect(result.kit.powers[0].charges.now).toBe(0)
+    expect(result.reason).toContain('spent')
+  })
+
+  it('says when the charge comes back, so the player is not left guessing', () => {
+    const restful = {
+      ...emptyKit(),
+      powers: [{ ...powerFromGrant(grant(), 1, 600)!, charges: { now: 0, max: 3 } }],
+    }
+    expect(spendPower(restful, 'ember-hand').reason).toContain('rest')
+  })
+
+  it('refuses a power the kit does not hold rather than inventing one', () => {
+    const result = spendPower(kitWith(), 'fireball')
+    expect(result.power).toBeNull()
+    expect(result.kit.powers[0].charges.now).toBe(TIER_CHARGES[1])
+  })
+
+  it('the same power cannot be spent twice in one turn', () => {
+    // Without this a model that liked the answer spends it three times in one
+    // message and pays for it once.
+    const kit = kitWith()
+    const first = spendPower(kit, 'ember-hand', new Set())
+    const second = spendPower(first.kit, 'ember-hand', new Set(['ember-hand']))
+    expect(second.power).toBeNull()
+    expect(second.kit.powers[0].charges.now).toBe(TIER_CHARGES[1] - 1)
+  })
+
+  it('does not mutate the kit it was given', () => {
+    const kit = kitWith()
+    spendPower(kit, 'ember-hand')
+    expect(kit.powers[0].charges.now).toBe(TIER_CHARGES[1])
+  })
+})
+
+describe('appliesTo', () => {
+  it('an empty claim covers everything — that is why a general thing is worth +0', () => {
+    expect(appliesTo({}, 'dexterity', 'balance')).toBe(true)
+  })
+
+  it('a claim that names something covers only that', () => {
+    expect(appliesTo({ attributes: ['power'] }, 'power', null)).toBe(true)
+    expect(appliesTo({ attributes: ['power'] }, 'dexterity', null)).toBe(false)
+    expect(appliesTo({ skills: ['balance'] }, 'dexterity', 'balance')).toBe(true)
+    expect(appliesTo({ skills: ['balance'] }, 'dexterity', 'quickness')).toBe(false)
+  })
+})
+
+describe('powerEffect', () => {
+  it('a permits power adds a permission to the die card, not a modifier', () => {
+    // +0, and the zero is the point. It is on the card so the player can see
+    // why a thing they could not do a moment ago is suddenly a roll — the same
+    // reason a +0 item trait is named. It is not a bonus and must never become
+    // one.
+    const power = powerFromGrant(
+      { ...grant(), shape: 'permits', permits: 'throw fire, at range' },
+      1,
+      600
+    )!
+    const effect = powerEffect(power)
+
+    expect(effect.advantage).toBeNull()
+    expect(effect.permission?.value).toBe(0)
+    expect(effect.permission?.label).toContain('throw fire, at range')
+  })
+
+  it('an advantage power carries no number at all', () => {
+    // It moves the odds without moving anything anyone can point at, which is
+    // why it sits outside the ±6 budget and the +3 kit ceiling.
+    const power = powerFromGrant(
+      { ...grant(), shape: 'advantage', applies: { attributes: ['power'] } },
+      1,
+      600
+    )!
+    const effect = powerEffect(power)
+
+    expect(effect.permission).toBeNull()
+    expect(effect.advantage?.source.direction).toBe('advantage')
+    expect(JSON.stringify(effect.advantage?.source)).not.toMatch(/\d/)
+  })
+
+  it('an advantage power that matches nothing this turn still costs the charge', () => {
+    // The charge is spent by spendPower, before anything is rolled and without
+    // knowing whether a matching check will ever come. The effect it produces
+    // is only ever *offered* to a check — nothing here can hand the charge
+    // back, and that is what makes spending it a real decision.
+    const power = powerFromGrant(
+      { ...grant(), shape: 'advantage', applies: { attributes: ['power'] } },
+      1,
+      600
+    )!
+    const kit = { ...emptyKit(), powers: [power] }
+
+    const spent = spendPower(kit, power.id)
+    expect(spent.kit.powers[0].charges.now).toBe(TIER_CHARGES[1] - 1)
+
+    const effect = powerEffect(spent.power!)
+    // The turn's only check is a Dexterity one. The power claims Power, so
+    // nothing claims it — and the charge above is still gone.
+    expect(appliesTo(effect.advantage!.applies, 'dexterity', 'balance')).toBe(false)
+    expect(spent.kit.powers[0].charges.now).toBe(TIER_CHARGES[1] - 1)
   })
 })

--- a/src/app/dicebound/domain/__tests__/turn.test.ts
+++ b/src/app/dicebound/domain/__tests__/turn.test.ts
@@ -6,6 +6,7 @@ import {
   RECALL_TOOL,
   ROLL_CHECK_TOOL,
   type ToolCall,
+  USE_POWER_TOOL,
   partitionTurnCalls,
 } from '@/app/dicebound/domain/turn'
 
@@ -142,6 +143,34 @@ describe('partitionTurnCalls and grant_power', () => {
     ])
 
     expect(powerGrants.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+    expect(premature.map(c => c.id)).toEqual(['b'])
+  })
+})
+
+const usePowerCall = (id: string): ToolCall & { id: string } => ({
+  id,
+  name: USE_POWER_TOOL,
+  input: { id: 'ember-hand' },
+})
+
+describe('partitionTurnCalls and use_power', () => {
+  it('does not end the turn — the DM has to be told what the power made available', () => {
+    const { powerUses, ending } = partitionTurnCalls([usePowerCall('a')])
+
+    expect(powerUses.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+  })
+
+  it('discards narration written in the same breath as spending a power', () => {
+    // Invariant 2 again. That narration was composed before the power's effect
+    // existed — before the model knew whether the charge was even there.
+    const { powerUses, ending, premature } = partitionTurnCalls([
+      usePowerCall('a'),
+      narrate('b', 'Fire blooms in your palm and the guard goes down.'),
+    ])
+
+    expect(powerUses.map(c => c.id)).toEqual(['a'])
     expect(ending).toBeNull()
     expect(premature.map(c => c.id)).toEqual(['b'])
   })

--- a/src/app/dicebound/domain/kit.ts
+++ b/src/app/dicebound/domain/kit.ts
@@ -25,6 +25,7 @@ import { bool, boundedInt, isPlainObject, oneOf, slug, str } from './validate'
 import { PLAYER_ID } from './world'
 
 import type { AttributeId, SkillId } from './attributes'
+import type { AdvantageSource, Modifier } from './dice'
 import type { EntityId, World } from './world'
 
 /** When a trait or power applies. Empty means "the DM decides, in the fiction". */
@@ -490,7 +491,23 @@ export function kitModifiers(
 }
 
 function traitApplies(trait: Trait, attribute: AttributeId, skill: SkillId | null): boolean {
-  const { attributes, skills } = trait.applies
+  return appliesTo(trait.applies, attribute, skill)
+}
+
+/**
+ * Does a claim about where something applies cover this particular check?
+ *
+ * Shared by item traits and by powers, because they are the same question asked
+ * about the same two fields. An empty claim covers everything, deliberately —
+ * that is why a rope that is good in general is good for +0, and why a power
+ * that names nothing applies wherever the fiction says it does.
+ */
+export function appliesTo(
+  applies: Applicability,
+  attribute: AttributeId,
+  skill: SkillId | null
+): boolean {
+  const { attributes, skills } = applies
   const claimsSomething = (attributes?.length ?? 0) > 0 || (skills?.length ?? 0) > 0
   if (!claimsSomething) return true
 
@@ -699,4 +716,125 @@ export function addPower(kit: Kit, power: Power): { kit: Kit; added: boolean } {
   if (kit.powers.some(held => held.id === power.id)) return { kit, added: false }
   if (kit.powers.length >= MAX_POWERS) return { kit, added: false }
   return { kit: { ...kit, powers: [...kit.powers, power] }, added: true }
+}
+
+/** What spending a charge produced: the power, or the reason there is none. */
+export interface PowerSpend {
+  kit: Kit
+  /** Null when nothing was spent — see `reason`. */
+  power: Power | null
+  /** Addressed to the DM, on a spend as well as a refusal. */
+  reason: string
+}
+
+/**
+ * Spend a charge, and spend it whether or not anything comes of it.
+ *
+ * This is the rule the whole epic rests on, expressed as an ordering: the
+ * charge goes **first**, before any check is rolled and without knowing whether
+ * one will land. A power that only costs you something when it works is not a
+ * choice, it is a bonus with ceremony — and the moment using a power is free on
+ * a miss, the interesting question ("is this the moment?") stops being a
+ * question at all.
+ *
+ * Nothing here decides an outcome. It returns the power so the caller can turn
+ * it into a permission or into advantage; it never returns a modifier, and it
+ * never touches the die.
+ *
+ * `spentThisTurn` is passed in rather than tracked here because the domain has
+ * no idea what a turn is. Without it a model that liked the answer could spend
+ * the same power three times in one message and pay for it once.
+ */
+export function spendPower(
+  kit: Kit,
+  id: unknown,
+  spentThisTurn: ReadonlySet<string> = new Set()
+): PowerSpend {
+  const wanted = slug(id)
+  if (!wanted) return { kit, power: null, reason: 'That did not name a power.' }
+
+  const held = kit.powers.find(power => power.id === wanted)
+  // Refused, not invented. A power the character does not have is not a power
+  // they can use, however good the moment for it looks.
+  if (!held) {
+    return {
+      kit,
+      power: null,
+      reason: `They cannot do that. ${wanted} is not something they have. Narrate the moment without it.`,
+    }
+  }
+
+  if (spentThisTurn.has(wanted)) {
+    return {
+      kit,
+      power: null,
+      reason: `${held.name} has already been used this turn. Once is all they get.`,
+    }
+  }
+
+  if (held.charges.now <= 0) {
+    return {
+      kit,
+      power: null,
+      reason: `${held.name} is spent — no charges left, and they do not come back ${held.refresh === 'rest' ? 'until they rest properly' : 'until the next chapter'}. Narrate them reaching for it and finding nothing there.`,
+    }
+  }
+
+  // Floored, not merely decremented. `validatePower` re-derives `max` on the
+  // way in but nothing re-derives `now`, so the floor has to be enforced at the
+  // one place that moves it.
+  const spent: Power = {
+    ...held,
+    charges: { ...held.charges, now: Math.max(0, held.charges.now - 1) },
+  }
+
+  return {
+    kit: { ...kit, powers: kit.powers.map(power => (power.id === wanted ? spent : power)) },
+    power: spent,
+    reason: '',
+  }
+}
+
+/**
+ * What a spent power leaves on the table — and notably, what it does not.
+ *
+ * Neither branch is an outcome and neither is a magnitude the model chose. A
+ * `permits` power becomes a die-card row worth exactly **+0**: the capability
+ * is named, because the reason is real even when the number is nothing
+ * (invariant 18), and the check still has to be rolled at whatever DC the
+ * fiction sets. An `advantage` power becomes a flag with no number in it at
+ * all.
+ *
+ * This is a function rather than two lines at the call site so that the one
+ * thing worth protecting — *a power never resolves an outcome* — is somewhere a
+ * test can point at. The bonus is a literal zero here on purpose. If a later
+ * change ever wants it to be otherwise, it has to edit this line and explain
+ * itself, rather than quietly adding a number where the model was passing one
+ * through.
+ */
+export interface PowerEffect {
+  /** A +0 row for the die card, for a `permits` power. */
+  permission: Modifier | null
+  /** A flag for the next matching check, for an `advantage` power. */
+  advantage: { source: AdvantageSource; applies: Applicability } | null
+}
+
+export function powerEffect(power: Power): PowerEffect {
+  if (power.shape === 'advantage') {
+    return {
+      permission: null,
+      advantage: {
+        source: { direction: 'advantage', reason: power.name },
+        applies: power.applies,
+      },
+    }
+  }
+
+  return {
+    permission: {
+      label: power.permits ? `${power.name} — ${power.permits}` : power.name,
+      value: 0,
+    },
+    advantage: null,
+  }
 }

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -23,6 +23,7 @@ export const NARRATE_TOOL = 'narrate'
 export const RECALL_TOOL = 'recall'
 export const GRANT_ITEM_TOOL = 'grant_item'
 export const GRANT_POWER_TOOL = 'grant_power'
+export const USE_POWER_TOOL = 'use_power'
 
 /** One pass's tool calls, sorted into what the loop does with each. */
 export interface TurnCalls<T extends ToolCall> {
@@ -42,6 +43,12 @@ export interface TurnCalls<T extends ToolCall> {
    * got nothing, which is a normal outcome rather than an error.
    */
   powerGrants: T[]
+  /**
+   * `use_power` calls. The charge is spent before anything is rolled, so like
+   * every other bucket here the turn continues rather than ending — the DM has
+   * to be told what the power made available before it can narrate around it.
+   */
+  powerUses: T[]
   /** The `narrate` call that ends the turn, or null while the turn continues. */
   ending: T | null
   /**
@@ -73,6 +80,7 @@ export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T>
   const recalls = calls.filter(call => call.name === RECALL_TOOL)
   const grants = calls.filter(call => call.name === GRANT_ITEM_TOOL)
   const powerGrants = calls.filter(call => call.name === GRANT_POWER_TOOL)
+  const powerUses = calls.filter(call => call.name === USE_POWER_TOOL)
   const narrations = calls.filter(call => call.name === NARRATE_TOOL)
 
   // A narration sent alongside a lookup is as blind as one sent alongside a
@@ -80,8 +88,14 @@ export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T>
   // for cannot be in it. A power grant belongs in this list for a sharper
   // reason than the others — the grant can be *refused*, and narration written
   // beside it describes the character learning something they did not get.
-  if (rolls.length > 0 || recalls.length > 0 || grants.length > 0 || powerGrants.length > 0) {
-    return { rolls, recalls, grants, powerGrants, ending: null, premature: narrations }
+  if (
+    rolls.length > 0 ||
+    recalls.length > 0 ||
+    grants.length > 0 ||
+    powerGrants.length > 0 ||
+    powerUses.length > 0
+  ) {
+    return { rolls, recalls, grants, powerGrants, powerUses, ending: null, premature: narrations }
   }
 
   // Only the first narration ends the turn. A second one is a duplicate, not a
@@ -91,6 +105,7 @@ export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T>
     recalls,
     grants,
     powerGrants,
+    powerUses,
     ending: narrations[0] ?? null,
     premature: narrations.slice(1),
   }


### PR DESCRIPTION
Closes #3561. Turn lane. Depends on #3559 and #3560, both merged.

## The rule, expressed as an ordering

**A power never resolves an outcome; it only makes one available.** The charge is spent **first** — before any check is rolled, and without knowing whether one will land. A power that only costs you something when it works is not a choice, it is a bonus with ceremony, and the moment using one is free on a miss the interesting question ("is this the moment?") stops being a question.

By shape:

- **`permits`** — becomes a **+0 row on the die card**, named, exactly the way a +0 item trait is (invariant 18). The player can see why a thing they could not do a moment ago is suddenly a roll. The DM still calls `roll_check`.
- **`advantage`** — becomes a flag the next check it bears on claims. If nothing this turn matches, **the charge is gone anyway.** Refunding it would make spending it free, and spending it on the wrong moment is a real decision.

`powerEffect` is a domain function rather than two lines at the call site, so the one thing worth protecting has somewhere a test can point at. The bonus is a literal `0` in there on purpose: a later change that wants otherwise has to edit that line and explain itself, rather than quietly passing a number through.

## Two things the live runs found that the suite could not

The issue said this needs a real turn because "a DM that has started treating a power as an outcome is invisible to the test suite." It was invisible, and it was happening. Both of these were caught only by playing it.

### The DM was never told what the character can do

`sheetBlock` listed attributes and earned skills and nothing else. So `use_power` asked the model for the id of a power the kit holds — and never told it what the kit holds.

The advantage power was **ignored in 4 runs out of 4**. The permits power was only ever spent because the player's own words ("I say the ember word") let the model guess the id. Powers are now printed in the prompt with their ids and charge counts, and nothing is printed when there are none — invariant 17 applies to the DM's copy of the sheet for the same reason it applies to the player's.

**The pack has exactly the same gap and it predates this change.** `grant_item` has been live since `f6c4df21` and the DM has never been shown what the character carries either, so an item only reaches `roll_check`'s `items` field when the player happens to mention it. I have not fixed that here — it belongs to #3521 and to whoever takes #3556 — but it should not sit unnoticed.

### The DM spent the charge and then narrated the result

Fire thrown, guard down, no die. The prompt's standing guidance that "most turns are not checks" is right about most turns and wrong about this one. The `permits` tool result is now blunter than any other result in the file, and says in as many words that narrating without rolling means the power decided the outcome.

### Before and after, same seeded scenario

| | permits: rolled a check | advantage: charge spent, two dice |
| --- | --- | --- |
| before | 1 of 4 runs | 0 of 4 runs |
| after | **3 of 3** | **3 of 3** |

A representative after-run of each:

```
PERMITS    charges 2/3   DC 15 power/influence roll=20 total=20 critical-success
           card: Power +2 | twenty feet of open yard -2 | Ember Word — throw fire, at range +0

ADVANTAGE  charges 2/3   DC 18 dexterity/quickness roll=19 total=18 success
                         [twice: advantage "Steady Hand", discarded 3]
           card: Dexterity +1 | no cover in the yard -2
```

Note what is on each card. The permission is there at **+0**. The advantage is **not on the card at all** — no number moved, which is the whole reason it sits outside the ±6 budget and the +3 kit ceiling. Across the three permits runs the outcomes were a critical failure, a critical success and a strong failure: the power made the attempt possible and decided nothing.

## Edges

- No charges left: refused, the reply says when they come back, and `Math.max(0, …)` floors it where it is spent — `validatePower` re-derives `max` on the way in but nothing re-derives `now`.
- A power the kit does not hold is refused, not invented.
- The same power cannot be spent twice in one turn; `spentThisTurn` is passed in because the domain has no idea what a turn is.
- `MAX_CHECKS` is untouched, so a power cannot buy an extra pass — the step counter bounds passes regardless of what is called (invariant 3).
- Narration sent in the same message as `use_power` is discarded and asked for again (invariant 2). It was written before the model knew whether the charge was even there.
- Spends are dispatched **before** rolls in the same pass, so a model that sends both in one message still gets its permission onto its own die card.

`usePower` is named `spendPower` in the end: ESLint reads a `use`-prefixed function as a React hook, and spending is the better name anyway.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  9 passed (9)
      Tests  240 passed (240)      # +13: spendPower, powerEffect, appliesTo, partition

$ npx tsc --noEmit 2>&1 | grep dicebound          # empty
$ npx eslint src/app/dicebound src/app/api/v1/dicebound src/lib/dicebound
eslint=0
$ npm run lint:routes
check-route-slugs: ok
$ npx prettier --write <touched files>            # unchanged
```

Plus the six live turns tabulated above, driven through the real route handler.