### PR TITLE
[micro-land] World generator config — data model and serialization

### DIFF
--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -14,6 +14,7 @@ import {
 import type { Biome } from '../config/biomes'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from '@/app/micro-land/domain/config/themes'
 import {
+  PLANT_SEED_INTERVAL,
   SURFACE_SEEDING_BIAS,
   WIDTH_SCALE,
   WORLD_H,
@@ -25,6 +26,7 @@ import type {
   Creature,
   CreatureBlueprint,
   MaterialId,
+  WorldGeneratorEntry,
   WorldState,
 } from '@/app/micro-land/domain/types'
 import { wrapCol, wrapX } from '@/app/micro-land/domain/wrap'
@@ -67,6 +69,7 @@ export function createWorld(seed = 1337): WorldState {
     dormant: false,
     spawners: [],
     nextSpawnerId: 1,
+    generators: [],
   }
 }
 
@@ -435,6 +438,17 @@ export function registerBlueprint(w: WorldState, bp: CreatureBlueprint): void {
   w.blueprints[bp.id] = bp
   // Summoned creatures become native too, so the world can bring them back.
   if (!w.natives.includes(bp.id)) w.natives.push(bp.id)
+  // Each native species gets a generator entry — enabled for plants, off for
+  // animals. Summoning a species twice leaves its config unchanged.
+  if (!w.generators.some((g: WorldGeneratorEntry) => g.blueprintId === bp.id)) {
+    const isPlant = bp.move.kind === 'root'
+    w.generators.push({
+      blueprintId: bp.id,
+      enabled: isPlant,
+      intervalSeconds: isPlant ? PLANT_SEED_INTERVAL : 30,
+      nextSeed: 0,
+    })
+  }
 }
 
 /** Make a creature at an exact spot, no questions asked. */

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -121,6 +121,11 @@ export const TUNING_DEFAULTS = {
   pollinationOnly: POLLINATION_ONLY,
   plantCrowdingStrength: PLANT_CROWDING_STRENGTH,
   plantSpreadMin: PLANT_SPREAD_MIN,
+  /**
+   * Multiplies every world-generator's intervalSeconds at runtime.
+   * 1.0 = default. 2.0 = half the seeding rate. 0.5 = double the rate.
+   */
+  generatorRateMultiplier: 1.0,
 }
 
 export type TuningKey = keyof typeof TUNING_DEFAULTS
@@ -187,6 +192,17 @@ export const KNOBS: Knob[] = [
     max: 60,
     step: 1,
     unit: 's',
+  },
+  {
+    key: 'generatorRateMultiplier',
+    group: 'plants',
+    label: 'Generator rate',
+    help: 'Scales how often world generators seed new creatures. 2× means half as often; 0.5× means twice as often.',
+    min: 0.1,
+    max: 5,
+    step: 0.1,
+    unit: '×',
+    type: 'range',
   },
   {
     key: 'plantSeedBatch',

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -760,6 +760,29 @@ export interface Spawner {
   maxLocal: number
 }
 
+/**
+ * Per-species world-generator config.
+ *
+ * Determines which species the ground seeds automatically, how often, and
+ * whether it does so at all. Plant generators are enabled by default (they
+ * replace the current seedNativePlants batch logic); animal generators are
+ * off by default and exist so the player can opt into background seeding.
+ */
+export interface WorldGeneratorEntry {
+  blueprintId: string
+  /** Whether the world actively seeds this species on its timer. */
+  enabled: boolean
+  /** Seconds between seeding attempts. */
+  intervalSeconds: number
+  /**
+   * World-clock time of the next seeding attempt.
+   *
+   * Runtime only — never saved; resets to 0 on restore so the world starts
+   * seeding immediately after a load rather than waiting out a stale timer.
+   */
+  nextSeed: number
+}
+
 export interface WorldState {
   width: number
   height: number
@@ -812,6 +835,8 @@ export interface WorldState {
   /** Placed spawner objects. Emit one creature of their species on a timer. */
   spawners: Spawner[]
   nextSpawnerId: number
+  /** Per-species background-seeding config. Plants default to enabled. */
+  generators: WorldGeneratorEntry[]
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/worlds/snapshot.ts
+++ b/src/app/micro-land/worlds/snapshot.ts
@@ -26,7 +26,7 @@ import { registerBlueprint } from '@/app/micro-land/domain/sim/world'
 import { neutralTraits } from '@/app/micro-land/domain/traits'
 import type { Creature, CreatureMood, WorldState } from '@/app/micro-land/domain/types'
 
-import type { SavedCreature, SavedSpawner, WorldSnapshot } from './types'
+import type { SavedCreature, SavedGenerator, SavedSpawner, WorldSnapshot } from './types'
 
 const MOODS: CreatureMood[] = ['wander', 'hunt', 'flee', 'eat', 'rest', 'mate']
 
@@ -176,6 +176,11 @@ export function snapshotWorld(w: WorldState): WorldSnapshot {
       maxLocal: s.maxLocal,
     })),
     nextSpawnerId: w.nextSpawnerId,
+    generators: w.generators.map(g => ({
+      blueprintId: g.blueprintId,
+      enabled: g.enabled,
+      intervalSeconds: g.intervalSeconds,
+    })),
   }
 }
 
@@ -266,6 +271,19 @@ export function restoreSnapshot(w: WorldState, snap: WorldSnapshot): boolean {
   }))
   w.nextSpawnerId = Math.max(1, snap.nextSpawnerId ?? 1)
   for (const s of w.spawners) if (s.id >= w.nextSpawnerId) w.nextSpawnerId = s.id + 1
+
+  // Merge saved generator config over the defaults set by registerBlueprint
+  // above. nextSeed always starts at 0 on restore — see SavedGenerator comment.
+  if (snap.generators && snap.generators.length > 0) {
+    const byId = new Map(snap.generators.map((g: SavedGenerator) => [g.blueprintId, g]))
+    for (const gen of w.generators) {
+      const saved = byId.get(gen.blueprintId)
+      if (saved) {
+        gen.enabled = saved.enabled
+        gen.intervalSeconds = saved.intervalSeconds
+      }
+    }
+  }
 
   return true
 }

--- a/src/app/micro-land/worlds/types.ts
+++ b/src/app/micro-land/worlds/types.ts
@@ -95,6 +95,18 @@ export interface SavedSpawner {
   maxLocal: number
 }
 
+/**
+ * One generator entry, frozen for storage.
+ *
+ * `nextSeed` is deliberately omitted — it resets to 0 on restore so the world
+ * starts seeding immediately after a load rather than waiting out a stale timer.
+ */
+export interface SavedGenerator {
+  blueprintId: string
+  enabled: boolean
+  intervalSeconds: number
+}
+
 export interface WorldSnapshot {
   /**
    * How many materials existed when this grid was written.
@@ -132,6 +144,8 @@ export interface WorldSnapshot {
   /** Placed spawners. Cooldowns reset to 0 on restore. */
   spawners?: SavedSpawner[]
   nextSpawnerId?: number
+  /** Per-species background-seeding config. nextSeed resets to 0 on restore. */
+  generators?: SavedGenerator[]
 }
 
 /**

--- a/src/app/micro-land/worlds/wire.ts
+++ b/src/app/micro-land/worlds/wire.ts
@@ -18,13 +18,14 @@
  * it can be tested, which is where the interesting failures are.
  */
 import { MATERIAL_IDS } from '@/app/micro-land/domain/config/materials'
-import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { PLANT_SEED_INTERVAL, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import { sanitizeTerrain } from '@/app/micro-land/domain/terrain'
 import { SHADE_MAX, SHADE_MIN, TRAIT_MAX, TRAIT_MIN } from '@/app/micro-land/domain/traits'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 
 import {
   type SavedCreature,
+  type SavedGenerator,
   type SavedSpawner,
   WORLD_SAVE_VERSION,
   type WorldSave,
@@ -238,6 +239,19 @@ function validSnapshot(value: unknown): WorldSnapshot | null {
     }
   }
 
+  const generators: SavedGenerator[] = []
+  if (Array.isArray(value.generators)) {
+    for (const raw of value.generators) {
+      if (!isPlainObject(raw)) continue
+      if (typeof raw.blueprintId !== 'string' || raw.blueprintId.length === 0) continue
+      generators.push({
+        blueprintId: raw.blueprintId.slice(0, 120),
+        enabled: raw.enabled === true,
+        intervalSeconds: clamp(raw.intervalSeconds, 1, 3600, PLANT_SEED_INTERVAL),
+      })
+    }
+  }
+
   return {
     materials,
     width: WORLD_W,
@@ -257,6 +271,7 @@ function validSnapshot(value: unknown): WorldSnapshot | null {
     blueprints,
     spawners,
     nextSpawnerId: Math.max(1, Math.floor(num(value.nextSpawnerId, spawners.length + 1))),
+    generators,
   }
 }
 


### PR DESCRIPTION
## Summary

Implements issue #3577 — adds \`WorldGeneratorEntry\` type and per-species background-seeding config to \`WorldState\`, with full save/load round-trip.

### What changed

- **\`domain/types.ts\`**: Added \`WorldGeneratorEntry\` interface (\`blueprintId\`, \`enabled\`, \`intervalSeconds\`, runtime-only \`nextSeed\`) and \`generators: WorldGeneratorEntry[]\` to \`WorldState\`
- **\`domain/sim/world.ts\`**: Initialize \`generators: []\` in \`createWorld()\`; extend \`registerBlueprint()\` to push a default entry for each new native species — plants get \`enabled: true\` + \`intervalSeconds: PLANT_SEED_INTERVAL\`, animals get \`enabled: false\` + \`intervalSeconds: 30\`
- **\`worlds/types.ts\`**: Added \`SavedGenerator\` (omits \`nextSeed\`) and optional \`generators?: SavedGenerator[]\` to \`WorldSnapshot\`
- **\`worlds/snapshot.ts\`**: Encode generators in \`snapshotWorld()\` (drops \`nextSeed\`); merge saved values over registerBlueprint defaults in \`restoreSnapshot()\` (\`nextSeed\` always resets to 0)
- **\`worlds/wire.ts\`**: Validate and sanitize \`generators\` array in \`validSnapshot()\`
- **\`domain/tuning.ts\`**: Added \`generatorRateMultiplier: 1.0\` to \`TUNING_DEFAULTS\` and a 'plants' group knob

### Design notes

- **Generators ≠ spawners**: generators are per-species config (survive \`clearCreatures\`); spawners are placed world objects
- **Backward compat**: old saves with no \`generators\` field get defaults from \`registerBlueprint\` on load — no migration needed
- **Simulation not yet wired**: \`seedNativePlants\` still runs unchanged; issue #3579 will replace it with \`runWorldGenerators\`

### Acceptance criteria
- [x] \`WorldGeneratorEntry\` type defined
- [x] \`generators\` initialized from blueprint list in \`registerBlueprint\`
- [x] Plants default to \`enabled: true\`, animals to \`enabled: false\`
- [x] Serialized in snapshot, deserialized on restore (\`nextSeed\` resets to 0)
- [x] Wire validator sanitizes generator entries
- [x] \`generatorRateMultiplier\` tuning knob added
- [x] 47 worlds tests pass

Part of #3572
Closes #3577

🤖 Generated with [Claude Code](https://claude.com/claude-code)