### PR TITLE
feat(dicebound): charges come back only when code says you rested

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -85,11 +85,14 @@ import {
   addPower,
   appliesTo,
   canGrantPower,
+  chargesRestored,
   itemFromGrant,
   kitModifiers,
   levelFor,
   powerEffect,
   powerFromGrant,
+  restFor,
+  restore,
   spendPower,
 } from '@/app/dicebound/domain/kit'
 import {
@@ -103,6 +106,7 @@ import {
   applyTurn,
   partitionTurnCalls,
 } from '@/app/dicebound/domain/turn'
+import { bool } from '@/app/dicebound/domain/validate'
 import {
   EDGE_KINDS,
   ENTITY_KINDS,
@@ -801,6 +805,7 @@ async function playTurn(
   let dropped: number | undefined
   let chapters: number | undefined
   let repaired: World | undefined
+  let chapterTurned = false
 
   if (campaign.transcript.length > CONDENSE_AT) {
     const cut = campaign.transcript.length - TRANSCRIPT_WINDOW
@@ -822,6 +827,12 @@ async function playTurn(
           archivedAt: campaign.world.clock.elapsed,
         })
         chapters = campaign.chapters + 1
+        // A chapter boundary is the rarer refresh, and it is tied to the
+        // archive *landing* rather than to the condense being attempted. A
+        // failed archive already costs the player a slice of transcript; it
+        // must not also hand them back charges for a chapter that was never
+        // written, or the counter and the sheet start disagreeing.
+        chapterTurned = true
       } catch (error) {
         // A failed archive must not cost the player their turn. It does cost
         // this slice of transcript, which is why it is logged loudly rather
@@ -878,6 +889,21 @@ Resolve it, then call narrate with what happens.`,
   // Spent powers, held for the length of the turn. Anything still pending when
   // the turn ends is discarded with its charge already gone.
   const powers: TurnPowers = { permissions: [], pending: [], spent: new Set() }
+  // Latched for the turn. A fuse-interrupted turn narrates twice, and without
+  // this the second narration could rest again off the same span — "a week of
+  // travel is not seven rests" has to survive the one path that runs the clock
+  // more than once.
+  let rested = false
+  let restoredCharges = 0
+
+  // The chapter refresh happens here rather than inside the condense block
+  // because `kit` does not exist yet up there, and because a refill that
+  // happened before the turn ran would be invisible to anything the turn did.
+  if (chapterTurned) {
+    const refreshed = restore(kit, 'chapter')
+    restoredCharges += chargesRestored(kit, refreshed)
+    kit = refreshed
+  }
 
   for (let step = 0; step <= MAX_CHECKS; step++) {
     const lastStep = step === MAX_CHECKS
@@ -915,8 +941,23 @@ Resolve it, then call narrate with what happens.`,
         narration = narration ? `${narration}\n\n${text}` : text
       }
 
-      const applied = applyWorldDelta(world, (ending.input ?? {}) as Record<string, unknown>)
+      const delta = (ending.input ?? {}) as Record<string, unknown>
+      const before = world.clock.elapsed
+      const applied = applyWorldDelta(world, delta)
       world = applied.world
+
+      // Measured from the clock the server actually moved, not from the
+      // `elapsed` the model asked for. `advance` stops at a fuse, so a DM that
+      // claims a week and runs into something four hours in has had four hours
+      // — and four hours is not a rest. The world is read after the deltas so a
+      // thread that fired during the span is already urgent by the time this
+      // asks.
+      if (!rested) {
+        const outcome = restFor(kit, world, world.clock.elapsed - before, bool(delta.safe))
+        kit = outcome.kit
+        rested = outcome.rested
+        restoredCharges += outcome.restored
+      }
 
       // The clock ran into an open thread's fuse. The turn is not over: the
       // player asked for a week and got four hours, and they are owed the
@@ -1026,6 +1067,26 @@ Resolve it, then call narrate with what happens.`,
   }
 
   entries.push({ kind: 'narration', text: narration })
+
+  // A quiet line, in the game's own voice, and only when something actually
+  // came back. Not a toast and not a banner: the cave is light and ceremony
+  // lives inside the game (CLAUDE.md #2), and this is a small thing that
+  // happened in the fiction rather than an achievement. A rest that restored
+  // nothing — because nothing was spent — says nothing at all, or the player
+  // learns to read it as noise.
+  //
+  // It goes in the transcript rather than into a field, which is also how the
+  // DM finds out: next turn it reads this line back, and the powers block in
+  // the prompt already shows the refilled counts.
+  if (restoredCharges > 0) {
+    entries.push({
+      kind: 'narration',
+      text: rested
+        ? 'You sleep, and it is a real one. Whatever it is you spend doing the thing only you can do, it is back where you left it.'
+        : 'Something settles, the way it does when one part of a story finishes and another has not started yet. What you spent has come back.',
+    })
+  }
+
   return { entries, synopsis, dropped, world, chapters, kit }
 }
 

--- a/src/app/dicebound/domain/__tests__/kit.test.ts
+++ b/src/app/dicebound/domain/__tests__/kit.test.ts
@@ -22,6 +22,7 @@ import {
   maxTierAt,
   powerEffect,
   powerFromGrant,
+  restFor,
   restore,
   spendPower,
   validateItem,
@@ -642,5 +643,94 @@ describe('powerEffect', () => {
     // nothing claims it — and the charge above is still gone.
     expect(appliesTo(effect.advantage!.applies, 'dexterity', 'balance')).toBe(false)
     expect(spent.kit.powers[0].charges.now).toBe(TIER_CHARGES[1] - 1)
+  })
+})
+
+describe('restFor', () => {
+  const spentKit = (refresh: 'rest' | 'chapter' = 'rest') => ({
+    ...emptyKit(),
+    powers: [
+      {
+        ...powerFromGrant(grant(), 1, 600)!,
+        refresh,
+        charges: { now: 0, max: 3 },
+      },
+    ],
+  })
+
+  const thread = (pressure: 'urgent' | 'pressing' | 'patient'): Entity =>
+    ({
+      id: `thread-${pressure}`,
+      kind: 'thread',
+      name: 'the thing catching up',
+      note: '',
+      state: '',
+      status: 'active',
+      firstSeen: 0,
+      lastSeen: 0,
+      threadKind: 'threat',
+      resolution: 'open',
+      due: null,
+      pressure,
+      firings: 0,
+    }) as Entity
+
+  it('six hours in a safe place with nothing urgent is a rest', () => {
+    const result = restFor(spentKit(), worldWith({}), REST_MINUTES, true)
+    expect(result.rested).toBe(true)
+    expect(result.kit.powers[0].charges.now).toBe(3)
+    expect(result.restored).toBe(3)
+  })
+
+  it('six hours with an urgent thread open is not a rest, however safe the turn claimed to be', () => {
+    // The condition the model cannot talk its way around: an open thread at
+    // urgent pressure is a fact about the graph, not a claim.
+    const world = worldWith({ 'thread-urgent': thread('urgent') })
+    const result = restFor(spentKit(), world, REST_MINUTES, true)
+    expect(result.rested).toBe(false)
+    expect(result.kit.powers[0].charges.now).toBe(0)
+  })
+
+  it('a thread that is merely pressing does not stop a rest', () => {
+    const world = worldWith({ 'thread-pressing': thread('pressing') })
+    expect(restFor(spentKit(), world, REST_MINUTES, true).rested).toBe(true)
+  })
+
+  it('a chapter refresh does not come back on a rest', () => {
+    const result = restFor(spentKit('chapter'), worldWith({}), REST_MINUTES, true)
+    // The span qualified — but nothing this character has refreshes on it.
+    expect(result.rested).toBe(true)
+    expect(result.kit.powers[0].charges.now).toBe(0)
+    expect(result.restored).toBe(0)
+  })
+
+  it('a rest refresh does not wait for a chapter', () => {
+    const kit = spentKit('rest')
+    expect(restore(kit, 'chapter').powers[0].charges.now).toBe(0)
+    expect(restore(kit, 'rest').powers[0].charges.now).toBe(3)
+  })
+
+  it('a week of travel refills once, not seven times', () => {
+    // Nothing here counts spans. One call, one refill, and the caller latches
+    // `rested` so a turn that narrates twice cannot rest twice — restoring to
+    // `max` is idempotent, which is the other half of the guarantee.
+    const week = 7 * 24 * 60
+    const once = restFor(spentKit(), worldWith({}), week, true)
+    expect(once.restored).toBe(3)
+
+    const again = restFor(once.kit, worldWith({}), week, true)
+    expect(again.restored).toBe(0)
+    expect(again.kit.powers[0].charges.now).toBe(3)
+  })
+
+  it('says nothing came back when nothing was spent', () => {
+    const full = { ...emptyKit(), powers: [powerFromGrant(grant(), 1, 600)!] }
+    const result = restFor(full, worldWith({}), REST_MINUTES, true)
+    expect(result.rested).toBe(true)
+    expect(result.restored).toBe(0)
+  })
+
+  it('an unsafe span is not a rest even with time and quiet', () => {
+    expect(restFor(spentKit(), worldWith({}), REST_MINUTES, false).rested).toBe(false)
   })
 })

--- a/src/app/dicebound/domain/kit.ts
+++ b/src/app/dicebound/domain/kit.ts
@@ -22,7 +22,7 @@
  */
 import { isAttributeId, isSkillId } from './attributes'
 import { bool, boundedInt, isPlainObject, oneOf, slug, str } from './validate'
-import { PLAYER_ID } from './world'
+import { PLAYER_ID, openThreads } from './world'
 
 import type { AttributeId, SkillId } from './attributes'
 import type { AdvantageSource, Modifier } from './dice'
@@ -221,14 +221,46 @@ export function isRest(minutesElapsed: number, safe: boolean, urgentThreat: bool
   return minutesElapsed >= REST_MINUTES && safe && !urgentThreat
 }
 
-export function restore(kit: Kit): Kit {
+/**
+ * Refill the powers that refresh on this boundary, and only those.
+ *
+ * Two boundaries exist and they are deliberately different sizes. A rest is
+ * something a character can decide to have; a chapter is something the story
+ * does to them. A tier 3 power with one charge is meant to be the second kind —
+ * if a rest brought it back, "once a chapter" would be a label rather than a
+ * cost, and the whole reason the tier table is shaped the way it is would stop
+ * biting.
+ *
+ * Defaults to `'rest'` because that is what nearly every power does and because
+ * the previous signature took no argument at all: an existing call that has not
+ * been updated keeps meaning exactly what it used to.
+ */
+export function restore(kit: Kit, boundary: Refresh = 'rest'): Kit {
   return {
     ...kit,
-    powers: kit.powers.map(power => ({
-      ...power,
-      charges: { ...power.charges, now: power.charges.max },
-    })),
+    powers: kit.powers.map(power =>
+      power.refresh === boundary
+        ? { ...power, charges: { ...power.charges, now: power.charges.max } }
+        : power
+    ),
   }
+}
+
+/**
+ * How many charges came back, so the turn can say so only when it should.
+ *
+ * A rest that restored nothing — because nothing was spent, or because
+ * everything spent refreshes on a chapter instead — must not produce a line
+ * telling the player their powers returned. Counting is cheaper than making
+ * every caller diff two kits, and it keeps "did anything happen" out of the
+ * rendering.
+ */
+export function chargesRestored(before: Kit, after: Kit): number {
+  const was = new Map(before.powers.map(power => [power.id, power.charges.now]))
+  return after.powers.reduce(
+    (sum, power) => sum + Math.max(0, power.charges.now - (was.get(power.id) ?? power.charges.now)),
+    0
+  )
 }
 
 // -------------------------------------------------------------- validation
@@ -837,4 +869,39 @@ export function powerEffect(power: Power): PowerEffect {
     },
     advantage: null,
   }
+}
+
+export interface RestResult {
+  kit: Kit
+  /** True when the span qualified as a rest, whether or not anything refilled. */
+  rested: boolean
+  /** Charges that actually came back. Zero means the turn should say nothing. */
+  restored: number
+}
+
+/**
+ * Decide whether the span that just passed was a rest, and refill if it was.
+ *
+ * Three conditions, and the point of there being three is that the model
+ * controls at most two of them. It reports `elapsed` and it reports `safe` —
+ * both already constrained elsewhere, since `advance` will not step a fuse and
+ * the clock is the server's. The third it cannot touch at all: an open thread
+ * at `urgent` pressure is a fact about the graph, not a claim, so a DM cannot
+ * declare a peaceful evening while the thing chasing the player is one scene
+ * away.
+ *
+ * The world is read **after** the turn's deltas on purpose. A thread that fired
+ * during the span is exactly the case a rest must not survive, and reading the
+ * world as it stood before the turn would miss it.
+ *
+ * One qualifying span refills once. A week of travel is not seven rests — this
+ * is called once for the turn, and `rested` is what the caller latches so a
+ * turn that narrates twice cannot rest twice.
+ */
+export function restFor(kit: Kit, world: World, minutesElapsed: number, safe: boolean): RestResult {
+  const urgent = openThreads(world).some(thread => thread.pressure === 'urgent')
+  if (!isRest(minutesElapsed, safe, urgent)) return { kit, rested: false, restored: 0 }
+
+  const next = restore(kit, 'rest')
+  return { kit: next, rested: true, restored: chargesRestored(kit, next) }
 }

--- a/src/app/dicebound/domain/suggest.ts
+++ b/src/app/dicebound/domain/suggest.ts
@@ -1,0 +1,77 @@
+/**
+ * The three lines offered beside the composer, cleaned.
+ *
+ * A suggestion is not a mechanic. It never touches the dice, it is never
+ * stored, and the campaign does not know it existed — the whole feature is a
+ * string that lands in the text field for the player to edit or ignore. So the
+ * only domain rule here is what makes a *usable* string, and it lives apart
+ * from the route because that is the half worth testing.
+ *
+ * What this deliberately does not do is police voice. The prompt asks for first
+ * person and an attempt rather than an outcome, and a line that comes back in
+ * the wrong register is a prompt to fix, not a line to drop: dropping it leaves
+ * the player with two chips and no idea why.
+ */
+
+/** How many are offered. Three fits one row on a phone and reads as a choice rather than a menu. */
+export const SUGGESTION_COUNT = 3
+
+/**
+ * The longest a chip may be.
+ *
+ * Not a style rule — the prompt asks for about a dozen words and mostly gets
+ * them. This is the guard against a model that answers with a paragraph, which
+ * on a phone would push the composer off the screen.
+ */
+export const MAX_SUGGESTION = 120
+
+/** Leading list furniture a model adds when it thinks it is writing a list. */
+const FURNITURE = /^\s*(?:[-*•]|\d+[.)])\s*/
+
+/** Matched pairs of quotes around the whole line, which come back often enough to be worth stripping. */
+const WRAPPED = /^(["'“”‘’])(.*)\1$/
+
+function tidy(value: unknown): string {
+  if (typeof value !== 'string') return ''
+
+  const flat = value.replace(FURNITURE, '').replace(/\s+/g, ' ').trim()
+  const unwrapped = WRAPPED.exec(flat)?.[2]?.trim() ?? flat
+
+  if (unwrapped.length <= MAX_SUGGESTION) return unwrapped
+
+  // Cut back to a word boundary. A chip that ends mid-word reads as a bug,
+  // and this string is about to be dropped into a field the player edits —
+  // half a word is a worse starting point than a slightly shorter sentence.
+  const cut = unwrapped.slice(0, MAX_SUGGESTION)
+  const space = cut.lastIndexOf(' ')
+  return (space > MAX_SUGGESTION / 2 ? cut.slice(0, space) : cut).trim()
+}
+
+/**
+ * Whatever the model sent, turned into at most three offerable lines.
+ *
+ * Deduplication is case-insensitive and it matters more than it looks. The one
+ * thing this feature must not do is offer the same move three times: three
+ * chips that all say the obvious thing is worse than no chips, because it tells
+ * the player the scene has one exit.
+ */
+export function cleanSuggestions(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+
+  const seen = new Set<string>()
+  const out: string[] = []
+
+  for (const entry of value) {
+    const line = tidy(entry)
+    if (!line) continue
+
+    const key = line.toLowerCase()
+    if (seen.has(key)) continue
+
+    seen.add(key)
+    out.push(line)
+    if (out.length === SUGGESTION_COUNT) break
+  }
+
+  return out
+}

--- a/src/lib/dicebound/anthropic.ts
+++ b/src/lib/dicebound/anthropic.ts
@@ -29,9 +29,21 @@ export const DM_MODEL = 'claude-opus-5'
 /**
  * Condensing old turns into a synopsis is bookkeeping the player never reads
  * directly, and it happens on a turn that is already slow. A smaller model is
- * the right trade here and nowhere else in this game.
+ * the right trade here, and nowhere else that writes the story.
  */
 export const UTILITY_MODEL = 'claude-sonnet-5'
+
+/**
+ * The three lines offered beside the composer.
+ *
+ * The smallest model in the family, and not a compromise. The job is to read
+ * one scene and write three sentences a player might plausibly type — a
+ * fraction of what the dungeon master is doing, with none of the arithmetic and
+ * none of the world to keep. What it needs instead is speed: these arrive after
+ * the narration the player is still reading, and a suggestion that lands after
+ * they have already started typing may as well not have come at all.
+ */
+export const SUGGEST_MODEL = 'claude-haiku-4-5-20251001'
 
 export interface ToolDef {
   name: string


### PR DESCRIPTION
Closes #3562. Turn lane, plus `domain/kit.ts`. Depends on #3560 and #3561, both merged.

## Why three conditions

`isRest` and `restore` existed and nothing called them, so `refresh: 'rest'` was a string in a record.

The reason rest is three conditions rather than one is that a model deciding what counts as a rest decides when its own charges come back. It controls at most two of them, and both are already constrained: `advance` will not step a fuse, and the clock is the server's. The third it cannot touch at all — **an open thread at `urgent` pressure is a fact about the graph, not a claim**, so a DM cannot declare a peaceful evening while the thing chasing the player is one scene away.

## Two details that would have been quietly wrong

**The span is measured from the clock the server actually moved**, not from the `elapsed` the model asked for. A DM that claims a week and runs into a fuse four hours in has had four hours, and four hours is not a rest.

**The world is read after the turn's deltas.** A thread that fired *during* the span is precisely the case a rest must not survive; reading the world as it stood before the turn would miss it.

## restore takes a boundary now

It refilled everything. A rest is something a character can decide to have; a chapter is something the story does to them — and if a rest brought back a tier 3 power, "once a chapter" would be a label rather than a cost, and the shape of the tier table would stop biting. The parameter defaults to `'rest'` so the pre-existing call site keeps meaning what it did.

The chapter refresh is tied to the archive **landing**, not to `condense` being attempted. A failed archive already costs the player a slice of transcript; it must not also hand back charges for a chapter that was never written, or `chapters` and the sheet start disagreeing.

## One span, one refill

`rested` is latched for the turn, so the one path that narrates twice — a fuse interruption — cannot rest twice off the same span. Restoring to `max` is idempotent besides, which is the other half of the guarantee, and there is a test for a week of travel refilling once.

## What the player sees

One quiet line, in the game's own voice, and **only when something actually came back**. A rest that restored nothing — nothing was spent, or everything spent refreshes on a chapter — says nothing at all, or the player learns to read it as noise. Not a toast and not a banner: the cave is light and ceremony lives inside the game (CLAUDE.md #2), and this is a small thing that happened in the fiction.

It goes into the transcript rather than a field, which is also how the DM finds out: next turn it reads the line back, and `powersBlock` already shows the refilled counts. The issue asked for the DM to be told "in the tool result", but the restore lands at `narrate`, which is terminal — there is no tool result after it. The transcript line plus the powers block is the same information at the same moment, and it is the only place it can go without inventing a pass.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  10 passed (10)
      Tests  256 passed (256)      # +8 restFor/restore-by-boundary

$ npx tsc --noEmit 2>&1 | grep dicebound          # empty
$ npx eslint src/app/dicebound src/app/api/v1/dicebound src/lib/dicebound
eslint=0
$ npm run lint:routes
check-route-slugs: ok
```

### Real turns

Same seeded night's sleep with a fully spent power, run twice:

```
NOBODY FOLLOWING (quiet)      charges: 3/3 (was 0/3)   clock: 600 -> 1080
  · "The bar drops into its bracket with a sound like a decision…"
  · "You sleep, and it is a real one. Whatever it is you spend doing the thing only
     you can do, it is back where you left it."

RIDERS ON THE ROAD (urgent)   charges: 0/3 (was 0/3)   clock: 600 -> 675
  · "The bar drops into its iron cradle… You lie down on the bench in the warm dark…"
```

Worth being precise about the second one: the DM only advanced **75 minutes**, because the fiction itself cut the night short with riders on the road. So that run confirms the wiring end to end but the *elapsed* gate is what caught it, not the urgent-thread gate. The urgent-thread condition is isolated in the suite instead — `'six hours with an urgent thread open is not a rest, however safe the turn claimed to be'`.