### PR TITLE
feat(dicebound): three things you might try, and the box still belongs to the player

### DIFF
--- a/src/app/api/v1/dicebound/suggest/route.ts
+++ b/src/app/api/v1/dicebound/suggest/route.ts
@@ -1,0 +1,307 @@
+/**
+ * Three things the player might try, offered beside the composer.
+ *
+ * This is a separate route and a separate model call, and both halves of that
+ * are the design rather than the plumbing.
+ *
+ * Separate call, because the alternative — a `suggestions` field on `narrate` —
+ * would have the dungeon master compose the scene and the player's options in
+ * the same breath, and a DM that knows what it is about to offer starts writing
+ * scenes with three exits. Nothing here is visible from the turn loop, and the
+ * DM is never told this exists. The same instinct governs advantage (#3569) and
+ * item grants (#3521): the thing that writes prose does not get to see the
+ * affordance it is writing toward.
+ *
+ * Separate model, because this is not the dungeon master's job. It reads one
+ * scene and writes three sentences in the player's voice — no dice, no world to
+ * keep, no continuity to hold — and it has to come back fast, because it is
+ * racing the player's own reading of the paragraph that just arrived.
+ *
+ * Nothing it returns is stored. A suggestion is a string that lands in the text
+ * field for the player to edit; the campaign never learns it happened, which is
+ * why there is no version bump and nothing new on `Campaign`.
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import {
+  type Campaign,
+  type TranscriptEntry,
+  validateCampaign,
+} from '@/app/dicebound/domain/campaign'
+import type { Item, Kit, Power } from '@/app/dicebound/domain/kit'
+import { SUGGESTION_COUNT, cleanSuggestions } from '@/app/dicebound/domain/suggest'
+import {
+  PLAYER_ID,
+  type World,
+  currentPlace,
+  describeClock,
+  openThreads,
+  relevanceWindow,
+} from '@/app/dicebound/domain/world'
+import { verifyRequestAuth } from '@/lib/api/auth'
+import {
+  SUGGEST_MODEL,
+  type ToolDef,
+  callForTool,
+  requireApiKey,
+  toolSchema,
+} from '@/lib/dicebound/anthropic'
+import { loadCampaign } from '@/lib/dicebound/campaign-store'
+
+/** Short on purpose. This is losing a race with the player if it takes longer. */
+export const maxDuration = 30
+
+/** The hard deadline. Past this the player is typing and the answer is no longer wanted. */
+const DEADLINE_MS = 12_000
+
+/** Three short lines. The ceiling is a backstop against a model that decides to explain itself. */
+const SUGGEST_TOKENS = 400
+
+/** How much of the recent story the suggester is shown. Enough for the scene, not the campaign. */
+const RECENT_ENTRIES = 5
+
+const OFFER_TOOL = 'offer_actions'
+
+/**
+ * The rules, and three worked examples of them.
+ *
+ * The examples are here rather than beside the scene because they are rules
+ * expressed as examples — the user message stays purely this story, which is
+ * the thing that changes every turn.
+ *
+ * They span three unrelated worlds deliberately. A model given one set about a
+ * lantern and a harbour will put lanterns and harbours into a story about a
+ * space station: few-shot examples get echoed, not merely imitated, and the
+ * only defence is to make the shared thing the *shape* rather than the
+ * furniture. What each set demonstrates is the spread — one option that takes
+ * the scene at face value, one that reaches for a person or a thing carried,
+ * one sideways — because three flavours of the same move is the failure that
+ * would quietly narrow the game.
+ */
+const SYSTEM = `You help a player of Dicebound decide what to do next. You are not the dungeon master. You never narrate, and you never say what happens — you write three things the player might type into the box, in their own words.
+
+VOICE
+- First person, as they would type it: "I try to…", "I ask…", "I go for…", "I tell…".
+- One sentence. Short — about a dozen words at most.
+- An attempt, never its result. "I try to lever the chain off" — not "I get the chain off". The dice decide whether it works, and a line that promises the outcome teaches the player to expect one.
+- Specific and plain. "I go for his lantern hand" beats "I attack".
+
+THE THREE
+They must not be three flavours of the same move. Write one of each:
+  1. the situation in front of them, taken at face value
+  2. a reach for a person, a promise, or something they are carrying
+  3. sideways — the angle the scene did not offer
+
+Only suggest what this character could actually try. They have the things and the abilities listed and nothing else; an ability that is not listed is not available. Never suggest simply waiting, thinking, or looking around. Never ask the player a question. Never mention the dice, the rules, the game, or these suggestions.
+
+EXAMPLES OF THE SHAPE
+
+Scene: the tide is coming into the stairwell. Maren is on the step above you, and the grate at the top is chained.
+  I try to lever the chain off with the lantern hook.
+  I ask Maren who she paid to have this grate chained.
+  I go under, and feel along the wall for the drain the water is leaving by.
+
+Scene: the librarian has gone very still, and the book you asked for is already open on the desk behind her.
+  I attempt to read the open page without stepping any closer.
+  I tell her I know whose handwriting that is.
+  I go for the window latch.
+
+Scene: the caravan has stopped. The lead camel will not go forward, and the guide is pretending not to have noticed.
+  I try to see what the camel is looking at.
+  I ask the guide what he owes the people who live out here.
+  I go and cut the water skins loose while everyone is watching the front.`
+
+const OfferSchema = z.object({
+  actions: z
+    .array(z.string())
+    .length(SUGGESTION_COUNT)
+    .describe(
+      'Three things the player might type. First person, one short sentence each, an attempt and not its outcome. Each a different kind of move.'
+    ),
+})
+
+const OFFER: ToolDef = {
+  name: OFFER_TOOL,
+  description: 'Offer the player three things they might try next.',
+  input_schema: toolSchema(OfferSchema),
+}
+
+interface SuggestRequest {
+  campaign?: unknown
+}
+
+/**
+ * The campaign these suggestions are for.
+ *
+ * Deliberately not the turn route's `campaignFor`, though it starts the same
+ * way. That one carries an exception for the opening turn, whose campaign
+ * arrives in the body because the server has nothing to load yet — a creation.
+ * There is no opening case here: suggestions exist only once a story does, so
+ * a signed-in player with nothing stored has nothing to suggest against, and
+ * the simpler rule is the correct one rather than a copy waiting to drift.
+ */
+async function campaignFor(request: NextRequest, body: SuggestRequest): Promise<Campaign | null> {
+  const hasToken = /^Bearer\s+.+$/i.test(
+    request.headers.get('authorization') ?? request.headers.get('Authorization') ?? ''
+  )
+
+  // No token is the local-only backend: Firebase unconfigured, so there is no
+  // server-side story and the client sends its own, exactly as it does for a turn.
+  if (!hasToken) return validateCampaign(body.campaign)
+
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return null
+
+  return await loadCampaign(auth.claims.uid)
+}
+
+export async function POST(request: NextRequest) {
+  let body: SuggestRequest = {}
+  try {
+    body = (await request.json()) as SuggestRequest
+  } catch {
+    // An empty body is the ordinary signed-in case — the server loads its own
+    // campaign, so there is nothing for the request to carry.
+  }
+
+  // Every failure below answers the same way: no suggestions, and a playable
+  // game. This is an affordance beside the composer, not a turn — a player who
+  // never learns it was meant to be there has lost nothing, and an error banner
+  // over a story that is working would be worse than the silence.
+  let campaign: Campaign | null
+  try {
+    campaign = await campaignFor(request, body)
+  } catch (error) {
+    console.error('dicebound suggest could not load the campaign:', error)
+    return NextResponse.json({ suggestions: [] })
+  }
+
+  if (!campaign || campaign.transcript.length === 0) {
+    return NextResponse.json({ suggestions: [] })
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), DEADLINE_MS)
+
+  try {
+    const input = await callForTool({
+      apiKey: requireApiKey(),
+      model: SUGGEST_MODEL,
+      system: SYSTEM,
+      maxTokens: SUGGEST_TOKENS,
+      signal: controller.signal,
+      tool: OFFER,
+      messages: [{ role: 'user', content: promptFor(campaign) }],
+    })
+
+    const suggestions = cleanSuggestions((input as { actions?: unknown }).actions)
+    return NextResponse.json({ suggestions })
+  } catch (error) {
+    console.error('dicebound suggest failed:', error)
+    return NextResponse.json({ suggestions: [] })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function promptFor(campaign: Campaign): string {
+  return `${sceneBlock(campaign.world, campaign.kit)}
+
+${recentBlock(campaign.transcript)}
+
+Offer three things ${campaign.character.name} might try next.`
+}
+
+/**
+ * The scene, as the *player* sees it.
+ *
+ * Related to the turn route's `worldBlock` and pointedly not the same thing.
+ * That one prints entity ids, because the DM has to reuse them and to reach for
+ * `recall`; this one prints none, because an id is a slug and a slug that got
+ * echoed into a suggestion would land in the player's text field. Two spent
+ * powers make the difference plainest: the DM is shown them so it knows to
+ * refuse, and this is not shown them at all, because the surest way to stop a
+ * suggestion reaching for an ability that is gone is to never mention it.
+ */
+function sceneBlock(world: World, kit: Kit): string {
+  const { entities } = relevanceWindow(world)
+  const here = currentPlace(world)
+
+  const people = entities
+    .filter(entity => entity.kind === 'actor' && entity.id !== PLAYER_ID)
+    .map(entity => `  ${entity.name}${entity.state ? ` — ${entity.state}` : ''}`)
+
+  // Places as well as things, and the places are the interesting half: a
+  // somewhere the player already knows is what makes "I go back to the
+  // harbour" available as the sideways option, which the scene in front of
+  // them never offers.
+  const things = entities
+    .filter(entity => entity.kind === 'place' || entity.kind === 'thing')
+    .filter(entity => entity.id !== here?.id)
+    .map(entity => `  ${entity.name}${entity.state ? ` — ${entity.state}` : ''}`)
+
+  const threads = openThreads(world).map(thread => `  ${thread.name}`)
+
+  return [
+    `TIME: ${describeClock(world.clock)}`,
+    here ? `WHERE THEY ARE: ${here.name}${here.state ? ` — ${here.state}` : ''}` : '',
+    people.length ? `WHO IS AROUND:\n${people.join('\n')}` : '',
+    things.length ? `WHAT IS AROUND, AND WHERE THEY COULD GO:\n${things.join('\n')}` : '',
+    carriedBlock(kit.items),
+    abilitiesBlock(kit.powers),
+    threads.length ? `UNFINISHED:\n${threads.join('\n')}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+}
+
+/** What they are carrying, with the permission each thing grants said out loud. */
+function carriedBlock(items: readonly Item[]): string {
+  if (items.length === 0) return ''
+
+  const lines = items.map(item => {
+    // The trait labels are already written as permissions — "you have rope" —
+    // which is the exact register a suggestion wants. The bonus attached to
+    // them is not here and never will be: what a thing is worth on the die is
+    // the DM's business, and a suggester that could see the numbers would start
+    // steering the player toward the good ones.
+    const grants = item.traits.map(trait => trait.label).join('; ')
+    return `  ${item.name}${item.note ? ` — ${item.note}` : ''}${grants ? ` (${grants})` : ''}`
+  })
+
+  return `WHAT THEY CARRY:\n${lines.join('\n')}`
+}
+
+/** Only the abilities they could actually reach for right now. */
+function abilitiesBlock(powers: readonly Power[]): string {
+  const usable = powers.filter(power => power.charges.now > 0)
+  if (usable.length === 0) return ''
+
+  const lines = usable.map(power => {
+    const what =
+      power.shape === 'permits'
+        ? `lets them ${power.permits || 'do something they otherwise could not'}`
+        : power.note || 'helps when it bears on what they are doing'
+    return `  ${power.name} — ${what}${power.cost ? `, at the cost of ${power.cost}` : ''}`
+  })
+
+  return `WHAT THEY CAN DO:\n${lines.join('\n')}`
+}
+
+/**
+ * The last thing that happened, which is what the suggestions are actually about.
+ *
+ * Checks and earned ranks are dropped rather than summarised. A die roll is the
+ * mechanical half of a beat whose fictional half is in the narration either
+ * side of it, and telling this model about margins and DCs is how a suggestion
+ * ends up phrased as "I try again, harder".
+ */
+function recentBlock(entries: readonly TranscriptEntry[]): string {
+  const lines = entries
+    .filter(entry => entry.kind === 'narration' || entry.kind === 'player')
+    .slice(-RECENT_ENTRIES)
+    .map(entry => (entry.kind === 'player' ? `(they said: "${entry.text}")` : entry.text))
+
+  return `THE STORY JUST NOW:\n${lines.join('\n\n')}`
+}

--- a/src/app/dicebound/DiceboundGame.tsx
+++ b/src/app/dicebound/DiceboundGame.tsx
@@ -28,8 +28,18 @@ import { useDicebound } from './store'
 
 export function DiceboundGame() {
   const { user, loading: authLoading, configured } = useAuth()
-  const { phase, campaign, pending, error, attach, begin, act, abandon, dismissError } =
-    useDicebound()
+  const {
+    phase,
+    campaign,
+    pending,
+    error,
+    suggestions,
+    attach,
+    begin,
+    act,
+    abandon,
+    dismissError,
+  } = useDicebound()
 
   const [sheetOpen, setSheetOpen] = useState(false)
 
@@ -120,7 +130,7 @@ export function DiceboundGame() {
           </p>
         )}
 
-        <Composer onSend={act} disabled={pending} />
+        <Composer onSend={act} disabled={pending} suggestions={suggestions} />
       </div>
 
       {/* Desktop: the sheet is always there. Mobile: it slides over. */}

--- a/src/app/dicebound/api.ts
+++ b/src/app/dicebound/api.ts
@@ -87,3 +87,44 @@ export async function takeTurn(
 
   return (await response.json()) as TurnResponse
 }
+
+/**
+ * Three things the player might try next.
+ *
+ * The one call in this file that cannot fail. Everything else here throws so
+ * the store can put an in-character line in front of the player; this returns
+ * an empty list instead, because there is no failure worth telling them about.
+ * The suggestions are an offer beside a working game, and a player who never
+ * finds out they were meant to be there has lost nothing — whereas "the cave
+ * could not think of anything" over a story that is fine would be pure noise.
+ *
+ * Same two shapes as a turn: with a token the server loads its own campaign and
+ * the body is empty, without one there is no server-side story to read.
+ */
+export async function fetchSuggestions({
+  token,
+  campaign,
+}: {
+  token: string | null
+  campaign: Campaign
+}): Promise<string[]> {
+  try {
+    const response = await fetch('/api/v1/dicebound/suggest', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(token ? {} : { campaign }),
+    })
+
+    if (!response.ok) return []
+
+    const body = (await response.json()) as { suggestions?: unknown }
+    return Array.isArray(body.suggestions)
+      ? body.suggestions.filter((line): line is string => typeof line === 'string')
+      : []
+  } catch {
+    return []
+  }
+}

--- a/src/app/dicebound/components/__tests__/composer.test.tsx
+++ b/src/app/dicebound/components/__tests__/composer.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Composer } from '@/app/dicebound/components/composer'
+
+afterEach(cleanup)
+
+const THREE = [
+  'I try to lever the chain off with the lantern hook.',
+  'I ask Maren who she paid to chain this grate.',
+  'I go under, and feel for the drain the water is leaving by.',
+]
+
+const field = () => screen.getByRole('textbox') as HTMLTextAreaElement
+const chip = (label: string) => screen.getByRole('button', { name: label }) as HTMLButtonElement
+
+describe('Composer suggestions', () => {
+  it('fills the field on a tap and does not send', () => {
+    // The whole design decision, and the only thing protecting it. Dicebound is
+    // a game where the player writes the attempt in their own words; a chip
+    // that sent on tap would turn it into a three-option menu, and no test
+    // anywhere else would notice.
+    const onSend = vi.fn()
+    render(<Composer onSend={onSend} disabled={false} suggestions={THREE} />)
+
+    fireEvent.click(chip(THREE[1]))
+
+    expect(field().value).toBe(THREE[1])
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('leaves the caret at the end, so the edit is one keystroke away', () => {
+    render(<Composer onSend={vi.fn()} disabled={false} suggestions={THREE} />)
+
+    fireEvent.click(chip(THREE[0]))
+
+    expect(document.activeElement).toBe(field())
+    expect(field().selectionStart).toBe(THREE[0].length)
+  })
+
+  it('renders nothing at all when there is nothing to offer', () => {
+    // Invariant 17. An empty rail above the composer advertises a feature the
+    // player has not met and turns a quiet moment into a waiting one.
+    render(<Composer onSend={vi.fn()} disabled={false} suggestions={[]} />)
+    expect(screen.queryByRole('list')).toBeNull()
+  })
+
+  it('keeps the last three on screen while the dungeon master answers, untappable', () => {
+    // They stay so the composer does not jump: clearing the row mid-turn moves
+    // the send button out from under a thumb already reaching for it. Disabled
+    // so nobody acts on a scene that has already moved on.
+    render(<Composer onSend={vi.fn()} disabled={true} suggestions={THREE} />)
+
+    for (const line of THREE) {
+      expect(chip(line).disabled).toBe(true)
+    }
+  })
+})

--- a/src/app/dicebound/components/composer.tsx
+++ b/src/app/dicebound/components/composer.tsx
@@ -6,7 +6,10 @@
  * The placeholder is load-bearing. This is a game with no buttons and no verb
  * list, so the input field is the only place the rules can say "describe an
  * attempt, not a command" — and a player who types "attack" instead of "I
- * swing the lantern at the rope" gets a worse story out of the same model.
+ * swing the lantern at the rope" gets a worse story out of the same model. It
+ * is written in the first person, as the sentence the player is about to type,
+ * because the suggestion chips below speak in that voice and the field and the
+ * chips have to be teaching the same grammar.
  *
  * Enter sends and Shift+Enter breaks the line, which is the convention every
  * player already has in their hands. The textarea grows with the text so a
@@ -14,6 +17,7 @@
  */
 import { type KeyboardEvent, useEffect, useRef, useState } from 'react'
 
+import { Suggestions } from '@/app/dicebound/components/suggestions'
 import { MAX_ACTION } from '@/app/dicebound/domain/campaign'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 
@@ -22,12 +26,16 @@ const MAX_ROWS_PX = 200
 export function Composer({
   onSend,
   disabled,
+  suggestions = [],
 }: {
   onSend: (text: string) => void
   disabled: boolean
+  suggestions?: readonly string[]
 }) {
   const [value, setValue] = useState('')
   const ref = useRef<HTMLTextAreaElement>(null)
+  /** Set by a suggestion tap, read once by the effect that moves the caret. */
+  const caretToEnd = useRef(false)
 
   useEffect(() => {
     const el = ref.current
@@ -41,6 +49,30 @@ export function Composer({
   useEffect(() => {
     if (!disabled) ref.current?.focus()
   }, [disabled])
+
+  /**
+   * A tapped suggestion, waiting to be edited.
+   *
+   * The caret has to be put at the end afterwards rather than here: React
+   * writes the new value on the next render, and moving the caret before that
+   * lands it at the end of whatever the field used to contain. Focus follows
+   * for the same reason the field takes focus when the DM finishes — the edit
+   * has to be one keystroke away, or nobody makes it and the chip has quietly
+   * become a button that sends.
+   */
+  const fill = (text: string) => {
+    caretToEnd.current = true
+    setValue(text)
+  }
+
+  useEffect(() => {
+    if (!caretToEnd.current) return
+    caretToEnd.current = false
+    const el = ref.current
+    if (!el) return
+    el.focus()
+    el.setSelectionRange(el.value.length, el.value.length)
+  }, [value])
 
   const send = () => {
     const text = value.trim()
@@ -58,6 +90,7 @@ export function Composer({
 
   return (
     <div className="border-t-2 border-outline-variant bg-surface-container-low px-4 py-4 md:px-8">
+      <Suggestions suggestions={suggestions} onPick={fill} disabled={disabled} />
       <div className="mx-auto flex max-w-2xl items-end gap-3">
         <label htmlFor="dicebound-action" className="sr-only">
           What do you do?
@@ -71,7 +104,7 @@ export function Composer({
           disabled={disabled}
           onChange={event => setValue(event.target.value)}
           onKeyDown={onKeyDown}
-          placeholder="You try to…"
+          placeholder="I try to…"
           className="flex-1 resize-none rounded-ds-sm border-2 border-outline-variant bg-surface-container px-4 py-3 text-body-md text-on-surface placeholder:text-on-surface-variant/60 focus:border-ds-primary focus:outline-none disabled:opacity-50"
         />
         <ChunkyButton

--- a/src/app/dicebound/components/suggestions.tsx
+++ b/src/app/dicebound/components/suggestions.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+/**
+ * Three things you might try, offered under the composer.
+ *
+ * They fill the field; they do not send it. That is the whole design decision
+ * and it is the one thing in this file worth protecting. Dicebound is a game
+ * where the player writes an attempt in their own words — the composer's
+ * placeholder exists to teach that, and the DM is forbidden from ever asking
+ * "what do you do?" precisely so the sentence stays theirs. A chip that sent on
+ * tap would turn all of that into a three-option menu within a week, and the
+ * median action would get shorter and blander with it.
+ *
+ * So a tap is a starting point. The text lands in the box with the caret at the
+ * end of it, one keystroke away from being edited into something the player
+ * actually meant. It is the same bargain the creation screen already makes with
+ * its concept and premise chips.
+ *
+ * Nothing renders until there is something to offer (invariant 17) — but once
+ * the story is under way the row stays put through a turn, greyed and
+ * untappable while the dungeon master answers, so the composer under a player's
+ * thumb never moves.
+ */
+export function Suggestions({
+  suggestions,
+  onPick,
+  disabled,
+}: {
+  suggestions: readonly string[]
+  onPick: (text: string) => void
+  disabled: boolean
+}) {
+  if (suggestions.length === 0) return null
+
+  return (
+    <ul
+      // Keyed on the set itself so React remounts the list when the three
+      // change, which is what replays the fade. A new three arrive under a
+      // player who is still reading the paragraph above them, and something
+      // that appears without warning under moving eyes reads as a glitch.
+      key={suggestions.join(' ')}
+      aria-label="Things you might try. Choosing one fills the box; you can change it before you send."
+      className="dicebound-suggestions mx-auto flex max-w-2xl flex-wrap gap-2 pb-3"
+    >
+      {suggestions.map(suggestion => (
+        <li key={suggestion}>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onPick(suggestion)}
+            className="rounded-full border border-outline-variant bg-surface-container-low px-3 py-1.5 text-left text-sm italic text-on-surface-variant transition-colors hover:border-ds-primary/60 hover:not-italic hover:text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ds-primary disabled:opacity-40"
+          >
+            {suggestion}
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/app/dicebound/domain/__tests__/suggest.test.ts
+++ b/src/app/dicebound/domain/__tests__/suggest.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { MAX_SUGGESTION, SUGGESTION_COUNT, cleanSuggestions } from '@/app/dicebound/domain/suggest'
+
+describe('cleanSuggestions', () => {
+  it('keeps three plain lines as they were written', () => {
+    const lines = [
+      'I try to lever the chain off with the lantern hook.',
+      'I ask Maren who she paid to chain this grate.',
+      'I go under, and feel for the drain the water is leaving by.',
+    ]
+    expect(cleanSuggestions(lines)).toEqual(lines)
+  })
+
+  it('never offers the same move twice, whatever case it arrives in', () => {
+    // The one failure this feature must not have. Three chips that all say the
+    // obvious thing is worse than no chips at all — it tells the player the
+    // scene has a single exit, which is exactly the narrowing that suggestions
+    // are supposed to be worth risking.
+    expect(
+      cleanSuggestions(['I go for the latch.', 'I GO FOR THE LATCH.', 'I ask her about the book.'])
+    ).toEqual(['I go for the latch.', 'I ask her about the book.'])
+  })
+
+  it('strips the list furniture a model adds when it thinks it is writing a list', () => {
+    expect(
+      cleanSuggestions(['- I run for the door.', '2. I shout for Maren.', '"I wait."'])
+    ).toEqual(['I run for the door.', 'I shout for Maren.', 'I wait.'])
+  })
+
+  it('offers at most three, however many came back', () => {
+    const many = ['I one.', 'I two.', 'I three.', 'I four.', 'I five.']
+    expect(cleanSuggestions(many)).toHaveLength(SUGGESTION_COUNT)
+  })
+
+  it('drops anything that is not a usable string rather than rendering a hole', () => {
+    expect(cleanSuggestions(['I run.', '', '   ', null, 42, { text: 'I hide.' }])).toEqual([
+      'I run.',
+    ])
+  })
+
+  it('is empty for anything that is not a list at all', () => {
+    expect(cleanSuggestions(undefined)).toEqual([])
+    expect(cleanSuggestions('I try to leave.')).toEqual([])
+    expect(cleanSuggestions({ actions: ['I try to leave.'] })).toEqual([])
+  })
+
+  it('cuts an over-long line back to a word boundary, never mid-word', () => {
+    // The cap is a guard against a model that answers with a paragraph, and on
+    // a phone that paragraph would push the composer off the screen. But this
+    // string is about to be dropped into a field the player edits, and half a
+    // word is a worse starting point than a shorter sentence.
+    const long = `I try to ${'wander '.repeat(40)}away`
+    const [cut] = cleanSuggestions([long])
+
+    expect(cut.length).toBeLessThanOrEqual(MAX_SUGGESTION)
+    expect(cut).toMatch(/wander$/)
+  })
+})

--- a/src/app/dicebound/store.ts
+++ b/src/app/dicebound/store.ts
@@ -15,7 +15,7 @@ import { create } from 'zustand'
 
 import { getTodayPST, getYesterdayOf } from '@/lib/dates'
 
-import { createCharacter, takeTurn } from './api'
+import { createCharacter, fetchSuggestions, takeTurn } from './api'
 import { type CampaignBackend, nullBackend } from './backend'
 import { type Campaign, MAX_CONCEPT, MAX_PREMISE, newCampaign, withVisit } from './domain/campaign'
 import { applyTurn } from './domain/turn'
@@ -32,12 +32,34 @@ interface DiceboundState {
   /** In-character error text, cleared on the next successful action. */
   error: string | null
   backend: CampaignBackend
+  /**
+   * Three things the player might try, for the composer to offer.
+   *
+   * They belong to the scene rather than to the campaign, so they live here and
+   * are never saved. Deliberately *not* cleared when the player acts: the old
+   * three stay on screen, greyed and untappable, until the new three replace
+   * them. Clearing would collapse the row and shove the composer down the
+   * screen twice a turn, which on a phone means the send button moves under a
+   * thumb that is already reaching for it.
+   */
+  suggestions: string[]
+  /**
+   * Which request the suggestions on screen belong to.
+   *
+   * A turn takes real seconds and a suggestion call is fired after every one of
+   * them, so two can easily be in flight across a fast player's turn. Only the
+   * newest may land — an older one arriving late would offer moves for a scene
+   * that is already two paragraphs back.
+   */
+  suggestSeq: number
 
   attach: (backend: CampaignBackend) => Promise<void>
   begin: (premise: string, concept: string) => Promise<void>
   act: (action: string) => Promise<void>
   abandon: () => Promise<void>
   dismissError: () => void
+  /** Ask for a fresh three. Called by the store itself after anything that moves the story. */
+  refreshSuggestions: () => Promise<void>
 }
 
 function freshCampaign(premise: string, character: Character, now: number): Campaign {
@@ -50,6 +72,8 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
   pending: false,
   error: null,
   backend: nullBackend,
+  suggestions: [],
+  suggestSeq: 0,
 
   /**
    * Point the store at storage and load whatever is there.
@@ -63,7 +87,7 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
     const stored = await backend.load()
 
     if (!stored) {
-      set({ phase: 'creating', campaign: null })
+      set({ phase: 'creating', campaign: null, suggestions: [] })
       return
     }
 
@@ -71,6 +95,10 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
     const visited = withVisit(stored, today, getYesterdayOf(today))
     set({ phase: 'playing', campaign: visited })
     if (visited !== stored) void backend.save(visited)
+
+    // A returning player finds the three under the scene they left on, rather
+    // than an empty rail until they have taken one more turn (CLAUDE.md 3).
+    void get().refreshSuggestions()
   },
 
   async begin(premise, concept) {
@@ -97,6 +125,7 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
       // send the whole campaign straight back to the endpoint this change
       // exists to stop trusting.
       if (!authoritative) void get().backend.save(opened)
+      void get().refreshSuggestions()
     } catch (error) {
       set({
         pending: false,
@@ -132,6 +161,10 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
 
       set({ campaign: next, pending: false })
       if (!authoritative) void get().backend.save(next)
+      // Fired after the turn is on screen, never awaited. The player is
+      // already reading; the three arrive underneath them a beat later and the
+      // turn never waits on a model whose answer it does not need.
+      void get().refreshSuggestions()
     } catch (error) {
       // Roll the optimistic line back out, so the player can edit and resend
       // rather than staring at an action the story never received.
@@ -145,11 +178,35 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
 
   async abandon() {
     if (get().pending) return
-    set({ phase: 'creating', campaign: null, error: null })
+    // The sequence moves so a call still in flight for the abandoned story
+    // cannot land on the next one.
+    set({
+      phase: 'creating',
+      campaign: null,
+      error: null,
+      suggestions: [],
+      suggestSeq: get().suggestSeq + 1,
+    })
     await get().backend.clear()
   },
 
   dismissError() {
     set({ error: null })
+  },
+
+  async refreshSuggestions() {
+    const campaign = get().campaign
+    if (!campaign || campaign.transcript.length === 0) return
+
+    const seq = get().suggestSeq + 1
+    set({ suggestSeq: seq })
+
+    const token = await get().backend.token()
+    const suggestions = await fetchSuggestions({ token, campaign })
+
+    // A newer turn has already asked, or the story was abandoned underneath
+    // this. Either way these are about a scene that has moved on.
+    if (get().suggestSeq !== seq) return
+    set({ suggestions })
   },
 }))

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -717,6 +717,22 @@ body {
   }
 }
 
+/* ───────────────────────────────────────────────────────────────────
+   Dicebound — the three suggestions arriving under the composer.
+   They land a beat after the narration the player is still reading, so
+   they fade in rather than snap. Re-keying the list on a new set plays
+   it again. Reduced motion is handled by the global rule above.
+   ─────────────────────────────────────────────────────────────────── */
+
+@keyframes dicebound-suggestions-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.dicebound-suggestions {
+  animation: dicebound-suggestions-in 0.3s ease-out;
+}
+
 @media print {
   /* Page break control */
   .break-after-page {


### PR DESCRIPTION
Three suggested actions under the composer, generated by their own route and their own model, offered as a starting point rather than as a menu.


## The two decisions

**The dungeon master is never told these exist.** The cheap version — a `suggestions` field on `narrate` — would have the DM compose the scene and the player's options in the same breath, and a model that knows what it is about to offer starts writing scenes with three exits. That flattening is invisible: nobody can point at the turn where it happened, and no test would catch it. So this is a separate call to a separate model reading the finished scene, and **`turn/route.ts` is untouched**. Same split that keeps the resolver ignorant of powers (#3569) and puts item grants behind a tool rather than a field (#3521).

**A chip fills the field; it does not send it.** Dicebound is a game where the player writes an attempt in their own words — the composer placeholder exists to teach that, and the DM is forbidden from asking "what do you do?" for the same reason. Tap-to-send would raise turns per session and cost the thing the sessions are made of. The text lands in the box with the caret at the end, one keystroke from being edited, exactly as the creation screen's concept and premise chips already work. The placeholder moves to `"I try to…"` so the field and the chips teach the same grammar.

## What that implies

- **Haiku 4.5**, fired after the turn renders and never awaited. It is racing the player's own reading of the paragraph that just arrived.
- **Its scene block is not `worldBlock`.** No entity ids — a slug echoed into a suggestion would land in the player's text field. Spent powers are not shown *at all*, which is the surest way to stop it reaching for an ability that is gone.
- **Few-shot examples span three unrelated worlds.** Examples get echoed, not merely imitated; the only thing the three sets may share is the shape — one option at face value, one reaching for a person or a thing carried, one sideways.
- **Nothing is stored.** A suggestion is a string bound for a text field, so it lives on the response and never on `Campaign`. No version bump, no new blob field.
- **Every failure answers with an empty list.** This is an affordance beside a working game; a player who never learns it was meant to be there has lost nothing, and an error banner over a story that is fine would be pure noise.
- The row stays on screen greyed and disabled while the DM answers rather than clearing, so the send button never moves out from under a thumb mid-turn.

## Verification

`npx vitest run src/app/dicebound` (8 new tests) · `eslint` clean · `tsc --noEmit | grep dicebound` empty · `lint:routes` ok.

Live calls in two unrelated genres, 2.1s and 1.6s:

```
harbour  I try to lever the chain off with my hook before the water gets higher.
         I ask Maren if she put this chain here to keep me from leaving.
         I go down and feel along the left wall for where the water is draining to.

ship     I try to wedge my torque bar under the hatch seal to buy us time.
         I ask Oyelaran how long the sleeper bay has been running hot.
         I go into the sleeper bay and trigger Coldstart before she can stop me.
```

The second is the one that matters: no furniture from the examples leaked in, and it reached for a power with charges left while ignoring one planted at zero.

## Two notes for the reviewer

- `src/app/dicebound/domain/suggest.ts` and the `SUGGEST_MODEL` constant in `anthropic.ts` are **already on main** — they were swept into 19077ea6 (#3581) from a shared working tree. They belong to this change; they merely landed early.
- The risk this carries is not in the code. Always-visible plus fill means the field is never blank, and the thing to watch is whether the median action gets shorter and blander over a few weeks. `stats` does not track action length today. If it does drift, filling with a *partial* action is the lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

