### PR TITLE
feat(dicebound): the cave names what you already are

### DIFF
--- a/src/app/api/v1/dicebound/suggest/route.ts
+++ b/src/app/api/v1/dicebound/suggest/route.ts
@@ -1,0 +1,307 @@
+/**
+ * Three things the player might try, offered beside the composer.
+ *
+ * This is a separate route and a separate model call, and both halves of that
+ * are the design rather than the plumbing.
+ *
+ * Separate call, because the alternative — a `suggestions` field on `narrate` —
+ * would have the dungeon master compose the scene and the player's options in
+ * the same breath, and a DM that knows what it is about to offer starts writing
+ * scenes with three exits. Nothing here is visible from the turn loop, and the
+ * DM is never told this exists. The same instinct governs advantage (#3569) and
+ * item grants (#3521): the thing that writes prose does not get to see the
+ * affordance it is writing toward.
+ *
+ * Separate model, because this is not the dungeon master's job. It reads one
+ * scene and writes three sentences in the player's voice — no dice, no world to
+ * keep, no continuity to hold — and it has to come back fast, because it is
+ * racing the player's own reading of the paragraph that just arrived.
+ *
+ * Nothing it returns is stored. A suggestion is a string that lands in the text
+ * field for the player to edit; the campaign never learns it happened, which is
+ * why there is no version bump and nothing new on `Campaign`.
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import {
+  type Campaign,
+  type TranscriptEntry,
+  validateCampaign,
+} from '@/app/dicebound/domain/campaign'
+import type { Item, Kit, Power } from '@/app/dicebound/domain/kit'
+import { SUGGESTION_COUNT, cleanSuggestions } from '@/app/dicebound/domain/suggest'
+import {
+  PLAYER_ID,
+  type World,
+  currentPlace,
+  describeClock,
+  openThreads,
+  relevanceWindow,
+} from '@/app/dicebound/domain/world'
+import { verifyRequestAuth } from '@/lib/api/auth'
+import {
+  SUGGEST_MODEL,
+  type ToolDef,
+  callForTool,
+  requireApiKey,
+  toolSchema,
+} from '@/lib/dicebound/anthropic'
+import { loadCampaign } from '@/lib/dicebound/campaign-store'
+
+/** Short on purpose. This is losing a race with the player if it takes longer. */
+export const maxDuration = 30
+
+/** The hard deadline. Past this the player is typing and the answer is no longer wanted. */
+const DEADLINE_MS = 12_000
+
+/** Three short lines. The ceiling is a backstop against a model that decides to explain itself. */
+const SUGGEST_TOKENS = 400
+
+/** How much of the recent story the suggester is shown. Enough for the scene, not the campaign. */
+const RECENT_ENTRIES = 5
+
+const OFFER_TOOL = 'offer_actions'
+
+/**
+ * The rules, and three worked examples of them.
+ *
+ * The examples are here rather than beside the scene because they are rules
+ * expressed as examples — the user message stays purely this story, which is
+ * the thing that changes every turn.
+ *
+ * They span three unrelated worlds deliberately. A model given one set about a
+ * lantern and a harbour will put lanterns and harbours into a story about a
+ * space station: few-shot examples get echoed, not merely imitated, and the
+ * only defence is to make the shared thing the *shape* rather than the
+ * furniture. What each set demonstrates is the spread — one option that takes
+ * the scene at face value, one that reaches for a person or a thing carried,
+ * one sideways — because three flavours of the same move is the failure that
+ * would quietly narrow the game.
+ */
+const SYSTEM = `You help a player of Dicebound decide what to do next. You are not the dungeon master. You never narrate, and you never say what happens — you write three things the player might type into the box, in their own words.
+
+VOICE
+- First person, as they would type it: "I try to…", "I ask…", "I go for…", "I tell…".
+- One sentence. Short — about a dozen words at most.
+- An attempt, never its result. "I try to lever the chain off" — not "I get the chain off". The dice decide whether it works, and a line that promises the outcome teaches the player to expect one.
+- Specific and plain. "I go for his lantern hand" beats "I attack".
+
+THE THREE
+They must not be three flavours of the same move. Write one of each:
+  1. the situation in front of them, taken at face value
+  2. a reach for a person, a promise, or something they are carrying
+  3. sideways — the angle the scene did not offer
+
+Only suggest what this character could actually try. They have the things and the abilities listed and nothing else; an ability that is not listed is not available. Never suggest simply waiting, thinking, or looking around. Never ask the player a question. Never mention the dice, the rules, the game, or these suggestions.
+
+EXAMPLES OF THE SHAPE
+
+Scene: the tide is coming into the stairwell. Maren is on the step above you, and the grate at the top is chained.
+  I try to lever the chain off with the lantern hook.
+  I ask Maren who she paid to have this grate chained.
+  I go under, and feel along the wall for the drain the water is leaving by.
+
+Scene: the librarian has gone very still, and the book you asked for is already open on the desk behind her.
+  I attempt to read the open page without stepping any closer.
+  I tell her I know whose handwriting that is.
+  I go for the window latch.
+
+Scene: the caravan has stopped. The lead camel will not go forward, and the guide is pretending not to have noticed.
+  I try to see what the camel is looking at.
+  I ask the guide what he owes the people who live out here.
+  I go and cut the water skins loose while everyone is watching the front.`
+
+const OfferSchema = z.object({
+  actions: z
+    .array(z.string())
+    .length(SUGGESTION_COUNT)
+    .describe(
+      'Three things the player might type. First person, one short sentence each, an attempt and not its outcome. Each a different kind of move.'
+    ),
+})
+
+const OFFER: ToolDef = {
+  name: OFFER_TOOL,
+  description: 'Offer the player three things they might try next.',
+  input_schema: toolSchema(OfferSchema),
+}
+
+interface SuggestRequest {
+  campaign?: unknown
+}
+
+/**
+ * The campaign these suggestions are for.
+ *
+ * Deliberately not the turn route's `campaignFor`, though it starts the same
+ * way. That one carries an exception for the opening turn, whose campaign
+ * arrives in the body because the server has nothing to load yet — a creation.
+ * There is no opening case here: suggestions exist only once a story does, so
+ * a signed-in player with nothing stored has nothing to suggest against, and
+ * the simpler rule is the correct one rather than a copy waiting to drift.
+ */
+async function campaignFor(request: NextRequest, body: SuggestRequest): Promise<Campaign | null> {
+  const hasToken = /^Bearer\s+.+$/i.test(
+    request.headers.get('authorization') ?? request.headers.get('Authorization') ?? ''
+  )
+
+  // No token is the local-only backend: Firebase unconfigured, so there is no
+  // server-side story and the client sends its own, exactly as it does for a turn.
+  if (!hasToken) return validateCampaign(body.campaign)
+
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return null
+
+  return await loadCampaign(auth.claims.uid)
+}
+
+export async function POST(request: NextRequest) {
+  let body: SuggestRequest = {}
+  try {
+    body = (await request.json()) as SuggestRequest
+  } catch {
+    // An empty body is the ordinary signed-in case — the server loads its own
+    // campaign, so there is nothing for the request to carry.
+  }
+
+  // Every failure below answers the same way: no suggestions, and a playable
+  // game. This is an affordance beside the composer, not a turn — a player who
+  // never learns it was meant to be there has lost nothing, and an error banner
+  // over a story that is working would be worse than the silence.
+  let campaign: Campaign | null
+  try {
+    campaign = await campaignFor(request, body)
+  } catch (error) {
+    console.error('dicebound suggest could not load the campaign:', error)
+    return NextResponse.json({ suggestions: [] })
+  }
+
+  if (!campaign || campaign.transcript.length === 0) {
+    return NextResponse.json({ suggestions: [] })
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), DEADLINE_MS)
+
+  try {
+    const input = await callForTool({
+      apiKey: requireApiKey(),
+      model: SUGGEST_MODEL,
+      system: SYSTEM,
+      maxTokens: SUGGEST_TOKENS,
+      signal: controller.signal,
+      tool: OFFER,
+      messages: [{ role: 'user', content: promptFor(campaign) }],
+    })
+
+    const suggestions = cleanSuggestions((input as { actions?: unknown }).actions)
+    return NextResponse.json({ suggestions })
+  } catch (error) {
+    console.error('dicebound suggest failed:', error)
+    return NextResponse.json({ suggestions: [] })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function promptFor(campaign: Campaign): string {
+  return `${sceneBlock(campaign.world, campaign.kit)}
+
+${recentBlock(campaign.transcript)}
+
+Offer three things ${campaign.character.name} might try next.`
+}
+
+/**
+ * The scene, as the *player* sees it.
+ *
+ * Related to the turn route's `worldBlock` and pointedly not the same thing.
+ * That one prints entity ids, because the DM has to reuse them and to reach for
+ * `recall`; this one prints none, because an id is a slug and a slug that got
+ * echoed into a suggestion would land in the player's text field. Two spent
+ * powers make the difference plainest: the DM is shown them so it knows to
+ * refuse, and this is not shown them at all, because the surest way to stop a
+ * suggestion reaching for an ability that is gone is to never mention it.
+ */
+function sceneBlock(world: World, kit: Kit): string {
+  const { entities } = relevanceWindow(world)
+  const here = currentPlace(world)
+
+  const people = entities
+    .filter(entity => entity.kind === 'actor' && entity.id !== PLAYER_ID)
+    .map(entity => `  ${entity.name}${entity.state ? ` — ${entity.state}` : ''}`)
+
+  // Places as well as things, and the places are the interesting half: a
+  // somewhere the player already knows is what makes "I go back to the
+  // harbour" available as the sideways option, which the scene in front of
+  // them never offers.
+  const things = entities
+    .filter(entity => entity.kind === 'place' || entity.kind === 'thing')
+    .filter(entity => entity.id !== here?.id)
+    .map(entity => `  ${entity.name}${entity.state ? ` — ${entity.state}` : ''}`)
+
+  const threads = openThreads(world).map(thread => `  ${thread.name}`)
+
+  return [
+    `TIME: ${describeClock(world.clock)}`,
+    here ? `WHERE THEY ARE: ${here.name}${here.state ? ` — ${here.state}` : ''}` : '',
+    people.length ? `WHO IS AROUND:\n${people.join('\n')}` : '',
+    things.length ? `WHAT IS AROUND, AND WHERE THEY COULD GO:\n${things.join('\n')}` : '',
+    carriedBlock(kit.items),
+    abilitiesBlock(kit.powers),
+    threads.length ? `UNFINISHED:\n${threads.join('\n')}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+}
+
+/** What they are carrying, with the permission each thing grants said out loud. */
+function carriedBlock(items: readonly Item[]): string {
+  if (items.length === 0) return ''
+
+  const lines = items.map(item => {
+    // The trait labels are already written as permissions — "you have rope" —
+    // which is the exact register a suggestion wants. The bonus attached to
+    // them is not here and never will be: what a thing is worth on the die is
+    // the DM's business, and a suggester that could see the numbers would start
+    // steering the player toward the good ones.
+    const grants = item.traits.map(trait => trait.label).join('; ')
+    return `  ${item.name}${item.note ? ` — ${item.note}` : ''}${grants ? ` (${grants})` : ''}`
+  })
+
+  return `WHAT THEY CARRY:\n${lines.join('\n')}`
+}
+
+/** Only the abilities they could actually reach for right now. */
+function abilitiesBlock(powers: readonly Power[]): string {
+  const usable = powers.filter(power => power.charges.now > 0)
+  if (usable.length === 0) return ''
+
+  const lines = usable.map(power => {
+    const what =
+      power.shape === 'permits'
+        ? `lets them ${power.permits || 'do something they otherwise could not'}`
+        : power.note || 'helps when it bears on what they are doing'
+    return `  ${power.name} — ${what}${power.cost ? `, at the cost of ${power.cost}` : ''}`
+  })
+
+  return `WHAT THEY CAN DO:\n${lines.join('\n')}`
+}
+
+/**
+ * The last thing that happened, which is what the suggestions are actually about.
+ *
+ * Checks and earned ranks are dropped rather than summarised. A die roll is the
+ * mechanical half of a beat whose fictional half is in the narration either
+ * side of it, and telling this model about margins and DCs is how a suggestion
+ * ends up phrased as "I try again, harder".
+ */
+function recentBlock(entries: readonly TranscriptEntry[]): string {
+  const lines = entries
+    .filter(entry => entry.kind === 'narration' || entry.kind === 'player')
+    .slice(-RECENT_ENTRIES)
+    .map(entry => (entry.kind === 'player' ? `(they said: "${entry.text}")` : entry.text))
+
+  return `THE STORY JUST NOW:\n${lines.join('\n\n')}`
+}

--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -97,6 +97,13 @@ import {
   spendPower,
 } from '@/app/dicebound/domain/kit'
 import {
+  type ClassShape,
+  classShape,
+  fallbackClass,
+  readClass,
+  shouldNameClass,
+} from '@/app/dicebound/domain/klass'
+import {
   GRANT_ITEM_TOOL,
   GRANT_POWER_TOOL,
   NARRATE_TOOL,
@@ -105,6 +112,7 @@ import {
   type TurnResult,
   USE_POWER_TOOL,
   applyTurn,
+  creditSkills,
   partitionTurnCalls,
 } from '@/app/dicebound/domain/turn'
 import { bool } from '@/app/dicebound/domain/validate'
@@ -1069,6 +1077,31 @@ Resolve it, then call narrate with what happens.`,
 
   entries.push({ kind: 'narration', text: narration })
 
+  // The cave forms an opinion, once.
+  //
+  // Level is recomputed from the character this turn produced rather than from
+  // `level`, which was read before the turn ran — the check that pushed them to
+  // level 2 usually happens *in* this turn, and reading the stale value would
+  // hold the name back until the next one for no reason the player could see.
+  //
+  // `className === null` is the whole of the once-ness. Nothing re-reads the
+  // histogram at level 3, and whether a class should ever be revisited is a
+  // decision this issue deliberately does not settle by accident.
+  if (kit.className === null) {
+    const { character: credited } = creditSkills(campaign.character, entries, world.clock.elapsed)
+    if (shouldNameClass(kit, levelFor(earnedRanks(credited)))) {
+      const shape = classShape(credited)
+      const named = await nameClass(apiKey, campaign, shape, signal)
+      kit = { ...kit, className: named.name }
+      // A line in the DM's voice, not a modal and not a congratulations. The
+      // cave noticed what they are; it does not need to celebrate it.
+      entries.push({
+        kind: 'narration',
+        text: `Somewhere in all of that, without anybody deciding it, you became this: ${named.name}.${named.note ? ` ${named.note}` : ''}`,
+      })
+    }
+  }
+
   // A quiet line, in the game's own voice, and only when something actually
   // came back. Not a toast and not a banner: the cave is light and ceremony
   // lives inside the game (CLAUDE.md #2), and this is a small thing that
@@ -1709,6 +1742,83 @@ ${transcriptBlock(older)}`,
  * plus a shorter window, which reads as the DM being slightly forgetful rather
  * than as an error.
  */
+const NameClassSchema = z.object({
+  name: z
+    .string()
+    .describe(
+      'Two or three words at most, the way people at a table would refer to this person. Not a job title and not a fantasy-game class. "Cat Burglar", "Ropewalker", "The One Who Asks".'
+    ),
+  note: z
+    .string()
+    .describe(
+      'One short line saying what they are, in the second person. No numbers, no mechanics.'
+    ),
+})
+
+const NAME_CLASS: ToolDef = {
+  name: 'name_class',
+  description: 'Give the character the name for what they have turned out to be.',
+  input_schema: toolSchema(NameClassSchema),
+}
+
+/**
+ * Put a name on what the player has already been doing.
+ *
+ * Code has done the reading: which skills, how often, which attributes
+ * underneath, and whether that is narrow or broad. All the model does is name
+ * it, and it is told not to invent mechanics because a class that carries a
+ * bonus is a class the player starts steering toward instead of playing the
+ * character.
+ *
+ * Never throws. A failed call falls back to a table, because play does not
+ * block on a model call (invariant 16) and a character told the cave could not
+ * form an opinion about them is worse off than one called a Wayfarer.
+ */
+async function nameClass(
+  apiKey: string,
+  campaign: Campaign,
+  shape: ClassShape,
+  signal: AbortSignal
+): Promise<{ name: string; note: string }> {
+  const doing = shape.skills
+    .map(entry => `${SKILLS[entry.skill].name} (${entry.uses} times)`)
+    .join(', ')
+  const under = shape.attributes.map(id => ATTRIBUTES[id].name).join(', ')
+
+  try {
+    const input = await callForTool({
+      apiKey,
+      model: UTILITY_MODEL,
+      tool: NAME_CLASS,
+      maxTokens: 400,
+      signal,
+      system:
+        'You name people by what they have been doing. You are given a character and a tally of what they actually spent their time on, and you return the name a person at the table would use for them. Do not invent abilities, bonuses, numbers or mechanics of any kind — you are describing what somebody already is, not granting them anything. Avoid stock fantasy classes: no Fighter, Rogue, Wizard, Cleric, Ranger, Bard.',
+      messages: [
+        {
+          role: 'user',
+          content: `${campaign.character.name} — ${campaign.character.concept}
+Story: "${campaign.premise}"
+
+What they have actually been doing, most first: ${doing}
+Which sits under: ${under}
+Their play is ${shape.narrow ? 'narrow — they keep returning to the same few things' : 'broad — they range across a lot of different things'}.
+
+Name what they have turned out to be.`,
+        },
+      ],
+    })
+
+    return readClass(input) ?? fallbackClass(shape)
+  } catch (error) {
+    // Logged rather than swallowed: unlike a save, this one is recoverable and
+    // the player still gets a name, but a generator that has quietly stopped
+    // working should be visible to whoever looks.
+    console.error('dicebound class naming failed:', error)
+    return fallbackClass(shape)
+  }
+}
+
 async function condense(
   apiKey: string,
   campaign: Campaign,

--- a/src/app/dicebound/DiceboundGame.tsx
+++ b/src/app/dicebound/DiceboundGame.tsx
@@ -28,8 +28,18 @@ import { useDicebound } from './store'
 
 export function DiceboundGame() {
   const { user, loading: authLoading, configured } = useAuth()
-  const { phase, campaign, pending, error, attach, begin, act, abandon, dismissError } =
-    useDicebound()
+  const {
+    phase,
+    campaign,
+    pending,
+    error,
+    suggestions,
+    attach,
+    begin,
+    act,
+    abandon,
+    dismissError,
+  } = useDicebound()
 
   const [sheetOpen, setSheetOpen] = useState(false)
 
@@ -120,7 +130,7 @@ export function DiceboundGame() {
           </p>
         )}
 
-        <Composer onSend={act} disabled={pending} />
+        <Composer onSend={act} disabled={pending} suggestions={suggestions} />
       </div>
 
       {/* Desktop: the sheet is always there. Mobile: it slides over. */}

--- a/src/app/dicebound/api.ts
+++ b/src/app/dicebound/api.ts
@@ -87,3 +87,44 @@ export async function takeTurn(
 
   return (await response.json()) as TurnResponse
 }
+
+/**
+ * Three things the player might try next.
+ *
+ * The one call in this file that cannot fail. Everything else here throws so
+ * the store can put an in-character line in front of the player; this returns
+ * an empty list instead, because there is no failure worth telling them about.
+ * The suggestions are an offer beside a working game, and a player who never
+ * finds out they were meant to be there has lost nothing — whereas "the cave
+ * could not think of anything" over a story that is fine would be pure noise.
+ *
+ * Same two shapes as a turn: with a token the server loads its own campaign and
+ * the body is empty, without one there is no server-side story to read.
+ */
+export async function fetchSuggestions({
+  token,
+  campaign,
+}: {
+  token: string | null
+  campaign: Campaign
+}): Promise<string[]> {
+  try {
+    const response = await fetch('/api/v1/dicebound/suggest', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(token ? {} : { campaign }),
+    })
+
+    if (!response.ok) return []
+
+    const body = (await response.json()) as { suggestions?: unknown }
+    return Array.isArray(body.suggestions)
+      ? body.suggestions.filter((line): line is string => typeof line === 'string')
+      : []
+  } catch {
+    return []
+  }
+}

--- a/src/app/dicebound/components/__tests__/composer.test.tsx
+++ b/src/app/dicebound/components/__tests__/composer.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Composer } from '@/app/dicebound/components/composer'
+
+afterEach(cleanup)
+
+const THREE = [
+  'I try to lever the chain off with the lantern hook.',
+  'I ask Maren who she paid to chain this grate.',
+  'I go under, and feel for the drain the water is leaving by.',
+]
+
+const field = () => screen.getByRole('textbox') as HTMLTextAreaElement
+const chip = (label: string) => screen.getByRole('button', { name: label }) as HTMLButtonElement
+
+describe('Composer suggestions', () => {
+  it('fills the field on a tap and does not send', () => {
+    // The whole design decision, and the only thing protecting it. Dicebound is
+    // a game where the player writes the attempt in their own words; a chip
+    // that sent on tap would turn it into a three-option menu, and no test
+    // anywhere else would notice.
+    const onSend = vi.fn()
+    render(<Composer onSend={onSend} disabled={false} suggestions={THREE} />)
+
+    fireEvent.click(chip(THREE[1]))
+
+    expect(field().value).toBe(THREE[1])
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('leaves the caret at the end, so the edit is one keystroke away', () => {
+    render(<Composer onSend={vi.fn()} disabled={false} suggestions={THREE} />)
+
+    fireEvent.click(chip(THREE[0]))
+
+    expect(document.activeElement).toBe(field())
+    expect(field().selectionStart).toBe(THREE[0].length)
+  })
+
+  it('renders nothing at all when there is nothing to offer', () => {
+    // Invariant 17. An empty rail above the composer advertises a feature the
+    // player has not met and turns a quiet moment into a waiting one.
+    render(<Composer onSend={vi.fn()} disabled={false} suggestions={[]} />)
+    expect(screen.queryByRole('list')).toBeNull()
+  })
+
+  it('keeps the last three on screen while the dungeon master answers, untappable', () => {
+    // They stay so the composer does not jump: clearing the row mid-turn moves
+    // the send button out from under a thumb already reaching for it. Disabled
+    // so nobody acts on a scene that has already moved on.
+    render(<Composer onSend={vi.fn()} disabled={true} suggestions={THREE} />)
+
+    for (const line of THREE) {
+      expect(chip(line).disabled).toBe(true)
+    }
+  })
+})

--- a/src/app/dicebound/components/composer.tsx
+++ b/src/app/dicebound/components/composer.tsx
@@ -6,7 +6,10 @@
  * The placeholder is load-bearing. This is a game with no buttons and no verb
  * list, so the input field is the only place the rules can say "describe an
  * attempt, not a command" — and a player who types "attack" instead of "I
- * swing the lantern at the rope" gets a worse story out of the same model.
+ * swing the lantern at the rope" gets a worse story out of the same model. It
+ * is written in the first person, as the sentence the player is about to type,
+ * because the suggestion chips below speak in that voice and the field and the
+ * chips have to be teaching the same grammar.
  *
  * Enter sends and Shift+Enter breaks the line, which is the convention every
  * player already has in their hands. The textarea grows with the text so a
@@ -14,6 +17,7 @@
  */
 import { type KeyboardEvent, useEffect, useRef, useState } from 'react'
 
+import { Suggestions } from '@/app/dicebound/components/suggestions'
 import { MAX_ACTION } from '@/app/dicebound/domain/campaign'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 
@@ -22,12 +26,16 @@ const MAX_ROWS_PX = 200
 export function Composer({
   onSend,
   disabled,
+  suggestions = [],
 }: {
   onSend: (text: string) => void
   disabled: boolean
+  suggestions?: readonly string[]
 }) {
   const [value, setValue] = useState('')
   const ref = useRef<HTMLTextAreaElement>(null)
+  /** Set by a suggestion tap, read once by the effect that moves the caret. */
+  const caretToEnd = useRef(false)
 
   useEffect(() => {
     const el = ref.current
@@ -41,6 +49,30 @@ export function Composer({
   useEffect(() => {
     if (!disabled) ref.current?.focus()
   }, [disabled])
+
+  /**
+   * A tapped suggestion, waiting to be edited.
+   *
+   * The caret has to be put at the end afterwards rather than here: React
+   * writes the new value on the next render, and moving the caret before that
+   * lands it at the end of whatever the field used to contain. Focus follows
+   * for the same reason the field takes focus when the DM finishes — the edit
+   * has to be one keystroke away, or nobody makes it and the chip has quietly
+   * become a button that sends.
+   */
+  const fill = (text: string) => {
+    caretToEnd.current = true
+    setValue(text)
+  }
+
+  useEffect(() => {
+    if (!caretToEnd.current) return
+    caretToEnd.current = false
+    const el = ref.current
+    if (!el) return
+    el.focus()
+    el.setSelectionRange(el.value.length, el.value.length)
+  }, [value])
 
   const send = () => {
     const text = value.trim()
@@ -58,6 +90,7 @@ export function Composer({
 
   return (
     <div className="border-t-2 border-outline-variant bg-surface-container-low px-4 py-4 md:px-8">
+      <Suggestions suggestions={suggestions} onPick={fill} disabled={disabled} />
       <div className="mx-auto flex max-w-2xl items-end gap-3">
         <label htmlFor="dicebound-action" className="sr-only">
           What do you do?
@@ -71,7 +104,7 @@ export function Composer({
           disabled={disabled}
           onChange={event => setValue(event.target.value)}
           onKeyDown={onKeyDown}
-          placeholder="You try to…"
+          placeholder="I try to…"
           className="flex-1 resize-none rounded-ds-sm border-2 border-outline-variant bg-surface-container px-4 py-3 text-body-md text-on-surface placeholder:text-on-surface-variant/60 focus:border-ds-primary focus:outline-none disabled:opacity-50"
         />
         <ChunkyButton

--- a/src/app/dicebound/components/suggestions.tsx
+++ b/src/app/dicebound/components/suggestions.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+/**
+ * Three things you might try, offered under the composer.
+ *
+ * They fill the field; they do not send it. That is the whole design decision
+ * and it is the one thing in this file worth protecting. Dicebound is a game
+ * where the player writes an attempt in their own words — the composer's
+ * placeholder exists to teach that, and the DM is forbidden from ever asking
+ * "what do you do?" precisely so the sentence stays theirs. A chip that sent on
+ * tap would turn all of that into a three-option menu within a week, and the
+ * median action would get shorter and blander with it.
+ *
+ * So a tap is a starting point. The text lands in the box with the caret at the
+ * end of it, one keystroke away from being edited into something the player
+ * actually meant. It is the same bargain the creation screen already makes with
+ * its concept and premise chips.
+ *
+ * Nothing renders until there is something to offer (invariant 17) — but once
+ * the story is under way the row stays put through a turn, greyed and
+ * untappable while the dungeon master answers, so the composer under a player's
+ * thumb never moves.
+ */
+export function Suggestions({
+  suggestions,
+  onPick,
+  disabled,
+}: {
+  suggestions: readonly string[]
+  onPick: (text: string) => void
+  disabled: boolean
+}) {
+  if (suggestions.length === 0) return null
+
+  return (
+    <ul
+      // Keyed on the set itself so React remounts the list when the three
+      // change, which is what replays the fade. A new three arrive under a
+      // player who is still reading the paragraph above them, and something
+      // that appears without warning under moving eyes reads as a glitch.
+      key={suggestions.join(' ')}
+      aria-label="Things you might try. Choosing one fills the box; you can change it before you send."
+      className="dicebound-suggestions mx-auto flex max-w-2xl flex-wrap gap-2 pb-3"
+    >
+      {suggestions.map(suggestion => (
+        <li key={suggestion}>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onPick(suggestion)}
+            className="rounded-full border border-outline-variant bg-surface-container-low px-3 py-1.5 text-left text-sm italic text-on-surface-variant transition-colors hover:border-ds-primary/60 hover:not-italic hover:text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ds-primary disabled:opacity-40"
+          >
+            {suggestion}
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/app/dicebound/domain/__tests__/klass.test.ts
+++ b/src/app/dicebound/domain/__tests__/klass.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  type Character,
+  RANK_THRESHOLDS,
+  blankAttributes,
+  recordSkillUse,
+  startingSkills,
+} from '@/app/dicebound/domain/character'
+import { MAX_LEVEL, emptyKit } from '@/app/dicebound/domain/kit'
+import {
+  CLASS_AT_LEVEL,
+  FALLBACK_CLASSES,
+  NARROW_SHARE,
+  classShape,
+  fallbackClass,
+  readClass,
+  shouldNameClass,
+} from '@/app/dicebound/domain/klass'
+
+function character(overrides: Partial<Character> = {}): Character {
+  return {
+    name: 'Ilda',
+    concept: 'a nervous apprentice locksmith who talks too much',
+    reading: '',
+    attributes: blankAttributes(),
+    skills: {},
+    ...overrides,
+  }
+}
+
+describe('classShape', () => {
+  it('the class comes from the skills that were actually used, not the ones on the sheet at creation', () => {
+    // Three skills handed over for writing a sentence, and then twenty checks
+    // spent on something else entirely. The name has to describe the twenty.
+    let sheet = character({ skills: startingSkills(['humor', 'society', 'observation']) })
+    for (let i = 0; i < 20; i++) sheet = recordSkillUse(sheet, 'hand-eye').character
+
+    const shape = classShape(sheet)
+    expect(shape.skills[0].skill).toBe('hand-eye')
+    expect(shape.skills[0].uses).toBe(20)
+  })
+
+  it('reads uses rather than ranks, because rank flattens everything above it', () => {
+    // Both of these are rank 3. They are not the same character.
+    const sheet = character({
+      skills: {
+        'hand-eye': { uses: 40, rank: 3 },
+        balance: { uses: RANK_THRESHOLDS[2], rank: 3 },
+      },
+    })
+    expect(classShape(sheet).skills[0].skill).toBe('hand-eye')
+  })
+
+  it('calls concentrated play narrow and ranging play broad', () => {
+    const focused = character({
+      skills: { 'hand-eye': { uses: 30, rank: 3 }, humor: { uses: 2, rank: 0 } },
+    })
+    expect(classShape(focused).narrow).toBe(true)
+
+    // Six skills, evenly spread: the top three hold half the use, under the
+    // two-thirds line.
+    const ranging = character({
+      skills: Object.fromEntries(
+        ['hand-eye', 'humor', 'balance', 'observation', 'society', 'stomach'].map(skill => [
+          skill,
+          { uses: 5, rank: 1 },
+        ])
+      ),
+    })
+    const shape = classShape(ranging)
+    expect(shape.skills.reduce((sum, e) => sum + e.uses, 0) / shape.total).toBeLessThan(
+      NARROW_SHARE
+    )
+    expect(shape.narrow).toBe(false)
+  })
+
+  it('ignores skills nobody has touched', () => {
+    const sheet = character({
+      skills: { 'hand-eye': { uses: 4, rank: 1 }, balance: { uses: 0, rank: 0 } },
+    })
+    expect(classShape(sheet).skills.map(e => e.skill)).toEqual(['hand-eye'])
+  })
+
+  it('is not narrow for a character with no history — they are unwritten, not focused', () => {
+    const shape = classShape(character())
+    expect(shape.narrow).toBe(false)
+    expect(shape.total).toBe(0)
+  })
+})
+
+describe('fallbackClass', () => {
+  it('a failed generation still names the character', () => {
+    // Play never blocks on a model call. Being told the cave could not form an
+    // opinion about you is worse than being called a Wayfarer.
+    let sheet = character()
+    for (let i = 0; i < 20; i++) sheet = recordSkillUse(sheet, 'hand-eye').character
+
+    const named = fallbackClass(classShape(sheet))
+    expect(named.name).toBeTruthy()
+    expect(named.note).toContain('hand')
+  })
+
+  it('does not call a generalist by a specialist name', () => {
+    // The one way this table could actually be wrong about somebody.
+    const ranging = character({
+      skills: Object.fromEntries(
+        ['hand-eye', 'humor', 'balance', 'observation', 'society', 'stomach'].map(skill => [
+          skill,
+          { uses: 5, rank: 1 },
+        ])
+      ),
+    })
+    const shape = classShape(ranging)
+    const table = FALLBACK_CLASSES[shape.attributes[0]]
+    expect(fallbackClass(shape).name).toBe(table.broad)
+  })
+
+  it('has a name for every attribute, so no character can fall through it', () => {
+    for (const entry of Object.values(FALLBACK_CLASSES)) {
+      expect(entry.narrow).toBeTruthy()
+      expect(entry.broad).toBeTruthy()
+    }
+  })
+})
+
+describe('readClass', () => {
+  it('a number in the model response is discarded', () => {
+    // Not clamped. Clamping is what you do to a number you wanted; this is one
+    // nobody asked for, and keeping a clamped version of it is the first step
+    // toward a class that modifies something.
+    const named = readClass({
+      name: 'Cat Burglar',
+      note: 'You go in through the window.',
+      bonus: 3,
+      attributes: { dexterity: 2 },
+    })
+    expect(named).toEqual({ name: 'Cat Burglar', note: 'You go in through the window.' })
+    expect(named).not.toHaveProperty('bonus')
+    expect(named).not.toHaveProperty('attributes')
+  })
+
+  it('returns nothing usable rather than an empty name, so the caller falls back', () => {
+    expect(readClass({ note: 'You are something.' })).toBeNull()
+    expect(readClass({ name: '   ' })).toBeNull()
+    expect(readClass(null)).toBeNull()
+    expect(readClass('Cat Burglar')).toBeNull()
+  })
+
+  it('takes a name without a line, rather than refusing the whole thing', () => {
+    expect(readClass({ name: 'Ropewalker' })).toEqual({ name: 'Ropewalker', note: '' })
+  })
+})
+
+describe('shouldNameClass', () => {
+  it('the class is named once and does not change on the next level', () => {
+    // Not re-rolled as the character grows. Whether it should ever be revisited
+    // is a separate decision, and this must not settle it by accident.
+    const unnamed = { ...emptyKit(), className: null }
+    expect(shouldNameClass(unnamed, CLASS_AT_LEVEL)).toBe(true)
+
+    const named = { ...emptyKit(), className: 'Cat Burglar' }
+    expect(shouldNameClass(named, CLASS_AT_LEVEL)).toBe(false)
+    expect(shouldNameClass(named, 7)).toBe(false)
+    expect(shouldNameClass(named, MAX_LEVEL)).toBe(false)
+  })
+
+  it('says nothing about a character who has not got there yet', () => {
+    // Before the level fix this fired at creation, on a histogram holding
+    // nothing but the three skills the player was handed for a sentence.
+    expect(shouldNameClass({ ...emptyKit(), className: null }, 1)).toBe(false)
+  })
+})

--- a/src/app/dicebound/domain/__tests__/suggest.test.ts
+++ b/src/app/dicebound/domain/__tests__/suggest.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { MAX_SUGGESTION, SUGGESTION_COUNT, cleanSuggestions } from '@/app/dicebound/domain/suggest'
+
+describe('cleanSuggestions', () => {
+  it('keeps three plain lines as they were written', () => {
+    const lines = [
+      'I try to lever the chain off with the lantern hook.',
+      'I ask Maren who she paid to chain this grate.',
+      'I go under, and feel for the drain the water is leaving by.',
+    ]
+    expect(cleanSuggestions(lines)).toEqual(lines)
+  })
+
+  it('never offers the same move twice, whatever case it arrives in', () => {
+    // The one failure this feature must not have. Three chips that all say the
+    // obvious thing is worse than no chips at all — it tells the player the
+    // scene has a single exit, which is exactly the narrowing that suggestions
+    // are supposed to be worth risking.
+    expect(
+      cleanSuggestions(['I go for the latch.', 'I GO FOR THE LATCH.', 'I ask her about the book.'])
+    ).toEqual(['I go for the latch.', 'I ask her about the book.'])
+  })
+
+  it('strips the list furniture a model adds when it thinks it is writing a list', () => {
+    expect(
+      cleanSuggestions(['- I run for the door.', '2. I shout for Maren.', '"I wait."'])
+    ).toEqual(['I run for the door.', 'I shout for Maren.', 'I wait.'])
+  })
+
+  it('offers at most three, however many came back', () => {
+    const many = ['I one.', 'I two.', 'I three.', 'I four.', 'I five.']
+    expect(cleanSuggestions(many)).toHaveLength(SUGGESTION_COUNT)
+  })
+
+  it('drops anything that is not a usable string rather than rendering a hole', () => {
+    expect(cleanSuggestions(['I run.', '', '   ', null, 42, { text: 'I hide.' }])).toEqual([
+      'I run.',
+    ])
+  })
+
+  it('is empty for anything that is not a list at all', () => {
+    expect(cleanSuggestions(undefined)).toEqual([])
+    expect(cleanSuggestions('I try to leave.')).toEqual([])
+    expect(cleanSuggestions({ actions: ['I try to leave.'] })).toEqual([])
+  })
+
+  it('cuts an over-long line back to a word boundary, never mid-word', () => {
+    // The cap is a guard against a model that answers with a paragraph, and on
+    // a phone that paragraph would push the composer off the screen. But this
+    // string is about to be dropped into a field the player edits, and half a
+    // word is a worse starting point than a shorter sentence.
+    const long = `I try to ${'wander '.repeat(40)}away`
+    const [cut] = cleanSuggestions([long])
+
+    expect(cut.length).toBeLessThanOrEqual(MAX_SUGGESTION)
+    expect(cut).toMatch(/wander$/)
+  })
+})

--- a/src/app/dicebound/domain/klass.ts
+++ b/src/app/dicebound/domain/klass.ts
@@ -1,0 +1,169 @@
+/**
+ * The name for what the player already is.
+ *
+ * Chosen classes fight what makes this game good. "Pick Fighter or Wizard"
+ * turns the first screen into a menu, and it replaces a record of what you did
+ * with a prescription about what you will do. So nobody picks: at level 2 the
+ * game reads the skill-use histogram, notices what the player has actually been
+ * doing, and the model puts a name on it. You did not choose Cat Burglar. You
+ * kept picking locks, and the cave formed an opinion.
+ *
+ * The split is the same one everything else in here runs on. **Code computes
+ * the shape** — which skills, how often, which attributes underneath, and
+ * whether the spread is narrow or broad. **The model returns a name and a
+ * line.** Nothing numeric is read back, because there is no number here it
+ * could propose that anyone wants: a class in this game is a description, and
+ * the moment it carries a bonus it becomes a thing to optimise for, and the
+ * player starts steering toward the class instead of playing the character.
+ *
+ * Everything is pure. The model call lives in the route.
+ */
+import { ATTRIBUTES, type AttributeId, SKILLS, type SkillId } from './attributes'
+import { isPlainObject, str } from './validate'
+
+import type { Character } from './character'
+import type { Kit } from './kit'
+
+/** Level at which the cave has seen enough to have an opinion. */
+export const CLASS_AT_LEVEL = 2
+
+/** How many skills the shape is read from. */
+export const CLASS_SKILLS = 3
+
+/**
+ * Share of all use that has to sit in the top skills for play to read as
+ * narrow.
+ *
+ * Two thirds. A player who has spent two of every three checks on the same
+ * handful of things is recognisably doing one thing; below that they are
+ * ranging, and a name that claims a speciality would be describing somebody
+ * else. The number exists so "narrow or broad" is decided by the histogram
+ * rather than by whatever the model feels about the list it was handed.
+ */
+export const NARROW_SHARE = 2 / 3
+
+export interface ClassShape {
+  /** Most-used first, and only skills that have actually been used. */
+  skills: { skill: SkillId; uses: number }[]
+  /** The attributes beneath those skills, most represented first. */
+  attributes: AttributeId[]
+  /** True when play has concentrated rather than ranged. */
+  narrow: boolean
+  /** Every use counted, across every skill. */
+  total: number
+}
+
+/**
+ * Read what the character has been doing, from uses rather than from ranks.
+ *
+ * Uses, deliberately. A rank is a threshold that has been crossed and it
+ * flattens everything above it — a skill used forty times and one used
+ * eighteen are both rank 3 and are not the same character. The histogram is
+ * the record; the ranks are a summary of it.
+ *
+ * Seeded starting skills are counted here even though they do not count toward
+ * level. They are three uses each and they came from the player's own sentence,
+ * so they are a real if small statement about who this person is — and unlike
+ * level, a name is not something they can be handed too early: this only runs
+ * once real play has produced enough ranks to reach level 2.
+ */
+export function classShape(character: Character): ClassShape {
+  const used = Object.entries(character.skills)
+    .map(([skill, record]) => ({ skill: skill as SkillId, uses: record?.uses ?? 0 }))
+    .filter(entry => entry.uses > 0)
+    .sort((a, b) => b.uses - a.uses || SKILLS[a.skill].name.localeCompare(SKILLS[b.skill].name))
+
+  const total = used.reduce((sum, entry) => sum + entry.uses, 0)
+  const skills = used.slice(0, CLASS_SKILLS)
+  const top = skills.reduce((sum, entry) => sum + entry.uses, 0)
+
+  // Attributes ranked by how much use sits under them, not by how many skills
+  // they own — one skill used constantly says more about a character than three
+  // used once each.
+  const weight = new Map<AttributeId, number>()
+  for (const entry of skills) {
+    const attribute = SKILLS[entry.skill].attribute
+    weight.set(attribute, (weight.get(attribute) ?? 0) + entry.uses)
+  }
+
+  return {
+    skills,
+    attributes: [...weight.entries()]
+      .sort((a, b) => b[1] - a[1] || ATTRIBUTES[a[0]].name.localeCompare(ATTRIBUTES[b[0]].name))
+      .map(([attribute]) => attribute),
+    // A character with no history at all is not narrow, they are unwritten.
+    narrow: total > 0 && top / total >= NARROW_SHARE,
+    total,
+  }
+}
+
+/**
+ * Names for when the model cannot be reached.
+ *
+ * Play never blocks on a model call (invariant 16), and that includes this: a
+ * character told the cave could not form an opinion about them is worse off
+ * than one called a Wayfarer. Keyed on the attribute the play sits under, with
+ * a second name for a character who has ranged rather than specialised —
+ * breadth is a kind of identity too, and calling a generalist by a specialist's
+ * name is the one way this fallback could actually be wrong.
+ */
+export const FALLBACK_CLASSES: Record<AttributeId, { narrow: string; broad: string }> = {
+  intellect: { narrow: 'Reckoner', broad: 'Polymath' },
+  wisdom: { narrow: 'Watcher', broad: 'Wanderer' },
+  strength: { narrow: 'Bulwark', broad: 'Labourer' },
+  dexterity: { narrow: 'Threadneedle', broad: 'Rooftopper' },
+  constitution: { narrow: 'Enduring', broad: 'Long-Walker' },
+  charm: { narrow: 'Smooth Tongue', broad: 'Company-Keeper' },
+  power: { narrow: 'Kindler', broad: 'Strange One' },
+  beauty: { narrow: 'Striking', broad: 'Well-Met' },
+}
+
+export function fallbackClass(shape: ClassShape): { name: string; note: string } {
+  const attribute = shape.attributes[0]
+  // No history at all should not be possible here — the level gate means play
+  // has happened — but a name is owed either way rather than an empty string.
+  const table = attribute ? FALLBACK_CLASSES[attribute] : FALLBACK_CLASSES.wisdom
+  const name = shape.narrow ? table.narrow : table.broad
+
+  const doing = shape.skills.map(entry => SKILLS[entry.skill].name.toLowerCase())
+  return {
+    name,
+    note: doing.length
+      ? `What you keep coming back to: ${doing.join(', ')}.`
+      : 'What you are is still being decided by what you do.',
+  }
+}
+
+/**
+ * Read a name and a line out of a model response, and nothing else.
+ *
+ * Anything numeric is **discarded rather than clamped**. Clamping is what you
+ * do to a number you wanted; this is a number nobody asked for, and keeping a
+ * clamped version of it would be the first step toward a class that modifies
+ * something. Returns null when there is no usable name, so the caller falls
+ * back rather than storing an empty string.
+ */
+export function readClass(value: unknown): { name: string; note: string } | null {
+  if (!isPlainObject(value)) return null
+
+  const name = str(value.name, 40).trim()
+  if (!name) return null
+
+  return { name, note: str(value.note, 200).trim() }
+}
+
+/**
+ * Should the cave name this character now?
+ *
+ * A predicate rather than an `if` in the route, because the once-ness is the
+ * whole rule and it deserves somewhere a test can point at. `className === null`
+ * is all of it: nothing re-reads the histogram at level 3, and a class is not
+ * re-rolled every time the character grows.
+ *
+ * Whether a class should ever be revisited is a real question and a separate
+ * decision. It is left open on purpose — this must not settle it quietly by
+ * being idempotent-by-accident.
+ */
+export function shouldNameClass(kit: Kit, level: number): boolean {
+  return kit.className === null && level >= CLASS_AT_LEVEL
+}

--- a/src/app/dicebound/store.ts
+++ b/src/app/dicebound/store.ts
@@ -15,7 +15,7 @@ import { create } from 'zustand'
 
 import { getTodayPST, getYesterdayOf } from '@/lib/dates'
 
-import { createCharacter, takeTurn } from './api'
+import { createCharacter, fetchSuggestions, takeTurn } from './api'
 import { type CampaignBackend, nullBackend } from './backend'
 import { type Campaign, MAX_CONCEPT, MAX_PREMISE, newCampaign, withVisit } from './domain/campaign'
 import { applyTurn } from './domain/turn'
@@ -32,12 +32,34 @@ interface DiceboundState {
   /** In-character error text, cleared on the next successful action. */
   error: string | null
   backend: CampaignBackend
+  /**
+   * Three things the player might try, for the composer to offer.
+   *
+   * They belong to the scene rather than to the campaign, so they live here and
+   * are never saved. Deliberately *not* cleared when the player acts: the old
+   * three stay on screen, greyed and untappable, until the new three replace
+   * them. Clearing would collapse the row and shove the composer down the
+   * screen twice a turn, which on a phone means the send button moves under a
+   * thumb that is already reaching for it.
+   */
+  suggestions: string[]
+  /**
+   * Which request the suggestions on screen belong to.
+   *
+   * A turn takes real seconds and a suggestion call is fired after every one of
+   * them, so two can easily be in flight across a fast player's turn. Only the
+   * newest may land — an older one arriving late would offer moves for a scene
+   * that is already two paragraphs back.
+   */
+  suggestSeq: number
 
   attach: (backend: CampaignBackend) => Promise<void>
   begin: (premise: string, concept: string) => Promise<void>
   act: (action: string) => Promise<void>
   abandon: () => Promise<void>
   dismissError: () => void
+  /** Ask for a fresh three. Called by the store itself after anything that moves the story. */
+  refreshSuggestions: () => Promise<void>
 }
 
 function freshCampaign(premise: string, character: Character, now: number): Campaign {
@@ -50,6 +72,8 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
   pending: false,
   error: null,
   backend: nullBackend,
+  suggestions: [],
+  suggestSeq: 0,
 
   /**
    * Point the store at storage and load whatever is there.
@@ -63,7 +87,7 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
     const stored = await backend.load()
 
     if (!stored) {
-      set({ phase: 'creating', campaign: null })
+      set({ phase: 'creating', campaign: null, suggestions: [] })
       return
     }
 
@@ -71,6 +95,10 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
     const visited = withVisit(stored, today, getYesterdayOf(today))
     set({ phase: 'playing', campaign: visited })
     if (visited !== stored) void backend.save(visited)
+
+    // A returning player finds the three under the scene they left on, rather
+    // than an empty rail until they have taken one more turn (CLAUDE.md 3).
+    void get().refreshSuggestions()
   },
 
   async begin(premise, concept) {
@@ -97,6 +125,7 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
       // send the whole campaign straight back to the endpoint this change
       // exists to stop trusting.
       if (!authoritative) void get().backend.save(opened)
+      void get().refreshSuggestions()
     } catch (error) {
       set({
         pending: false,
@@ -132,6 +161,10 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
 
       set({ campaign: next, pending: false })
       if (!authoritative) void get().backend.save(next)
+      // Fired after the turn is on screen, never awaited. The player is
+      // already reading; the three arrive underneath them a beat later and the
+      // turn never waits on a model whose answer it does not need.
+      void get().refreshSuggestions()
     } catch (error) {
       // Roll the optimistic line back out, so the player can edit and resend
       // rather than staring at an action the story never received.
@@ -145,11 +178,35 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
 
   async abandon() {
     if (get().pending) return
-    set({ phase: 'creating', campaign: null, error: null })
+    // The sequence moves so a call still in flight for the abandoned story
+    // cannot land on the next one.
+    set({
+      phase: 'creating',
+      campaign: null,
+      error: null,
+      suggestions: [],
+      suggestSeq: get().suggestSeq + 1,
+    })
     await get().backend.clear()
   },
 
   dismissError() {
     set({ error: null })
+  },
+
+  async refreshSuggestions() {
+    const campaign = get().campaign
+    if (!campaign || campaign.transcript.length === 0) return
+
+    const seq = get().suggestSeq + 1
+    set({ suggestSeq: seq })
+
+    const token = await get().backend.token()
+    const suggestions = await fetchSuggestions({ token, campaign })
+
+    // A newer turn has already asked, or the story was abandoned underneath
+    // this. Either way these are about a scene that has moved on.
+    if (get().suggestSeq !== seq) return
+    set({ suggestions })
   },
 }))

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -717,6 +717,22 @@ body {
   }
 }
 
+/* ───────────────────────────────────────────────────────────────────
+   Dicebound — the three suggestions arriving under the composer.
+   They land a beat after the narration the player is still reading, so
+   they fade in rather than snap. Re-keying the list on a new set plays
+   it again. Reduced motion is handled by the global rule above.
+   ─────────────────────────────────────────────────────────────────── */
+
+@keyframes dicebound-suggestions-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.dicebound-suggestions {
+  animation: dicebound-suggestions-in 0.3s ease-out;
+}
+
 @media print {
   /* Page break control */
   .break-after-page {


### PR DESCRIPTION
Closes #3564. Kit lane — new `domain/klass.ts`, plus the moment in `turn/route.ts`. Depends on #3558, merged.

## Why nobody picks

Chosen classes fight what makes this game good. "Pick Fighter or Wizard" turns the first screen into a menu, and it replaces a record of what you did with a prescription about what you will do.

So at level 2 the game reads the skill-use histogram and the model puts a name on what is already there. **You did not choose Cat Burglar. You kept picking locks, and the cave formed an opinion.**

## The split

**Code computes the shape** — which skills, how often, which attributes sit underneath, and whether two thirds of all use falls in the top three, which is what decides narrow from broad. The threshold is a constant with its reasoning next to it, so "narrow or broad" is settled by the histogram rather than by how the model feels about the list it was handed.

**The model returns a name and a line.** Anything numeric is **discarded rather than clamped**. Clamping is what you do to a number you wanted; this is one nobody asked for, and keeping a clamped version of it is the first step toward a class that modifies something — at which point the player starts steering toward the class instead of playing the character.

## Uses, not ranks

A rank is a threshold that has been crossed, and it flattens everything above it: a skill used forty times and one used eighteen are both rank 3 and are not the same person. The histogram is the record; ranks are a summary of it.

Seeded starting skills **do** count here, even though they deliberately do not count toward level. They came from the player's own sentence and are a real if small statement about who this is — and unlike level, a name cannot be handed over too early, because none of this runs until real play has produced level 2.

## Two details

**Level is recomputed from the character this turn produced**, not from the value read before the turn ran. The check that pushes someone to level 2 usually happens *in* that turn, and reading the stale value would hold the name back a turn for no reason the player could see. Both live runs confirm it lands on the crossing turn.

**`shouldNameClass` is a predicate rather than an `if` in the route**, because the once-ness is the whole rule and deserves somewhere a test can point at. `className !== null` is all of it — nothing re-reads the histogram at level 3. Whether a class should ever be revisited is a real question and is left open on purpose; this must not settle it by being idempotent-by-accident.

## Anonymous-first

A fallback table, because play never blocks on a model call (invariant 16). A character told the cave could not form an opinion about them is worse off than one called a Wayfarer. It keeps a second name per attribute for someone who **ranged rather than specialised** — calling a generalist by a specialist's name is the one way this table could actually be wrong about a person.

## The moment

One line in the DM's voice, in the transcript. Not a modal and not a congratulations — the cave noticed what you are, it does not need to celebrate.

## Verification

```
$ npx vitest run src/app/dicebound/domain
 Test Files  9 passed (9)
      Tests  267 passed (267)      # +13, a new klass suite

$ npx eslint src/app/dicebound src/app/api/v1/dicebound src/lib/dicebound
eslint=0
$ npm run lint:routes
check-route-slugs: ok
$ npx tsc --noEmit 2>&1 | grep -E 'domain/klass|turn/route'
                                   # empty
```

### Real turns

A locksmith one rank short of level 2, with a lopsided history, played three turns:

```
RUN 1   start: level 1, class none
  turn 1: level 2, class The Nervous Picklock
     -> "Somewhere in all of that, without anybody deciding it, you became this:
         The Nervous Picklock. You are the one whose fingers know every tumbler
         before your mouth stops talking."
  turn 2: level 2, class The Nervous Picklock
  turn 3: level 2, class The Nervous Picklock
  shape: hand-eye x19, humor x4 | narrow

RUN 2   start: level 1, class none
  turn 1: level 2, class The Lockpick
     -> "...you became this: The Lockpick. You are the one whose fingers already
         know the tumblers before your mind catches up, nervous chatter spilling
         out while your hands stay perfectly steady."
  turn 2: level 2, class The Lockpick
  turn 3: level 2, class The Lockpick
  shape: hand-eye x19, humor x4, observation x1 | narrow
```

Both names come from what was actually done — `hand-eye` nineteen times — crossed with the concept's nervousness, and neither is a stock fantasy class. Neither changed on the two turns after.

Note on `tsc`: this checkout currently has unrelated in-flight work under `src/app/dicebound/` that reports its own errors, so the grep is scoped to the files this PR touches. Nothing here contributes one.