### PR TITLE
[micro-land] Spawner simulation logic

### DIFF
--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -530,3 +530,21 @@ export const NEST_DECAY_SECONDS = 120
  * harness — if starvation still dominates, the reach problem is not solved.
  */
 export const LIFESPAN_SCALE = 10
+
+/**
+ * Default interval between spawner emissions, in seconds.
+ *
+ * Ten seconds lets a new world populate without overwhelming the population
+ * caps, while still being fast enough to notice. Adjust per-spawner at
+ * placement time.
+ */
+export const SPAWNER_DEFAULT_INTERVAL = 10
+
+/**
+ * Default local-population cap for a spawner.
+ *
+ * A spawner suppresses its next emission if this many creatures of the same
+ * species are already within maxLocal tiles. Keeps each spawner from flooding
+ * a small area while still letting the species spread.
+ */
+export const SPAWNER_DEFAULT_MAX_LOCAL = 5

--- a/src/app/micro-land/domain/sim/spawner-sim.ts
+++ b/src/app/micro-land/domain/sim/spawner-sim.ts
@@ -1,0 +1,64 @@
+/**
+ * Spawner tick — emit one creature per placed spawner when its cooldown expires.
+ */
+import type { SimEvent } from './creature-sim'
+import { countByBlueprint, spawnCreature } from './world'
+import { TUNING } from '@/app/micro-land/domain/tuning'
+import type { WorldState } from '@/app/micro-land/domain/types'
+import { deltaX } from '@/app/micro-land/domain/wrap'
+
+/**
+ * Radius in tiles that counts as "local" for the per-spawner population cap.
+ * Any creature of the same species within this range counts toward maxLocal.
+ */
+const SPAWNER_LOCAL_RADIUS = 10
+
+export function tickSpawners(w: WorldState, dt: number, events: SimEvent[]): void {
+  if (w.spawners.length === 0) return
+
+  // Count creatures per species once for all spawners this tick.
+  const globalCount = countByBlueprint(w)
+
+  for (const spawner of w.spawners) {
+    spawner.cooldown -= dt
+    if (spawner.cooldown > 0) continue
+
+    // Reset for next emission before the cap checks — so a capped tick still
+    // delays the next attempt by a full interval, not by zero.
+    spawner.cooldown = spawner.intervalSeconds
+
+    const bp = w.blueprints[spawner.blueprintId]
+    if (!bp) continue
+
+    // Global species cap: don't flood the world beyond its carrying capacity.
+    const isPlant = bp.move.kind === 'root'
+    const globalCap = isPlant ? TUNING.plantSpeciesCap : TUNING.speciesSoftCap
+    if ((globalCount[spawner.blueprintId] ?? 0) >= globalCap) continue
+
+    // Local population cap: don't pile creatures at the spawner position.
+    // Walk the population once per spawner — spawners are rare, so this is fine.
+    const r2 = SPAWNER_LOCAL_RADIUS * SPAWNER_LOCAL_RADIUS
+    let nearby = 0
+    for (const c of w.creatures) {
+      if (c.blueprintId !== spawner.blueprintId) continue
+      // deltaX handles horizontal world wrapping.
+      const dx = deltaX(spawner.x, c.x)
+      const dy = c.y - spawner.y
+      if (dx * dx + dy * dy <= r2) {
+        nearby++
+        if (nearby >= spawner.maxLocal) break
+      }
+    }
+    if (nearby >= spawner.maxLocal) continue
+
+    // Place one creature at the spawner position.
+    const creature = spawnCreature(w, bp, spawner.x, spawner.y)
+    if (!creature) continue // global creature ceiling (TUNING.maxCreatures) reached
+
+    // Update the running count so a cluster of spawners in the same tick
+    // each sees the previous one's contribution.
+    globalCount[spawner.blueprintId] = (globalCount[spawner.blueprintId] ?? 0) + 1
+
+    events.push({ kind: 'born', blueprintId: spawner.blueprintId, x: spawner.x, y: spawner.y })
+  }
+}

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -65,6 +65,8 @@ export function createWorld(seed = 1337): WorldState {
     natives: [],
     nextPlantSeed: 0,
     dormant: false,
+    spawners: [],
+    nextSpawnerId: 1,
   }
 }
 
@@ -666,6 +668,7 @@ export function seedStarters(w: WorldState, themeId: string, rng: Rng): void {
 export function clearCreatures(w: WorldState): void {
   w.creatures.length = 0
   w.particles.length = 0
+  w.spawners.length = 0
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -739,6 +739,27 @@ export interface Nest {
   decaySeconds: number
 }
 
+/**
+ * An in-world object that continuously emits creatures of a chosen species.
+ *
+ * Placed by the player via the toolbar. Counts down a cooldown each tick and
+ * drops one creature when it reaches zero, subject to local and global
+ * population caps.
+ */
+export interface Spawner {
+  id: number
+  x: number
+  y: number
+  /** Which species this spawner emits. */
+  blueprintId: string
+  /** Seconds between emissions. */
+  intervalSeconds: number
+  /** Seconds remaining until the next emission. Counts down each tick. */
+  cooldown: number
+  /** Do not emit if this many creatures of the target species are within maxLocal tiles. */
+  maxLocal: number
+}
+
 export interface WorldState {
   width: number
   height: number
@@ -788,6 +809,9 @@ export interface WorldState {
    * generative — painting, placing, summoning, changing theme — wakes it again.
    */
   dormant: boolean
+  /** Placed spawner objects. Emit one creature of their species on a timer. */
+  spawners: Spawner[]
+  nextSpawnerId: number
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -39,6 +39,7 @@ import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, EMPTY_THEME_ID, THEME_BY_ID, type Theme } from './domain/config/themes'
 import { ELDER_MIN_SECONDS, TICK_S, TILE_TICK_EVERY, WORLD_H, WORLD_W } from './domain/constants'
 import { type SimEvent, emitParticles, tickCreatures } from './domain/sim/creature-sim'
+import { tickSpawners } from './domain/sim/spawner-sim'
 import { makeRng } from './domain/sim/prng'
 import { tickTiles } from './domain/sim/tile-sim'
 import {
@@ -470,6 +471,7 @@ export class GameInstance {
     }
 
     tickCreatures(w, TICK_S, this.rng, gravity, events)
+    tickSpawners(w, TICK_S, events)
 
     // --- heatmap update (every 5 ticks) ---
     this.heatmapTickCounter++

--- a/src/app/micro-land/worlds/snapshot.ts
+++ b/src/app/micro-land/worlds/snapshot.ts
@@ -26,7 +26,7 @@ import { registerBlueprint } from '@/app/micro-land/domain/sim/world'
 import { neutralTraits } from '@/app/micro-land/domain/traits'
 import type { Creature, CreatureMood, WorldState } from '@/app/micro-land/domain/types'
 
-import type { SavedCreature, WorldSnapshot } from './types'
+import type { SavedCreature, SavedSpawner, WorldSnapshot } from './types'
 
 const MOODS: CreatureMood[] = ['wander', 'hunt', 'flee', 'eat', 'rest', 'mate']
 
@@ -167,6 +167,15 @@ export function snapshotWorld(w: WorldState): WorldSnapshot {
       name: c.name,
     })),
     blueprints,
+    spawners: w.spawners.map(s => ({
+      id: s.id,
+      x: round(s.x),
+      y: round(s.y),
+      blueprintId: s.blueprintId,
+      intervalSeconds: round(s.intervalSeconds),
+      maxLocal: s.maxLocal,
+    })),
+    nextSpawnerId: w.nextSpawnerId,
   }
 }
 
@@ -245,6 +254,18 @@ export function restoreSnapshot(w: WorldState, snap: WorldSnapshot): boolean {
   let nextId = snap.nextCreatureId
   for (const c of w.creatures) if (c.id >= nextId) nextId = c.id + 1
   w.nextCreatureId = nextId
+
+  w.spawners = (snap.spawners ?? []).map(s => ({
+    id: s.id,
+    x: s.x,
+    y: s.y,
+    blueprintId: s.blueprintId,
+    intervalSeconds: s.intervalSeconds,
+    cooldown: 0,  // reset on restore, per the contract
+    maxLocal: s.maxLocal,
+  }))
+  w.nextSpawnerId = Math.max(1, snap.nextSpawnerId ?? 1)
+  for (const s of w.spawners) if (s.id >= w.nextSpawnerId) w.nextSpawnerId = s.id + 1
 
   return true
 }

--- a/src/app/micro-land/worlds/types.ts
+++ b/src/app/micro-land/worlds/types.ts
@@ -79,6 +79,22 @@ export interface SavedCreature {
   name: string | null
 }
 
+/**
+ * A spawner, frozen for storage.
+ *
+ * `cooldown` is deliberately omitted — it resets to 0 on restore so a
+ * spawner that was mid-countdown does not carry stale timer state across a
+ * save/load cycle.
+ */
+export interface SavedSpawner {
+  id: number
+  x: number
+  y: number
+  blueprintId: string
+  intervalSeconds: number
+  maxLocal: number
+}
+
 export interface WorldSnapshot {
   /**
    * How many materials existed when this grid was written.
@@ -113,6 +129,9 @@ export interface WorldSnapshot {
    * config, and `createWorld` already has them.
    */
   blueprints: CreatureBlueprint[]
+  /** Placed spawners. Cooldowns reset to 0 on restore. */
+  spawners?: SavedSpawner[]
+  nextSpawnerId?: number
 }
 
 /**

--- a/src/app/micro-land/worlds/wire.ts
+++ b/src/app/micro-land/worlds/wire.ts
@@ -25,6 +25,7 @@ import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 
 import {
   type SavedCreature,
+  type SavedSpawner,
   WORLD_SAVE_VERSION,
   type WorldSave,
   type WorldSnapshot,
@@ -221,6 +222,22 @@ function validSnapshot(value: unknown): WorldSnapshot | null {
       isPlainObject(bp) && typeof bp.id === 'string' && isPlainObject(bp.body)
   )
 
+  const spawners: SavedSpawner[] = []
+  if (Array.isArray(value.spawners)) {
+    for (const raw of value.spawners) {
+      if (!isPlainObject(raw)) continue
+      if (typeof raw.blueprintId !== 'string' || raw.blueprintId.length === 0) continue
+      spawners.push({
+        id: Math.max(1, Math.floor(num(raw.id, spawners.length + 1))),
+        x: clamp(raw.x, 0, WORLD_W, 0),
+        y: clamp(raw.y, 0, WORLD_H, 0),
+        blueprintId: raw.blueprintId.slice(0, 120),
+        intervalSeconds: clamp(raw.intervalSeconds, 1, 3600, 10),
+        maxLocal: clamp(raw.maxLocal, 0, 500, 5),
+      })
+    }
+  }
+
   return {
     materials,
     width: WORLD_W,
@@ -238,6 +255,8 @@ function validSnapshot(value: unknown): WorldSnapshot | null {
     tiles,
     creatures,
     blueprints,
+    spawners,
+    nextSpawnerId: Math.max(1, Math.floor(num(value.nextSpawnerId, spawners.length + 1))),
   }
 }
 


### PR DESCRIPTION
## Summary

Implements issue #3574 — world-tick logic that reads `w.spawners` and emits one creature per spawner when its cooldown expires.

**Depends on #3583** (Spawner data model).

### What changed

- **`domain/sim/spawner-sim.ts`** (new file): exports `tickSpawners(w, dt, events)`
  - Counts creatures per species once per tick (not per spawner) for efficiency
  - For each spawner: decrements cooldown; on expiry, resets to `intervalSeconds` then checks caps:
    - Global species cap (`TUNING.speciesSoftCap` or `TUNING.plantSpeciesCap`)
    - Local population cap: counts same-species creatures within 10 tiles, suppresses if `>= spawner.maxLocal`
  - Calls `spawnCreature` and emits a `'born'` event — field guide stats, history log, and sounds all update normally
- **`game-instance.ts`**: calls `tickSpawners(w, TICK_S, events)` right after `tickCreatures` in `step()`

### Acceptance criteria
- [x] A spawner with `intervalSeconds: 10` emits one creature every 10 seconds
- [x] A spawner does not emit if `maxLocal` creatures of its species are already within 10 tiles
- [x] A spawner does not emit if the global species cap is reached
- [x] `born` event appears in the event stream → field guide and history log update
- [x] Spawner cooldown resets to 0 on save/load (handled in #3583)

## Test plan
- [ ] 47 worlds tests pass (confirmed locally)
- [ ] TypeScript passes (CI)

Part of #3572
Closes #3574

🤖 Generated with [Claude Code](https://claude.com/claude-code)