### PR TITLE
[micro-land] World generator settings UI

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -125,6 +125,14 @@ export function MicroLandGame() {
           const { blueprint, traits } = state.workshopSpawnRequest
           queueMicrotask(() => game?.workshopIntroduce(blueprint, traits))
         }
+        if (
+          state.generatorConfigRequest !== previous.generatorConfigRequest &&
+          state.generatorConfigRequest &&
+          game
+        ) {
+          const req = state.generatorConfigRequest
+          queueMicrotask(() => game?.setGeneratorConfig(req.blueprintId, req))
+        }
       })
     })
 

--- a/src/app/micro-land/components/settings-panel.tsx
+++ b/src/app/micro-land/components/settings-panel.tsx
@@ -7,6 +7,7 @@ import {
   TUNING_DEFAULTS,
   type TuningKey,
 } from '@/app/micro-land/domain/tuning'
+import type { CreatureBlueprint, WorldGeneratorEntry } from '@/app/micro-land/domain/types'
 import { useMicroLand } from '@/app/micro-land/store'
 
 const heading: React.CSSProperties = {
@@ -52,6 +53,9 @@ export function SettingsPane() {
   const setKnob = useMicroLand(s => s.setTuningKnob)
   const reset = useMicroLand(s => s.resetTuningKnobs)
   const notify = useMicroLand(s => s.notify)
+  const generators = useMicroLand(s => s.generators)
+  const blueprints = useMicroLand(s => s.blueprints)
+  const updateGenerator = useMicroLand(s => s.updateGenerator)
 
   async function copySettings() {
     const text = JSON.stringify(tuning, null, 2)
@@ -185,6 +189,101 @@ export function SettingsPane() {
           </section>
         ))}
 
+        {/* ── World rhythms ──────────────────────────────────── */}
+        {generators.length > 0 && (
+          <section
+            className="px-4 py-3"
+            style={{ borderTop: '1px solid var(--cc-panel-divider)', marginTop: 12 }}
+          >
+            <h3 style={heading}>World rhythms</h3>
+            <p
+              className="pb-1 pt-1"
+              style={{ fontSize: 11, color: 'var(--cc-text-muted)', opacity: 0.8, lineHeight: 1.5 }}
+            >
+              The cave breathes these species into existence on a quiet timer. Plants are on by default;
+              animals wait for you to wake them.
+            </p>
+
+            {/* Plants */}
+            {(() => {
+              const plantGens = generators.filter(g => {
+                const bp = blueprints.find(b => b.id === g.blueprintId)
+                return bp?.move.kind === 'root'
+              })
+              if (plantGens.length === 0) return null
+              return (
+                <div style={{ marginTop: 8 }}>
+                  <p style={{ fontSize: 10, letterSpacing: 1.5, textTransform: 'uppercase', color: 'var(--cc-text-muted)', marginBottom: 6, fontFamily: 'var(--cc-font-mono)' }}>Plants</p>
+                  <div className="flex flex-col gap-3">
+                    {plantGens.map(g => (
+                      <GeneratorRow
+                        key={g.blueprintId}
+                        entry={g}
+                        blueprint={blueprints.find(b => b.id === g.blueprintId)}
+                        onChange={patch => updateGenerator(g.blueprintId, patch)}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )
+            })()}
+
+            {/* Animals */}
+            {(() => {
+              const animalGens = generators.filter(g => {
+                const bp = blueprints.find(b => b.id === g.blueprintId)
+                return bp && bp.move.kind !== 'root'
+              })
+              if (animalGens.length === 0) return null
+              return (
+                <div style={{ marginTop: 12 }}>
+                  <p style={{ fontSize: 10, letterSpacing: 1.5, textTransform: 'uppercase', color: 'var(--cc-text-muted)', marginBottom: 6, fontFamily: 'var(--cc-font-mono)' }}>Animals</p>
+                  <div className="flex flex-col gap-3">
+                    {animalGens.map(g => (
+                      <GeneratorRow
+                        key={g.blueprintId}
+                        entry={g}
+                        blueprint={blueprints.find(b => b.id === g.blueprintId)}
+                        onChange={patch => updateGenerator(g.blueprintId, patch)}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )
+            })()}
+
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => {
+                // Reset all generators to default (plants enabled, animals disabled)
+                for (const g of generators) {
+                  const bp = blueprints.find(b => b.id === g.blueprintId)
+                  const isPlant = bp?.move.kind === 'root'
+                  updateGenerator(g.blueprintId, {
+                    enabled: isPlant,
+                    intervalSeconds: isPlant ? 13 : 30,
+                  })
+                }
+              }}
+              style={{
+                marginTop: 12,
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 10,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '6px 10px',
+                minHeight: 32,
+                borderRadius: 4,
+                border: '1px solid var(--cc-mint-line)',
+                color: 'var(--cc-text-muted)',
+              }}
+            >
+              Reset to defaults
+            </button>
+          </section>
+        )}
+
         <div className="h-4" />
       </div>
     </>
@@ -265,6 +364,92 @@ function KnobRow({
       >
         {knob.help}
       </p>
+    </div>
+  )
+}
+
+/** Seconds-to-label mapping for the rate picker. */
+const RATE_PRESETS = [
+  { label: 'Slow', seconds: 60 },
+  { label: 'Normal', seconds: 30 },
+  { label: 'Fast', seconds: 10 },
+  { label: 'Relentless', seconds: 5 },
+] as const
+
+function GeneratorRow({
+  entry,
+  blueprint,
+  onChange,
+}: {
+  entry: WorldGeneratorEntry
+  blueprint: CreatureBlueprint | undefined
+  onChange: (patch: { enabled?: boolean; intervalSeconds?: number }) => void
+}) {
+  const name = blueprint?.name ?? entry.blueprintId
+  const activePreset = RATE_PRESETS.find(p => p.seconds === entry.intervalSeconds)
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        opacity: entry.enabled ? 1 : 0.5,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <input
+          type="checkbox"
+          id={`gen-${entry.blueprintId}`}
+          checked={entry.enabled}
+          onChange={e => onChange({ enabled: e.target.checked })}
+          style={{ accentColor: 'var(--cc-mint)', width: 14, height: 14 }}
+        />
+        <label
+          htmlFor={`gen-${entry.blueprintId}`}
+          style={{ fontSize: 12, color: 'var(--cc-text-default)', cursor: 'pointer', flex: 1 }}
+        >
+          {name}
+        </label>
+        {entry.enabled && (
+          <span
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 10,
+              color: 'var(--cc-text-muted)',
+            }}
+          >
+            {activePreset ? activePreset.label : `${entry.intervalSeconds}s`}
+          </span>
+        )}
+      </div>
+
+      {entry.enabled && (
+        <div style={{ display: 'flex', gap: 4, paddingLeft: 22 }}>
+          {RATE_PRESETS.map(preset => {
+            const active = entry.intervalSeconds === preset.seconds
+            return (
+              <button
+                key={preset.label}
+                type="button"
+                className="cc-btn"
+                onClick={() => onChange({ intervalSeconds: preset.seconds })}
+                aria-pressed={active}
+                style={{
+                  fontSize: 10,
+                  padding: '2px 6px',
+                  borderRadius: 3,
+                  border: `1px solid ${active ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+                  color: active ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                  background: active ? 'rgba(var(--cc-mint-rgb,80,200,160),0.08)' : 'transparent',
+                }}
+              >
+                {preset.label}
+              </button>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1335,6 +1335,31 @@ export class GameInstance {
 
   private syncBlueprintsToStore(): void {
     useMicroLand.getState().setBlueprints(Object.values(this.world.blueprints))
+    this.syncGeneratorsToStore()
+  }
+
+  private syncGeneratorsToStore(): void {
+    useMicroLand.getState().setGenerators([...this.world.generators])
+  }
+
+  /**
+   * Apply a generator config change from the settings UI to the live world.
+   *
+   * Resets `nextSeed` to 0 when intervalSeconds changes so the next seeding
+   * attempt happens on the fresh interval rather than completing a partial one.
+   */
+  setGeneratorConfig(
+    blueprintId: string,
+    patch: { enabled?: boolean; intervalSeconds?: number }
+  ): void {
+    const gen = this.world.generators.find(g => g.blueprintId === blueprintId)
+    if (!gen) return
+    if (patch.enabled !== undefined) gen.enabled = patch.enabled
+    if (patch.intervalSeconds !== undefined) {
+      gen.intervalSeconds = patch.intervalSeconds
+      gen.nextSeed = 0
+    }
+    useMicroLand.getState().clearGeneratorConfigRequest()
   }
 
   /**

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -10,6 +10,7 @@
 import { create } from 'zustand'
 
 import { DEFAULT_THEME } from './domain/config/themes'
+import type { WorldGeneratorEntry } from './domain/types'
 import {
   TUNING,
   type Tuning,
@@ -301,6 +302,13 @@ interface MicroLandState {
 
   /** Every creature that exists in this world, built-in and summoned. */
   blueprints: CreatureBlueprint[]
+  /** Current world generators, synced from game-instance after any world change. */
+  generators: WorldGeneratorEntry[]
+  /**
+   * Non-null when the UI has changed a generator; MicroLandGame.tsx watches
+   * this and applies the change to the live world.
+   */
+  generatorConfigRequest: { blueprintId: string; enabled?: boolean; intervalSeconds?: number } | null
   population: PopulationEntry[]
   totalCreatures: number
   elapsed: number
@@ -492,6 +500,9 @@ interface MicroLandState {
   setBlueprints: (list: CreatureBlueprint[]) => void
   /** Add a single blueprint without resetting population history. */
   addBlueprint: (bp: CreatureBlueprint) => void
+  setGenerators: (entries: WorldGeneratorEntry[]) => void
+  updateGenerator: (blueprintId: string, patch: { enabled?: boolean; intervalSeconds?: number }) => void
+  clearGeneratorConfigRequest: () => void
   setStats: (population: PopulationEntry[], total: number, elapsed: number) => void
   addExtinction: (record: ExtinctionRecord) => void
   clearExtinctions: () => void
@@ -593,6 +604,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
   speed: 1,
 
   blueprints: [],
+  generators: [],
+  generatorConfigRequest: null,
   population: [],
   totalCreatures: 0,
   elapsed: 0,
@@ -659,6 +672,15 @@ export const useMicroLand = create<MicroLandState>(set => ({
         ? s.blueprints.map(b => (b.id === bp.id ? bp : b))
         : [...s.blueprints, bp],
     })),
+  setGenerators: entries => set({ generators: entries }),
+  updateGenerator: (blueprintId, patch) =>
+    set(state => ({
+      generators: state.generators.map(g =>
+        g.blueprintId === blueprintId ? { ...g, ...patch } : g
+      ),
+      generatorConfigRequest: { blueprintId, ...patch },
+    })),
+  clearGeneratorConfigRequest: () => set({ generatorConfigRequest: null }),
   setStats: (population, totalCreatures, elapsed) =>
     set(s => {
       const last = s.populationHistory[s.populationHistory.length - 1]


### PR DESCRIPTION
## Summary

Implements issue #3578 — a "World rhythms" settings panel section where players configure per-species background seeding.

**Depends on #3598** (merged — world generator config data model).

### What changed

- **`store.ts`**: added `generators: WorldGeneratorEntry[]`, `generatorConfigRequest`, `setGenerators`, `updateGenerator`, `clearGeneratorConfigRequest`
- **`game-instance.ts`**: added `syncGeneratorsToStore()` (called from every `syncBlueprintsToStore` call) and `setGeneratorConfig()` which mutates `w.generators` directly and clears the request token
- **`MicroLandGame.tsx`**: added `generatorConfigRequest` subscribe handler — detects changes and calls `game.setGeneratorConfig()` via `queueMicrotask` (same pattern as `workshopSpawnRequest`)
- **`components/settings-panel.tsx`**:
  - "World rhythms" section after the tuning KNOBS groups
  - Plants and animals in separate sub-groups
  - Per-species: enable/disable checkbox + Slow (60s) / Normal (30s) / Fast (10s) / Relentless (5s) rate presets
  - "Reset to defaults" button restores plants enabled, animals disabled
  - Section hidden when `generators` is empty (world not yet loaded)

### Design notes

- **No simulation changes**: `seedNativePlants` still runs unchanged; issue #3579 will replace it
- **Live updates**: toggle/rate changes apply immediately to the running world's next seeding tick
- **`nextSeed` reset**: when `intervalSeconds` changes, `nextSeed` resets to 0 so timing is clean
- **Cosmic-narrator copy**: "The cave breathes these species into existence on a quiet timer" per CLAUDE.md §4

### Acceptance criteria
- [x] Toggling a species on/off updates `generator.enabled` on the live world
- [x] Rate preset changes update `generator.intervalSeconds` and reset `nextSeed`
- [x] Default state shows native plants enabled, animals disabled
- [x] Reset button restores defaults
- [x] Section hidden until generators are synced from game-instance
- [x] 47 worlds tests pass

Part of #3572
Closes #3578

🤖 Generated with [Claude Code](https://claude.com/claude-code)