### PR TITLE
[micro-land] Data model: in-world Spawner object type

### DIFF
--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -530,3 +530,21 @@ export const NEST_DECAY_SECONDS = 120
  * harness — if starvation still dominates, the reach problem is not solved.
  */
 export const LIFESPAN_SCALE = 10
+
+/**
+ * Default interval between spawner emissions, in seconds.
+ *
+ * Ten seconds lets a new world populate without overwhelming the population
+ * caps, while still being fast enough to notice. Adjust per-spawner at
+ * placement time.
+ */
+export const SPAWNER_DEFAULT_INTERVAL = 10
+
+/**
+ * Default local-population cap for a spawner.
+ *
+ * A spawner suppresses its next emission if this many creatures of the same
+ * species are already within maxLocal tiles. Keeps each spawner from flooding
+ * a small area while still letting the species spread.
+ */
+export const SPAWNER_DEFAULT_MAX_LOCAL = 5

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -65,6 +65,8 @@ export function createWorld(seed = 1337): WorldState {
     natives: [],
     nextPlantSeed: 0,
     dormant: false,
+    spawners: [],
+    nextSpawnerId: 1,
   }
 }
 
@@ -666,6 +668,7 @@ export function seedStarters(w: WorldState, themeId: string, rng: Rng): void {
 export function clearCreatures(w: WorldState): void {
   w.creatures.length = 0
   w.particles.length = 0
+  w.spawners.length = 0
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -739,6 +739,27 @@ export interface Nest {
   decaySeconds: number
 }
 
+/**
+ * An in-world object that continuously emits creatures of a chosen species.
+ *
+ * Placed by the player via the toolbar. Counts down a cooldown each tick and
+ * drops one creature when it reaches zero, subject to local and global
+ * population caps.
+ */
+export interface Spawner {
+  id: number
+  x: number
+  y: number
+  /** Which species this spawner emits. */
+  blueprintId: string
+  /** Seconds between emissions. */
+  intervalSeconds: number
+  /** Seconds remaining until the next emission. Counts down each tick. */
+  cooldown: number
+  /** Do not emit if this many creatures of the target species are within maxLocal tiles. */
+  maxLocal: number
+}
+
 export interface WorldState {
   width: number
   height: number
@@ -788,6 +809,9 @@ export interface WorldState {
    * generative — painting, placing, summoning, changing theme — wakes it again.
    */
   dormant: boolean
+  /** Placed spawner objects. Emit one creature of their species on a timer. */
+  spawners: Spawner[]
+  nextSpawnerId: number
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/worlds/snapshot.ts
+++ b/src/app/micro-land/worlds/snapshot.ts
@@ -26,7 +26,7 @@ import { registerBlueprint } from '@/app/micro-land/domain/sim/world'
 import { neutralTraits } from '@/app/micro-land/domain/traits'
 import type { Creature, CreatureMood, WorldState } from '@/app/micro-land/domain/types'
 
-import type { SavedCreature, WorldSnapshot } from './types'
+import type { SavedCreature, SavedSpawner, WorldSnapshot } from './types'
 
 const MOODS: CreatureMood[] = ['wander', 'hunt', 'flee', 'eat', 'rest', 'mate']
 
@@ -167,6 +167,15 @@ export function snapshotWorld(w: WorldState): WorldSnapshot {
       name: c.name,
     })),
     blueprints,
+    spawners: w.spawners.map(s => ({
+      id: s.id,
+      x: round(s.x),
+      y: round(s.y),
+      blueprintId: s.blueprintId,
+      intervalSeconds: round(s.intervalSeconds),
+      maxLocal: s.maxLocal,
+    })),
+    nextSpawnerId: w.nextSpawnerId,
   }
 }
 
@@ -245,6 +254,18 @@ export function restoreSnapshot(w: WorldState, snap: WorldSnapshot): boolean {
   let nextId = snap.nextCreatureId
   for (const c of w.creatures) if (c.id >= nextId) nextId = c.id + 1
   w.nextCreatureId = nextId
+
+  w.spawners = (snap.spawners ?? []).map(s => ({
+    id: s.id,
+    x: s.x,
+    y: s.y,
+    blueprintId: s.blueprintId,
+    intervalSeconds: s.intervalSeconds,
+    cooldown: 0,  // reset on restore, per the contract
+    maxLocal: s.maxLocal,
+  }))
+  w.nextSpawnerId = Math.max(1, snap.nextSpawnerId ?? 1)
+  for (const s of w.spawners) if (s.id >= w.nextSpawnerId) w.nextSpawnerId = s.id + 1
 
   return true
 }

--- a/src/app/micro-land/worlds/types.ts
+++ b/src/app/micro-land/worlds/types.ts
@@ -79,6 +79,22 @@ export interface SavedCreature {
   name: string | null
 }
 
+/**
+ * A spawner, frozen for storage.
+ *
+ * `cooldown` is deliberately omitted — it resets to 0 on restore so a
+ * spawner that was mid-countdown does not carry stale timer state across a
+ * save/load cycle.
+ */
+export interface SavedSpawner {
+  id: number
+  x: number
+  y: number
+  blueprintId: string
+  intervalSeconds: number
+  maxLocal: number
+}
+
 export interface WorldSnapshot {
   /**
    * How many materials existed when this grid was written.
@@ -113,6 +129,9 @@ export interface WorldSnapshot {
    * config, and `createWorld` already has them.
    */
   blueprints: CreatureBlueprint[]
+  /** Placed spawners. Cooldowns reset to 0 on restore. */
+  spawners?: SavedSpawner[]
+  nextSpawnerId?: number
 }
 
 /**

--- a/src/app/micro-land/worlds/wire.ts
+++ b/src/app/micro-land/worlds/wire.ts
@@ -25,6 +25,7 @@ import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 
 import {
   type SavedCreature,
+  type SavedSpawner,
   WORLD_SAVE_VERSION,
   type WorldSave,
   type WorldSnapshot,
@@ -221,6 +222,22 @@ function validSnapshot(value: unknown): WorldSnapshot | null {
       isPlainObject(bp) && typeof bp.id === 'string' && isPlainObject(bp.body)
   )
 
+  const spawners: SavedSpawner[] = []
+  if (Array.isArray(value.spawners)) {
+    for (const raw of value.spawners) {
+      if (!isPlainObject(raw)) continue
+      if (typeof raw.blueprintId !== 'string' || raw.blueprintId.length === 0) continue
+      spawners.push({
+        id: Math.max(1, Math.floor(num(raw.id, spawners.length + 1))),
+        x: clamp(raw.x, 0, WORLD_W, 0),
+        y: clamp(raw.y, 0, WORLD_H, 0),
+        blueprintId: raw.blueprintId.slice(0, 120),
+        intervalSeconds: clamp(raw.intervalSeconds, 1, 3600, 10),
+        maxLocal: clamp(raw.maxLocal, 0, 500, 5),
+      })
+    }
+  }
+
   return {
     materials,
     width: WORLD_W,
@@ -238,6 +255,8 @@ function validSnapshot(value: unknown): WorldSnapshot | null {
     tiles,
     creatures,
     blueprints,
+    spawners,
+    nextSpawnerId: Math.max(1, Math.floor(num(value.nextSpawnerId, spawners.length + 1))),
   }
 }
 


### PR DESCRIPTION
## Summary

Implements issue #3573 — pure data plumbing for placed creature spawners. No UI or simulation logic yet.

- Adds `Spawner` interface to `WorldState` with `id`, `x`, `y`, `blueprintId`, `intervalSeconds`, `cooldown`, and `maxLocal` fields
- Adds `nextSpawnerId` counter to `WorldState` (same pattern as `nextCreatureId`, etc.)
- Initializes `spawners: []` and `nextSpawnerId: 1` in `createWorld()`
- Clears spawners in `clearCreatures()`, so theme changes, Clear Life, and Clear World all empty the array
- Adds `SPAWNER_DEFAULT_INTERVAL = 10` and `SPAWNER_DEFAULT_MAX_LOCAL = 5` constants
- Adds `SavedSpawner` (without `cooldown`) to the wire format — cooldown resets to 0 on restore so stale timer state never crosses a save/load boundary
- Optional `spawners?` / `nextSpawnerId?` on `WorldSnapshot` for backward compat with existing saves

## Test plan

- [ ] Existing worlds tests (snapshot round-trips, wire validation, shelf) pass — confirmed locally (47 passing)
- [ ] Old saves without `spawners` field load correctly (optional fields default to `[]` / `1`)
- [ ] TypeScript passes (CI)

Part of #3572
Closes #3573

🤖 Generated with [Claude Code](https://claude.com/claude-code)