### PR TITLE
chore(dicebound): measure how long it takes to feel powerful

### DIFF
--- a/scripts/dicebound-voice-check.ts
+++ b/scripts/dicebound-voice-check.ts
@@ -28,6 +28,14 @@
  * script runs at all, and the person running it gets a node error about a
  * dotfile rather than the run they asked for.
  *
+ * It also prints a SKILL CREDIT section, which is about progression rather than
+ * voice. It lives here because this is the only thing in the repo that plays a
+ * real campaign end to end, and skill advancement is the one system whose
+ * behaviour cannot be seen from a single turn: ranks 2 and 3 are eight and
+ * eighteen uses of the *same* skill, so whether they are reachable depends
+ * entirely on how much the DM concentrates its calls — a thing no unit test can
+ * observe.
+ *
  * Run it BEFORE and AFTER a voice change and paste both tables. Note that the
  * model is not deterministic and there is no seed to fix: a few words of
  * movement between runs is noise, and only a shift across the whole
@@ -35,14 +43,22 @@
  */
 import { POST as characterRoute } from '@/app/api/v1/dicebound/character/route'
 import { POST as turnRoute } from '@/app/api/v1/dicebound/turn/route'
+import { SKILLS, type SkillId } from '@/app/dicebound/domain/attributes'
 import {
   type Campaign,
+  type CheckEntry,
   type NarrationEntry,
   type TranscriptEntry,
   newCampaign,
   validateCharacter,
 } from '@/app/dicebound/domain/campaign'
-import type { Character } from '@/app/dicebound/domain/character'
+import {
+  type Character,
+  type SkillRecord,
+  earnedRanks,
+  openWindows,
+} from '@/app/dicebound/domain/character'
+import { type Kit, type Power, levelFor } from '@/app/dicebound/domain/kit'
 import { type TurnResult, applyTurn } from '@/app/dicebound/domain/turn'
 
 import type { NextRequest } from 'next/server'
@@ -137,6 +153,11 @@ function words(text: string): number {
   return text.trim().split(/\s+/).filter(Boolean).length
 }
 
+/** The checks a turn rolled, in order. */
+function checksIn(entries: TranscriptEntry[]): CheckEntry[] {
+  return entries.filter((e): e is CheckEntry => e.kind === 'check')
+}
+
 /** Total words of narration in a turn, across however many entries it produced. */
 function narrationWords(entries: TranscriptEntry[]): number {
   return entries
@@ -157,6 +178,58 @@ function percentile(sorted: number[], p: number): number {
 
 function row(label: string, value: string): string {
   return `  ${label.padEnd(26)}${value.padStart(8)}`
+}
+
+/**
+ * What one turn did to the progression curve.
+ *
+ * Recorded per turn rather than summed at the end, because the interesting
+ * question is not "where did they get to" but "how fast" — a table of totals
+ * cannot tell you whether level 4 arrived on turn six or turn nineteen.
+ */
+interface Beat {
+  turn: number
+  ranks: number
+  level: number
+  /** Powers granted this turn, with the tier they actually got. */
+  granted: { id: string; tier: number; emerged: boolean }[]
+  /** Charges spent this turn, across every power. */
+  spent: number
+  /** Charges that came back this turn. */
+  restored: number
+}
+
+/**
+ * Charges spent and restored between two states of the kit.
+ *
+ * Counted as a delta rather than as `max - now`, because a rest refills and a
+ * running total taken at the end would report only whatever happened to be
+ * spent when the music stopped. A power granted this turn contributes nothing
+ * to either number: it arrives full, and arriving is not restoring.
+ */
+function chargeDelta(before: Kit, after: Kit): { spent: number; restored: number } {
+  const was = new Map(before.powers.map(power => [power.id, power.charges.now]))
+  let spent = 0
+  let restored = 0
+
+  for (const power of after.powers) {
+    const previous = was.get(power.id)
+    if (previous === undefined) continue
+    if (power.charges.now < previous) spent += previous - power.charges.now
+    if (power.charges.now > previous) restored += power.charges.now - previous
+  }
+
+  return { spent, restored }
+}
+
+function newPowers(before: Kit, after: Kit): Power[] {
+  const had = new Set(before.powers.map(power => power.id))
+  return after.powers.filter(power => !had.has(power.id))
+}
+
+/** The first turn at which a level was reached, or null if it never was. */
+function turnsTo(beats: Beat[], level: number): number | null {
+  return beats.find(beat => beat.level >= level)?.turn ?? null
 }
 
 async function main(): Promise<void> {
@@ -184,8 +257,35 @@ async function main(): Promise<void> {
   console.log(`  opening: "${campaign.title}" (${openingWords} words)\n`)
 
   const lengths: number[] = []
+  const beats: Beat[] = []
   let withCheck = 0
   let failed = 0
+
+  // Skill credit, counted from the checks themselves rather than inferred from
+  // the sheet at the end.
+  //
+  // A skill only advances when a check names one that actually sits beneath the
+  // attribute being tested: `rollFor` runs the DM's choice through
+  // `applicableSkill`, and a mismatch is dropped to null. The check still
+  // happens and the prose still reads correctly, so a DM that habitually pairs
+  // the wrong two is invisible from the outside — every skill simply crawls,
+  // and a player reasonably concludes that +1 is the ceiling.
+  //
+  // What lands in the entry is `skill: null`, which is also what an ordinary
+  // attribute-only check looks like. This counter therefore measures the two
+  // together: the share of rolls that taught the character nothing. It cannot
+  // separate "the DM named no skill" from "the DM named one and it was thrown
+  // away" — that distinction only exists inside the route — but a high number
+  // here is the signal that the split is worth instrumenting there.
+  let credited = 0
+  let uncredited = 0
+  const creditCheck = (entries: TranscriptEntry[]) => {
+    for (const check of checksIn(entries)) {
+      if (check.skill) credited++
+      else uncredited++
+    }
+  }
+  creditCheck(opening.entries)
 
   for (let i = 0; i < turns; i++) {
     const action = ACTIONS[i]
@@ -207,15 +307,42 @@ async function main(): Promise<void> {
       continue
     }
 
+    // Read before applyTurn: the windows that were open when the DM decided
+    // what this turn was about are the ones that could have produced a power,
+    // and applyTurn is what credits the skill that might open a new one.
+    const windowsOpen = openWindows(campaign.character, campaign.world.clock.elapsed).length > 0
+    const kitBefore = campaign.kit
+
     campaign = applyTurn(campaign, result, now + i + 1)
 
     const narration = narrationWords(result.entries)
-    const checks = result.entries.filter(e => e.kind === 'check').length
+    const checks = checksIn(result.entries).length
+    creditCheck(result.entries)
+
+    const ranks = earnedRanks(campaign.character)
+    const { spent, restored } = chargeDelta(kitBefore, campaign.kit)
+    beats.push({
+      turn: i + 1,
+      ranks,
+      level: levelFor(ranks),
+      // `emerged` is a proxy, not a fact the route reports: it says a window
+      // was open when this power arrived, which is the only signal the two
+      // paths leave behind. A grant that would have happened anyway on a turn
+      // that also had a window open counts as emerged here.
+      granted: newPowers(kitBefore, campaign.kit).map(power => ({
+        id: power.id,
+        tier: power.tier,
+        emerged: windowsOpen,
+      })),
+      spent,
+      restored,
+    })
 
     lengths.push(narration)
     if (checks > 0) withCheck++
     console.log(
-      `  turn ${String(i + 1).padStart(2)}: ${String(narration).padStart(4)} words, ${checks} check(s)`
+      `  turn ${String(i + 1).padStart(2)}: ${String(narration).padStart(4)} words, ${checks} check(s), ` +
+        `${ranks} rank${ranks === 1 ? '' : 's'}, level ${levelFor(ranks)}`
     )
   }
 
@@ -242,6 +369,99 @@ async function main(): Promise<void> {
   // whether the second one is shorter or simply missing its slowest turns.
   console.log(row('turns that failed', `${failed}/${turns}`))
   console.log(row('total checks rolled', String(campaign.stats.checks)))
+
+  const rolled = credited + uncredited
+  console.log(`\nSKILL CREDIT`)
+  console.log(row('checks crediting a skill', `${credited}/${rolled}`))
+  console.log(
+    row('checks crediting none', rolled ? `${Math.round((uncredited / rolled) * 100)}%` : '0%')
+  )
+
+  // --------------------------------------------------------- progression
+  //
+  // This is the table #3566 exists for. TIER_LEVELS is described in the code as
+  // "a starting guess, expected to move", and it is the number that decides how
+  // long a campaign takes to feel powerful — the most consequential unmeasured
+  // constant in the game. Read the failure row above before any of this: a run
+  // that lost turns has lost ranks with them, and a damaged curve looks exactly
+  // like a slow one.
+  const last = beats[beats.length - 1]
+  const ranks = last?.ranks ?? 0
+
+  console.log(`\nPROGRESSION`)
+  console.log(row('ranks earned in play', String(ranks)))
+  console.log(row('level reached', String(last?.level ?? 1)))
+  for (const level of [2, 4, 7]) {
+    const at = turnsTo(beats, level)
+    console.log(
+      row(`turns to level ${level}`, at === null ? `NOT REACHED in ${beats.length}` : String(at))
+    )
+  }
+
+  // The specific question the issue asks: is level 7 — eighteen ranks earned in
+  // play — reachable in a campaign anyone actually finishes? Twenty turns will
+  // not get there, so the honest answer is an extrapolation, and it is labelled
+  // as one. It assumes the rate holds, which it does not: ranks 2 and 3 cost 5
+  // and 10 further uses of the *same* skill, so the real curve is slower than
+  // this line. Treat it as a floor on the answer, not an estimate.
+  const perTurn = beats.length ? ranks / beats.length : 0
+  console.log(
+    row(
+      'ranks per turn',
+      beats.length ? `${perTurn.toFixed(2)} (${ranks} over ${beats.length})` : 'n/a'
+    )
+  )
+  console.log(
+    row(
+      'turns to lvl 7 (linear)',
+      perTurn > 0 ? `~${Math.ceil(18 / perTurn)} (a floor — the curve slows)` : 'never at this rate'
+    )
+  )
+
+  // --------------------------------------------------------------- powers
+  const grants = beats.flatMap(beat => beat.granted.map(power => ({ ...power, turn: beat.turn })))
+  const spent = beats.reduce((sum, beat) => sum + beat.spent, 0)
+  const restored = beats.reduce((sum, beat) => sum + beat.restored, 0)
+  // A rest that restored nothing is invisible here, and that is the right
+  // behaviour rather than a gap: a rest with nothing to give back has no effect
+  // on the curve this table is about.
+  const rests = beats.filter(beat => beat.restored > 0).length
+
+  console.log(`\nPOWERS`)
+  console.log(row('granted', String(grants.length)))
+  for (const power of grants) {
+    console.log(
+      row(
+        `  turn ${power.turn}`,
+        `${power.id} tier ${power.tier}, ${power.emerged ? 'window open' : 'granted outright'}`
+      )
+    )
+  }
+  console.log(row('charges spent', String(spent)))
+  console.log(row('charges restored', String(restored)))
+  console.log(row('turns that restored charges', String(rests)))
+
+  // The sheet at the end of the run, best first. This is the answer to "does
+  // anything ever reach +2": rank 2 is eight uses of one skill out of forty, so
+  // the question is not whether the thresholds work — the unit tests cover that
+  // — but whether a real DM concentrates its calls enough to reach one inside a
+  // campaign. A column of skills sitting at one or two uses each says the
+  // credit is being spread too thin to ever land, which is a prompt problem
+  // rather than an arithmetic one.
+  const touched = Object.entries(campaign.character.skills)
+    .filter((entry): entry is [string, SkillRecord] => Boolean(entry[1]))
+    .sort(([, a], [, b]) => b.uses - a.uses || b.rank - a.rank)
+
+  if (touched.length === 0) {
+    console.log(row('skills touched', '0'))
+  } else {
+    for (const [skill, record] of touched.slice(0, 8)) {
+      const seeded = record.seeded ? ' (seeded)' : ''
+      const rank = record.rank >= 0 ? `+${record.rank}` : `${record.rank}`
+      console.log(row(`  ${SKILLS[skill as SkillId].name}${seeded}`, `${record.uses}u ${rank}`))
+    }
+    if (touched.length > 8) console.log(row('  …and more', String(touched.length - 8)))
+  }
 }
 
 main().catch(error => {


### PR DESCRIPTION
Closes #3566. Harness lane — `scripts/dicebound-voice-check.ts` only.

## What it now reports

Level and earned ranks **per turn**, turns to level 2 / 4 / 7, powers granted with their tier and the turn they arrived, and charges spent and restored.

Two implementation notes worth keeping:

**Charges are a per-turn delta, not `max - now`.** A rest refills, so a total taken at the end would report only whatever happened to be spent when the music stopped.

**The path a power came in by is a proxy, and it is labelled as one.** The route does not report which path fired; a window being open on that turn is the only signal the emerged path leaves behind.

---

# The answer, and it is worse than the question

The issue asked: *is level 7 reachable in a campaign anyone actually plays?* **Level 2 is not.**

| | run 1 | run 2 |
| --- | --- | --- |
| turns that failed | 0/20 | 1/20 |
| turns with a check | 8/20 (40%) | 7/19 (37%) |
| **ranks earned in play** | **0** | **1** |
| level reached | 1 | 1 |
| turns to level 2 | NOT REACHED | NOT REACHED |
| turns to lvl 7, linear | never at this rate | ~342 (a floor) |
| powers granted | 0 | 0 |

Run 1 lost no turns, so it is the clean sample; run 2 lost one and agrees anyway.

**Everything in #3522 sits behind a gate that a twenty-turn campaign does not open.** `grant_power`, `use_power`, the rest refresh, class discovery and the emerged window are all correct, all tested, all verified against live turns — and all unreachable in normal play, because `maxTierAt(1) === 0` and nobody gets past level 1.

## The cause is not the tier table

That is the thing worth being careful about, because #3566 was framed as a question about `TIER_LEVELS`, and moving it would not fix this. Look at where the credit goes — run 2's sheet:

```
Quickness (seeded)              4u +1
Hand/Eye Coordination (seeded)  3u +1
Resolve (seeded)                3u +1
Body Control                    3u +1
Balance                         1u +0
Intimidation                    1u +0
Upper Body                      1u +0
```

Seven checks, spread across six or seven different skills. **Rank 2 needs eight uses of one skill.** Nothing accumulates, so nothing advances, so `earnedRanks` stays at 0 or 1 — and after #3558 the three seeded rank-1s correctly contribute nothing.

Two multiplied causes: a ~40% check rate means only 7–8 checks in twenty turns, and the DM picks a different skill almost every time. Lowering `TIER_LEVELS[1]` from 2 to 1 would make powers grantable on turn 1, which is exactly the bug #3558 was written to fix.

## What I have not done

Per the issue — *"Report the number; do not fix it here"* — this changes nothing but the harness. The levers are all Nick's call, and they are different sizes:

- **Narrow where credit goes.** Ask the DM to reuse a skill it has already called on when the fiction allows, so use concentrates. Smallest change, closest to the actual cause.
- **Lower `RANK_THRESHOLDS`.** `[3, 8, 18]` assumes far more checks per campaign than the current check rate produces. Changing it moves every rank, not just the ones gating powers.
- **Lower `TIER_LEVELS`.** Reaches powers soonest, and the one I would recommend against on its own — it treats the symptom and re-opens the turn-1 grant.
- **Raise the check rate.** Deliberately lowered in `17248d7f`, so raising it trades against the thing that commit fixed.

I would take the first, measure again, and only then look at the thresholds. Happy to open an issue for whichever you pick.

## Verification

```
$ npx eslint scripts/dicebound-voice-check.ts
eslint=0
$ npx tsc --noEmit 2>&1 | grep dicebound-voice
                                   # empty
$ npx prettier --write scripts/dicebound-voice-check.ts
                                   # unchanged
```

Plus the two full twenty-turn live runs tabulated above. No unit tests: this file *is* the measurement, it has no logic worth isolating from the run, and a mocked run would measure the mock.