### PR TITLE
feat(dicebound): a matured skill opens a window, and the DM is told rather than instructed

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -55,6 +55,7 @@ import {
   attributeRank,
   earnedRanks,
   earnedSkills,
+  openWindows,
   skillRank,
 } from '@/app/dicebound/domain/character'
 import {
@@ -1506,7 +1507,37 @@ function sheetBlock(campaign: Campaign): string {
   return `THE CHARACTER
 ${c.name} — ${c.concept}
 Attributes: ${attributes}
-Earned skills: ${skills}${powersBlock(campaign.kit)}`
+Earned skills: ${skills}${windowBlock(campaign)}${powersBlock(campaign.kit)}`
+}
+
+/**
+ * A skill that has just matured, mentioned once and left alone.
+ *
+ * This is the other path to a power, and the one that makes them read as a
+ * story rather than as a level-up screen: you did the thing enough times.
+ *
+ * The wording is the entire issue. It is a **fact told to the DM**, not an
+ * instruction — "if the fiction offers a moment" and "may" are load-bearing,
+ * and so is the sentence saying outright that most turns should do nothing
+ * with it. A model handed "something may come of it" and nothing else reads it
+ * as "grant a power now", and then the power arrives because a counter said so
+ * rather than because the story had anywhere to put it.
+ *
+ * It sits in the sheet block, above the world and the transcript, so the DM has
+ * it before it decides what the turn is about rather than as a footnote it
+ * reaches after the scene is already planned.
+ *
+ * The provenance rule gets no exception here. Twenty turns of throwing burning
+ * things is not a source; the person who taught you, the thing you were
+ * throwing, or the place it happened is. That is stated in the line because the
+ * gate will otherwise refuse the grant and the DM will not know why.
+ */
+function windowBlock(campaign: Campaign): string {
+  const windows = openWindows(campaign.character, campaign.world.clock.elapsed)
+  if (windows.length === 0) return ''
+
+  const named = windows.map(w => SKILLS[w.skill].name).join(', ')
+  return `\nLately mastered: ${named}. They have done this enough times to be genuinely, unusually good at it, and the story has noticed. If a moment comes where that mastery turns into something they can DO — someone teaching them the last of it, a place that marks them, a thing that answers to it — take the moment and call grant_power, sourced from that person, place or thing. Do not manufacture one out of nothing. Do not mention any of this to the player.`
 }
 
 /**

--- a/src/app/dicebound/domain/__tests__/campaign.test.ts
+++ b/src/app/dicebound/domain/__tests__/campaign.test.ts
@@ -152,6 +152,38 @@ describe('validateCampaign', () => {
     expect(result?.character.skills.humor).not.toHaveProperty('seeded')
   })
 
+  it('round-trips the moment a skill matured, so its window does not vanish on save', () => {
+    const result = validateCampaign({
+      ...campaign(),
+      character: {
+        name: 'Ilda',
+        concept: '',
+        reading: '',
+        attributes: {},
+        skills: { balance: { uses: 18, rank: 3, maturedAt: 1000 } },
+      },
+    })
+    expect(result?.character.skills.balance?.maturedAt).toBe(1000)
+  })
+
+  it('leaves a skill that never matured without the key', () => {
+    // Absent, not zero. A character stored before windows existed must not read
+    // as one whose skills all matured at minute zero and closed before anyone
+    // looked — and must not read as one with a window open either.
+    const result = validateCampaign({
+      ...campaign(),
+      character: {
+        name: 'Ilda',
+        concept: '',
+        reading: '',
+        attributes: {},
+        skills: { balance: { uses: 18, rank: 3 }, humor: { uses: 3, rank: 1, maturedAt: 'soon' } },
+      },
+    })
+    expect(result?.character.skills.balance).not.toHaveProperty('maturedAt')
+    expect(result?.character.skills.humor).not.toHaveProperty('maturedAt')
+  })
+
   it('round-trips a die that was thrown twice', () => {
     const result = validateCampaign({
       ...campaign(),

--- a/src/app/dicebound/domain/__tests__/character.test.ts
+++ b/src/app/dicebound/domain/__tests__/character.test.ts
@@ -5,13 +5,16 @@ import {
   ATTRIBUTE_BUDGET,
   type Character,
   MAX_ATTRIBUTE,
+  MAX_SKILL_RANK,
   MAX_STARTING_SKILLS,
   MIN_ATTRIBUTE,
   RANK_THRESHOLDS,
+  WINDOW_MINUTES,
   blankAttributes,
   earnedRanks,
   earnedSkills,
   normalizeAttributes,
+  openWindows,
   rankFor,
   recordSkillUse,
   startingSkills,
@@ -304,5 +307,64 @@ describe('earnedRanks', () => {
     })
     expect(earnedRanks(legacy)).toBe(3)
     expect(levelFor(earnedRanks(legacy))).toBe(2)
+  })
+})
+
+describe('openWindows', () => {
+  /** Use a skill until it tops out, at the given clock minute. */
+  function mastered(at: number): Character {
+    let sheet = character()
+    for (let i = 0; i < RANK_THRESHOLDS[2]; i++) {
+      sheet = recordSkillUse(sheet, 'balance', at).character
+    }
+    return sheet
+  }
+
+  it('a skill reaching rank 3 opens a window', () => {
+    const sheet = mastered(1000)
+    expect(sheet.skills.balance?.rank).toBe(MAX_SKILL_RANK)
+    expect(openWindows(sheet, 1000).map(w => w.skill)).toEqual(['balance'])
+  })
+
+  it('a skill short of the top rank opens nothing', () => {
+    let sheet = character()
+    for (let i = 0; i < RANK_THRESHOLDS[1]; i++) {
+      sheet = recordSkillUse(sheet, 'balance', 1000).character
+    }
+    expect(sheet.skills.balance?.rank).toBe(2)
+    expect(openWindows(sheet, 1000)).toEqual([])
+  })
+
+  it('a window opened long enough ago is closed and does not reopen', () => {
+    // A window that never closes is a standing instruction, and a standing
+    // instruction gets obeyed eventually just to make it stop.
+    const sheet = mastered(1000)
+    expect(openWindows(sheet, 1000 + WINDOW_MINUTES)).toHaveLength(1)
+    expect(openWindows(sheet, 1000 + WINDOW_MINUTES + 1)).toEqual([])
+  })
+
+  it('using the skill again does not reopen a closed window', () => {
+    // maturedAt is stamped once, on the crossing use. Re-stamping would make
+    // the window reopen every time the skill came up.
+    let sheet = mastered(1000)
+    sheet = recordSkillUse(sheet, 'balance', 99_000).character
+    expect(sheet.skills.balance?.maturedAt).toBe(1000)
+    expect(openWindows(sheet, 99_000)).toEqual([])
+  })
+
+  it('an innate skill never opens one, however often it comes up', () => {
+    // Innate ranks never advance, so nothing ever crosses the threshold.
+    let sheet = character({ skills: { size: { uses: 0, rank: -2 } } })
+    for (let i = 0; i < 40; i++) sheet = recordSkillUse(sheet, 'size', 500).character
+    expect(openWindows(sheet, 500)).toEqual([])
+  })
+
+  it('a matured skill is not by itself a source — it names a skill, never an entity', () => {
+    // Twenty turns of throwing burning things is not provenance. The window
+    // says what matured; canGrantPower still demands an entity the world holds,
+    // and this returns nothing that could be mistaken for one.
+    const window = openWindows(mastered(1000), 1000)[0]
+    expect(Object.keys(window).sort()).toEqual(['since', 'skill'])
+    expect(window.skill).toBe('balance')
   })
 })

--- a/src/app/dicebound/domain/campaign.ts
+++ b/src/app/dicebound/domain/campaign.ts
@@ -297,6 +297,12 @@ export function validateCharacter(value: unknown): Character | null {
         // only when it is true also keeps it out of every campaign blob that
         // has no seeded skills.
         ...(record.seeded === true ? { seeded: true as const } : {}),
+        // Same treatment, and for the same reason: absent stays absent. A
+        // character stored before windows existed has no matured skills rather
+        // than one that matured at minute zero and closed before anyone looked.
+        ...(typeof record.maturedAt === 'number' && Number.isFinite(record.maturedAt)
+          ? { maturedAt: Math.max(0, Math.round(record.maturedAt)) }
+          : {}),
       }
     }
   }

--- a/src/app/dicebound/domain/character.ts
+++ b/src/app/dicebound/domain/character.ts
@@ -56,6 +56,15 @@ export interface SkillRecord {
    * keep reading as valid; see `earnedRanks` for what absent means.
    */
   seeded?: true
+  /**
+   * Clock minute at which this reached the top rank, if it has.
+   *
+   * Only ever set once, and only on the use that crosses the last threshold.
+   * It exists so a matured skill can open a *window* rather than a standing
+   * fact — see `openWindows`. Optional because almost no skill has one and
+   * because every character stored before it existed has to keep reading.
+   */
+  maturedAt?: number
 }
 
 export interface Character {
@@ -192,13 +201,21 @@ export interface SkillAdvance {
  */
 export function recordSkillUse(
   character: Character,
-  skill: SkillId
+  skill: SkillId,
+  /** Clock minutes of fiction, for stamping the moment a skill matures. */
+  now = 0
 ): { character: Character; earned: SkillAdvance | null } {
   if (!isSkillId(skill)) return { character, earned: null }
 
   const before = character.skills[skill] ?? { uses: 0, rank: 0 }
   const uses = before.uses + 1
   const rank = SKILLS[skill].innate ? before.rank : rankFor(uses)
+  // Stamped once, on the use that crosses the top threshold, and never again.
+  // Re-stamping on later uses would make the window reopen every time the
+  // skill came up, which is the difference between a moment the story can use
+  // and a standing instruction nobody can turn off.
+  const matured =
+    rank >= MAX_SKILL_RANK && before.rank < MAX_SKILL_RANK ? { maturedAt: Math.max(0, now) } : {}
 
   return {
     character: {
@@ -207,7 +224,7 @@ export function recordSkillUse(
       // being used. Rebuilding the record from `{ uses, rank }` would clear it
       // on the first check, and the head start would quietly become an
       // achievement the moment the player touched the skill.
-      skills: { ...character.skills, [skill]: { ...before, uses, rank } },
+      skills: { ...character.skills, [skill]: { ...before, ...matured, uses, rank } },
     },
     earned: rank > before.rank ? { skill, rank } : null,
   }
@@ -259,4 +276,52 @@ export function earnedSkills(character: Character): { skill: SkillId; record: Sk
       .filter(entry => entry.record.rank !== 0)
       .sort((a, b) => b.record.rank - a.record.rank || b.record.uses - a.record.uses)
   )
+}
+
+/**
+ * How long a matured skill stays interesting, in minutes of fiction.
+ *
+ * Two days. The number is doing something specific: it has to be long enough
+ * that the moment can arrive in a *different scene* from the one where the rank
+ * landed — a night's sleep and the next day's business both fit inside it — and
+ * short enough that it cannot follow the character across a journey. A window
+ * that never closes is a standing instruction, and a standing instruction the
+ * DM reads every turn is nagging: it will eventually be obeyed just to make it
+ * stop, which is exactly how a power arrives because a counter said so rather
+ * than because the story had somewhere to put it.
+ *
+ * Two days rather than one because a single day is often a single scene, and
+ * the whole point is to give the fiction a chance to offer something.
+ */
+export const WINDOW_MINUTES = 2 * 24 * 60
+
+export interface MaturedSkill {
+  skill: SkillId
+  /** Clock minute it matured. */
+  since: number
+}
+
+/**
+ * Skills that matured recently enough to still be worth mentioning.
+ *
+ * The DM is *told*, never instructed — this returns the fact, and the prompt
+ * that renders it is careful to stay a fact. A power arrives when the story has
+ * somewhere to put it, or it does not arrive, and either is a correct turn.
+ *
+ * A window that closes unused stays closed: `maturedAt` is stamped once, so
+ * nothing here can reopen one. Innate skills never reach a rank they did not
+ * start with, so they never appear.
+ */
+export function openWindows(character: Character, now: number): MaturedSkill[] {
+  const out: MaturedSkill[] = []
+
+  for (const [skill, record] of Object.entries(character.skills)) {
+    if (!record || record.maturedAt === undefined) continue
+    if (now - record.maturedAt > WINDOW_MINUTES) continue
+    out.push({ skill: skill as SkillId, since: record.maturedAt })
+  }
+
+  // Most recent first: if two windows are somehow open at once, the one that
+  // just happened is the one the scene is more likely to be about.
+  return out.sort((a, b) => b.since - a.since)
 }

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -160,7 +160,15 @@ export function tallyChecks(stats: CampaignStats, entries: TranscriptEntry[]): C
  */
 export function creditSkills(
   character: Character,
-  entries: TranscriptEntry[]
+  entries: TranscriptEntry[],
+  /**
+   * Clock minutes of fiction at the end of the turn.
+   *
+   * Story time, not wall time. It is only used to stamp the moment a skill
+   * matures, and a window measured in wall-clock minutes would close while the
+   * player was making a cup of tea.
+   */
+  now = 0
 ): { character: Character; entries: TranscriptEntry[] } {
   let current = character
   const out: TranscriptEntry[] = []
@@ -169,7 +177,7 @@ export function creditSkills(
     out.push(entry)
     if (entry.kind !== 'check' || !entry.skill) continue
 
-    const { character: next, earned } = recordSkillUse(current, entry.skill)
+    const { character: next, earned } = recordSkillUse(current, entry.skill, now)
     current = next
     if (earned) out.push({ kind: 'earned', skill: earned.skill, rank: earned.rank })
   }
@@ -184,7 +192,10 @@ export function creditSkills(
  * caller owns time; this owns state.
  */
 export function applyTurn(campaign: Campaign, result: TurnResult, now: number): Campaign {
-  const { character, entries } = creditSkills(campaign.character, result.entries)
+  // The clock as the turn left it, falling back to where it started when the
+  // turn never reached a narrate and so produced no world.
+  const clock = (result.world ?? campaign.world).clock.elapsed
+  const { character, entries } = creditSkills(campaign.character, result.entries, clock)
 
   const kept =
     result.dropped && result.dropped > 0


### PR DESCRIPTION
Closes #3563. Turn lane — prompt plus domain. Depends on #3560, merged.

## Why

The other path in, and the one that makes powers read as a story rather than as a level-up screen: *you did the thing enough times*. Granting is how you get fireball in a world that has wizards in it; this is how you get fireball after twenty turns of throwing burning things.

## The window

A skill crossing the top rank stamps `maturedAt` **once**, on the use that crosses it. Re-stamping on later uses would reopen the window every time the skill came up — the difference between a moment the story can use and a standing instruction nobody can turn off. A window that closes unused stays closed, and there is a test for using the skill again afterwards.

It lasts **two days of fiction**. Long enough that the moment can arrive in a *different scene* from the one where the rank landed — a night's sleep and the next day's business both fit — and short enough that it cannot follow the character across a journey. Two rather than one because a single day is often a single scene, and the whole point is to give the fiction a chance to offer something.

The clock threaded into `recordSkillUse` is **story time, not wall time**. A window measured in wall-clock minutes would close while the player was making a cup of tea.

## Provenance gets no exception

Twenty turns of throwing burning things is not a source. `openWindows` returns a skill and a minute — nothing an entity lookup could mistake for provenance — so `grant_power` still demands a person, place or thing the world already holds. The prompt line says so explicitly, because otherwise the gate refuses the grant and the DM never learns why.

## The sentence took two passes, and that is the finding

The issue anticipated one failure mode: a DM reading "something may come of it" as "grant a power now", and said the fix belongs in this PR. **The failure was the opposite one**, and it was worse.

Written with a hedge on both ends — *"if — and only if —"*, *"most turns will not offer such a moment, and letting one pass is the right call"* — the path **never fired at all**:

| | window open, power granted |
| --- | --- |
| ordinary actions (sit, ask, walk the wire, reflect) — 2 runs × 4 turns | **0 / 8** |
| player asks outright to be taught — 2 runs × 2 turns | **0 / 4** |

A path that never fires is decoration. Rewritten to state the fact and then say to take the moment when one comes — keeping only "do not manufacture one out of nothing":

| | window open, power granted |
| --- | --- |
| ordinary actions — 2 runs × 4 turns | **1 of 2 runs**, and on turn 2, not turn 1 |
| player asks outright to be taught — 2 runs × 2 turns | **2 of 2 runs**, on turn 1 |

Which is the shape the issue asked for, reached from the other side: it arrives when the story has somewhere to put it, and one run of four ordinary turns produced nothing at all, which is also a correct turn.

Every grant in those runs came out sourced from `old-sabre` — a real entity — at tier 1, correctly clamped for a level 2 character, and each was granted once with the duplicate gate holding on the following turns.

The line sits in the sheet block, above the world and the transcript, so the DM has it **before** it decides what the turn is about rather than as a footnote it reaches after the scene is planned. It ends by telling the DM not to mention any of it to the player.

## Verification

```
$ npx vitest run src/app/dicebound/domain
 Test Files  8 passed (8)
      Tests  254 passed (254)      # +8 openWindows, +2 validator round-trip

$ npx eslint src/app/dicebound/domain src/app/api/v1/dicebound src/lib/dicebound
eslint=0
$ npm run lint:routes
check-route-slugs: ok
$ npx tsc --noEmit 2>&1 | grep -E 'domain/character|domain/campaign|domain/turn|turn/route'
                                    # empty
```

Note on `tsc`: this checkout currently has unrelated in-flight work (a suggestion-chips feature) that reports its own errors under `src/app/dicebound/`, so the grep is scoped to the files this PR touches rather than to `dicebound`. Nothing here contributes an error.

Plus the sixteen live turns tabulated above.