### PR TITLE
[micro-land] Spawner simulation logic

### DIFF
--- a/src/app/micro-land/domain/sim/spawner-sim.ts
+++ b/src/app/micro-land/domain/sim/spawner-sim.ts
@@ -1,0 +1,64 @@
+/**
+ * Spawner tick — emit one creature per placed spawner when its cooldown expires.
+ */
+import type { SimEvent } from './creature-sim'
+import { countByBlueprint, spawnCreature } from './world'
+import { TUNING } from '@/app/micro-land/domain/tuning'
+import type { WorldState } from '@/app/micro-land/domain/types'
+import { deltaX } from '@/app/micro-land/domain/wrap'
+
+/**
+ * Radius in tiles that counts as "local" for the per-spawner population cap.
+ * Any creature of the same species within this range counts toward maxLocal.
+ */
+const SPAWNER_LOCAL_RADIUS = 10
+
+export function tickSpawners(w: WorldState, dt: number, events: SimEvent[]): void {
+  if (w.spawners.length === 0) return
+
+  // Count creatures per species once for all spawners this tick.
+  const globalCount = countByBlueprint(w)
+
+  for (const spawner of w.spawners) {
+    spawner.cooldown -= dt
+    if (spawner.cooldown > 0) continue
+
+    // Reset for next emission before the cap checks — so a capped tick still
+    // delays the next attempt by a full interval, not by zero.
+    spawner.cooldown = spawner.intervalSeconds
+
+    const bp = w.blueprints[spawner.blueprintId]
+    if (!bp) continue
+
+    // Global species cap: don't flood the world beyond its carrying capacity.
+    const isPlant = bp.move.kind === 'root'
+    const globalCap = isPlant ? TUNING.plantSpeciesCap : TUNING.speciesSoftCap
+    if ((globalCount[spawner.blueprintId] ?? 0) >= globalCap) continue
+
+    // Local population cap: don't pile creatures at the spawner position.
+    // Walk the population once per spawner — spawners are rare, so this is fine.
+    const r2 = SPAWNER_LOCAL_RADIUS * SPAWNER_LOCAL_RADIUS
+    let nearby = 0
+    for (const c of w.creatures) {
+      if (c.blueprintId !== spawner.blueprintId) continue
+      // deltaX handles horizontal world wrapping.
+      const dx = deltaX(spawner.x, c.x)
+      const dy = c.y - spawner.y
+      if (dx * dx + dy * dy <= r2) {
+        nearby++
+        if (nearby >= spawner.maxLocal) break
+      }
+    }
+    if (nearby >= spawner.maxLocal) continue
+
+    // Place one creature at the spawner position.
+    const creature = spawnCreature(w, bp, spawner.x, spawner.y)
+    if (!creature) continue // global creature ceiling (TUNING.maxCreatures) reached
+
+    // Update the running count so a cluster of spawners in the same tick
+    // each sees the previous one's contribution.
+    globalCount[spawner.blueprintId] = (globalCount[spawner.blueprintId] ?? 0) + 1
+
+    events.push({ kind: 'born', blueprintId: spawner.blueprintId, x: spawner.x, y: spawner.y })
+  }
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -39,6 +39,7 @@ import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, EMPTY_THEME_ID, THEME_BY_ID, type Theme } from './domain/config/themes'
 import { ELDER_MIN_SECONDS, TICK_S, TILE_TICK_EVERY, WORLD_H, WORLD_W } from './domain/constants'
 import { type SimEvent, emitParticles, tickCreatures } from './domain/sim/creature-sim'
+import { tickSpawners } from './domain/sim/spawner-sim'
 import { makeRng } from './domain/sim/prng'
 import { tickTiles } from './domain/sim/tile-sim'
 import {
@@ -470,6 +471,7 @@ export class GameInstance {
     }
 
     tickCreatures(w, TICK_S, this.rng, gravity, events)
+    tickSpawners(w, TICK_S, events)
 
     // --- heatmap update (every 5 ticks) ---
     this.heatmapTickCounter++


### PR DESCRIPTION
## Summary

Implements issue #3574 — world-tick logic that reads `w.spawners` and emits one creature per spawner when its cooldown expires.

**Depends on #3583** (merged — Spawner data model in main).

### What changed

- **`domain/sim/spawner-sim.ts`** (new file): exports `tickSpawners(w, dt, events)`
  - Counts creatures per species once per tick (not per spawner) for efficiency
  - For each spawner: decrements cooldown; on expiry, resets to `intervalSeconds` then checks caps:
    - Global species cap (`TUNING.speciesSoftCap` or `TUNING.plantSpeciesCap`)
    - Local population cap: counts same-species creatures within 10 tiles, suppresses if `>= spawner.maxLocal`
  - Calls `spawnCreature` and emits a `'born'` event — field guide stats, history log, and sounds all update normally
- **`game-instance.ts`**: calls `tickSpawners(w, TICK_S, events)` right after `tickCreatures` in `step()`

### Acceptance criteria
- [x] A spawner with `intervalSeconds: 10` emits one creature every 10 seconds
- [x] A spawner does not emit if `maxLocal` creatures of its species are already within 10 tiles
- [x] A spawner does not emit if the global species cap is reached
- [x] `born` event appears in the event stream → field guide and history log update
- [x] Spawner cooldown resets to 0 on save/load (handled in merged #3583)

## Test plan
- [ ] 47 worlds tests pass (confirmed locally)
- [ ] TypeScript passes (CI)

Part of #3572
Closes #3574

🤖 Generated with [Claude Code](https://claude.com/claude-code)