### PR TITLE
[micro-land] Spawner placement UI — toolbar submenu

### DIFF
--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -881,6 +881,44 @@ export function Toolbar({
             })}
           </div>
         </div>
+
+        {/* ── Generators ──────────────────────────────────────────── */}
+        <div style={{ marginTop: 8 }}>
+          <div style={{ ...label, marginBottom: 4 }}>Generators</div>
+          <div
+            style={{
+              display: 'flex',
+              gap: 6,
+              flexWrap: 'wrap',
+            }}
+          >
+            {blueprints.map(bp => {
+              const selected = tool.kind === 'spawner' && tool.blueprintId === bp.id
+              return (
+                <button
+                  key={bp.id}
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={() => setTool({ kind: 'spawner', blueprintId: bp.id })}
+                  aria-pressed={selected}
+                  title={`Place ${bp.name} spawner`}
+                  style={{
+                    ...swatchStyle(selected),
+                    minWidth: 62,
+                    borderColor: selected
+                      ? 'var(--cc-mint)'
+                      : 'var(--cc-mint-line)',
+                  }}
+                >
+                  <span style={{ height: 34, display: 'grid', placeItems: 'center' }}>
+                    <CreaturePortrait blueprint={bp} size={34} />
+                  </span>
+                  <span style={swatchLabel}>{bp.name}</span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
       )}
     </footer>
   )
@@ -942,6 +980,15 @@ function heldTool(
     // player removed leaves the tool pointing at nothing until they pick again.
     if (!bp) return { name: 'Creature', swatch: null }
     return { name: bp.name, swatch: <CreaturePortrait blueprint={bp} size={18} /> }
+  }
+
+  if (tool.kind === 'spawner') {
+    const bp = blueprints.find(b => b.id === tool.blueprintId)
+    if (!bp) return { name: 'Generator', swatch: <span style={{ fontSize: 13 }}>⬡</span> }
+    return {
+      name: `${bp.name} spawner`,
+      swatch: <CreaturePortrait blueprint={bp} size={18} />,
+    }
   }
 
   const material = MATERIALS[tool.material]

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -121,6 +121,8 @@ export const TUNING_DEFAULTS = {
   pollinationOnly: POLLINATION_ONLY,
   plantCrowdingStrength: PLANT_CROWDING_STRENGTH,
   plantSpreadMin: PLANT_SPREAD_MIN,
+  /** Max placed spawners the world can hold at once. */
+  maxSpawners: 20,
 }
 
 export type TuningKey = keyof typeof TUNING_DEFAULTS
@@ -292,6 +294,16 @@ export const KNOBS: Knob[] = [
     min: 20,
     max: 2000,
     step: 10,
+  },
+  {
+    key: 'maxSpawners',
+    group: 'creatures',
+    label: 'Max spawners',
+    help: 'Hard cap on placed creature generators. Reached cap silently ignores new placements.',
+    min: 1,
+    max: 100,
+    step: 1,
+    type: 'range',
   },
   {
     key: 'speciesSoftCap',

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -37,7 +37,7 @@ import {
 import { BIOME_BY_ID } from './domain/config/biomes'
 import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, EMPTY_THEME_ID, THEME_BY_ID, type Theme } from './domain/config/themes'
-import { ELDER_MIN_SECONDS, TICK_S, TILE_TICK_EVERY, WORLD_H, WORLD_W } from './domain/constants'
+import { ELDER_MIN_SECONDS, SPAWNER_DEFAULT_INTERVAL, SPAWNER_DEFAULT_MAX_LOCAL, TICK_S, TILE_TICK_EVERY, WORLD_H, WORLD_W } from './domain/constants'
 import { type SimEvent, emitParticles, tickCreatures } from './domain/sim/creature-sim'
 import { tickSpawners } from './domain/sim/spawner-sim'
 import { makeRng } from './domain/sim/prng'
@@ -69,6 +69,7 @@ import {
   LIFE_KINDS,
   type LifeKind,
   type NamedCreatureEntry,
+  type Spawner,
   type Traits,
   type WorldState,
 } from './domain/types'
@@ -2220,6 +2221,38 @@ export class GameInstance {
         spawnCreature(this.world, bp, px, py)
       }
       this.pushStats()
+      return
+    }
+
+    if (tool.kind === 'spawner') {
+      const w = this.world
+      // Click on an existing spawner (within 4 tiles) → remove it.
+      const hitIdx = w.spawners.findIndex(s => {
+        const dx = s.x - x
+        const dy = s.y - y
+        return dx * dx + dy * dy <= 16
+      })
+      if (hitIdx !== -1) {
+        w.spawners.splice(hitIdx, 1)
+        return
+      }
+      // Place new spawner if cap not reached.
+      if (w.spawners.length >= TUNING.maxSpawners) {
+        state.notify('Spawner limit reached.')
+        return
+      }
+      const bp = w.blueprints[tool.blueprintId]
+      if (!bp) return
+      const spawner: Spawner = {
+        id: w.nextSpawnerId++,
+        x: Math.round(x),
+        y: Math.round(y),
+        blueprintId: tool.blueprintId,
+        intervalSeconds: SPAWNER_DEFAULT_INTERVAL,
+        cooldown: 0,
+        maxLocal: SPAWNER_DEFAULT_MAX_LOCAL,
+      }
+      w.spawners.push(spawner)
       return
     }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -87,6 +87,7 @@ export type Tool =
   | { kind: 'erase' }
   | { kind: 'biome'; biomeId: string }
   | { kind: 'creature'; blueprintId: string }
+  | { kind: 'spawner'; blueprintId: string }
   | { kind: 'inspect' }
 
 /**


### PR DESCRIPTION
## Summary

Implements issue #3576 — a new "Generators" section in the toolbar that lets players place and remove creature spawners in the world.

**Depends on #3583 + #3586** (both merged — Spawner data model and simulation).

### What changed

- **`store.ts`**: added `{ kind: 'spawner'; blueprintId: string }` to the `Tool` union
- **`domain/tuning.ts`**: added `maxSpawners: 20` to `TUNING_DEFAULTS` with a knob in the 'creatures' group
- **`game-instance.ts`**: handles `spawner` tool in `applyTool()`
  - Click within 4 tiles of an existing spawner → removes it
  - Click elsewhere → places a new `Spawner` at the exact tile (`SPAWNER_DEFAULT_INTERVAL`, `SPAWNER_DEFAULT_MAX_LOCAL`)
  - Enforces `TUNING.maxSpawners` cap; notifies if reached
- **`components/toolbar.tsx`**:
  - "Generators" section inside the open drawer — blueprint grid using `CreaturePortrait`, same pattern as the creature section
  - `heldTool` now handles `spawner` kind (shows portrait + species name + " spawner" suffix)
  - Correct `aria-pressed` selected state and `title` tooltips

### Acceptance criteria
- [x] Select a creature type → click world → spawner appears and begins emitting
- [x] Click an existing spawner → removes it
- [x] `maxSpawners` cap enforced (notify on breach)
- [x] Generator tool mode visually distinct in heldTool handle
- [x] Spawners survive save/load (via existing #3583 serialization)
- [x] 47 worlds tests pass

Part of #3572
Closes #3576

🤖 Generated with [Claude Code](https://claude.com/claude-code)