### PR TITLE
[micro-land] Spawner renderer

### DIFF
--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -599,6 +599,7 @@ export class Renderer {
       this.drawTombstones(w)
       if (heatmap) this.drawHeatmap(heatmap, vx, vw)
       this.drawEggs(w)
+      this.drawSpawners(w)
       this.drawCreatures(w)
       this.drawStatusDots(w)
       this.drawPollinatorAuras(w)
@@ -1060,6 +1061,64 @@ export class Renderer {
 
     ctx.textAlign = 'left'
     ctx.textBaseline = 'alphabetic'
+  }
+
+  /**
+   * Draw placed spawners as discreet beacon markers.
+   *
+   * Each spawner is a small filled circle in the species' primary color with a
+   * pulsing ring around it — "this place is special" without being a UI widget.
+   * The ring pulse skips when `prefers-reduced-motion` is active (static at
+   * half opacity instead).
+   */
+  private drawSpawners(w: WorldState): void {
+    if (!w.spawners?.length) return
+    const ctx = this.wctx
+    const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+
+    for (const spawner of w.spawners) {
+      if (!this.onScreen(spawner.x - 4, 8)) continue
+
+      // Primary color: first non-transparent pixel in the blueprint palette.
+      // Falls back to a neutral cosmic tint if the blueprint is missing.
+      let color = '#88aaff'
+      const bp = w.blueprints[spawner.blueprintId]
+      if (bp?.art?.palette && bp.art.frames.length > 0) {
+        outer: for (const frame of bp.art.frames) {
+          for (const row of frame) {
+            for (const ch of row) {
+              if (ch !== '.' && bp.art.palette[ch]) {
+                color = bp.art.palette[ch]
+                break outer
+              }
+            }
+          }
+        }
+      }
+
+      const x = Math.round(spawner.x)
+      const y = Math.round(spawner.y)
+
+      // Solid inner circle — always visible.
+      ctx.globalAlpha = 0.85
+      ctx.fillStyle = color
+      ctx.beginPath()
+      ctx.arc(x, y, 2, 0, Math.PI * 2)
+      ctx.fill()
+
+      // Pulsing ring at ~1 Hz. Static at half opacity on prefers-reduced-motion.
+      const ringAlpha = reducedMotion
+        ? 0.45
+        : 0.25 + 0.35 * (Math.sin(w.elapsed * Math.PI * 2) * 0.5 + 0.5)
+      ctx.globalAlpha = ringAlpha
+      ctx.strokeStyle = color
+      ctx.lineWidth = 0.5
+      ctx.beginPath()
+      ctx.arc(x, y, 3.5, 0, Math.PI * 2)
+      ctx.stroke()
+
+      ctx.globalAlpha = 1
+    }
   }
 
   private drawEggs(w: WorldState): void {


### PR DESCRIPTION
## Summary

Implements issue #3575 — renders placed spawners as discreet beacon markers in the world canvas.

**Depends on #3583** (merged — Spawner data model) and **#3586** (Spawner simulation logic, pending CI).

### What changed

**`rendering/renderer.ts`** — new `drawSpawners(w)` private method:
- Draws each `Spawner` in `w.spawners` as a small filled circle (2px radius) + unfilled ring (3.5px radius)
- Color is the species' primary pixel color (first non-transparent palette entry) — falls back to `#88aaff` if the blueprint is missing
- Ring pulses at ~1 Hz using `w.elapsed` — same pattern as existing creature flicker and elder halo
- `window.matchMedia('prefers-reduced-motion: reduce')` check: ring stays static at 0.45 opacity instead
- Called in the existing two-pass wrap loop between `drawEggs` and `drawCreatures` (above terrain, below creatures)
- Removing a spawner from `w.spawners` makes it disappear on the next render frame

### Design
- Reads as "a glowing seed pod or ritual circle" — visible enough to spot, not so prominent it distracts from creatures
- No text labels or UI chrome — the species color is the only identity signal at this layer

## Test plan
- [ ] 47 worlds tests pass (confirmed locally)
- [ ] TypeScript passes (CI)
- [ ] Spawners visible in world canvas at placed coordinates
- [ ] Ring pulses on standard motion, static on prefers-reduced-motion

Part of #3572
Closes #3575

🤖 Generated with [Claude Code](https://claude.com/claude-code)