### PR TITLE
feat(dicebound): quality bands — provenance-weighted rolling (closes #3552)

### DIFF
--- a/docs/dicebound-phase-2.md
+++ b/docs/dicebound-phase-2.md
@@ -384,9 +384,10 @@ Slots, not weight. A cap of around twelve, because a limit that forces a choice
 makes a story and a limit that requires arithmetic does not.
 
 An `Item` is a carried thing with 0–2 traits, optional charges, and an origin
-pointing at the world entity it came from. The model proposes a quality band;
-code assigns the numbers from a rarity table adapted from
-`itemRarityGenerator.ts`, weighted by where the item came from.
+pointing at the world entity it came from. The model names the thing and says where it came from;
+code rolls the quality band from a provenance table adapted from
+`itemRarityGenerator.ts`. There is no field for requesting a better item —
+the provenance is the only input.
 
 Items reach a check the same way situational modifiers do: the DM names which
 ones it is using, and code looks up what they are actually worth. The model can

--- a/src/app/dicebound/domain/__tests__/loot.test.ts
+++ b/src/app/dicebound/domain/__tests__/loot.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest'
+
+import { MAX_TRAIT } from '@/app/dicebound/domain/kit'
+import {
+  PROVENANCE_TABLES,
+  QUALITY_BANDS,
+  type Provenance,
+  type QualityBand,
+  describeQuality,
+  rollQuality,
+  traitsFor,
+  worthOf,
+} from '@/app/dicebound/domain/loot'
+
+// A simple deterministic counter-based rng for seeded tests.
+function counterRng(values: number[]): () => number {
+  let i = 0
+  return () => values[i++ % values.length]
+}
+
+// A minimal lcg rng seeded with a fixed value.
+function lcgRng(seed = 1): () => number {
+  let s = seed
+  return () => {
+    s = (s * 1664525 + 1013904223) & 0xffffffff
+    return (s >>> 0) / 0x100000000
+  }
+}
+
+describe('PROVENANCE_TABLES', () => {
+  const provenances = Object.keys(PROVENANCE_TABLES) as Provenance[]
+
+  it('every table sums to 1.0', () => {
+    for (const provenance of provenances) {
+      const sum = PROVENANCE_TABLES[provenance].reduce((acc, entry) => acc + entry.weight, 0)
+      expect(sum, `${provenance} table sum`).toBeCloseTo(1.0, 9)
+    }
+  })
+
+  it('plain is the majority outcome for underfoot (weight 0.55 > all others)', () => {
+    const table = PROVENANCE_TABLES.underfoot
+    const plain = table.find(e => e.band === 'plain')!
+    const others = table.filter(e => e.band !== 'plain')
+    expect(plain.weight).toBe(0.55)
+    for (const other of others) {
+      expect(plain.weight).toBeGreaterThan(other.weight)
+    }
+  })
+
+  it('plain has weight 0.10 for taken (not impossible, but not the majority)', () => {
+    const table = PROVENANCE_TABLES.taken
+    const plain = table.find(e => e.band === 'plain')!
+    expect(plain.weight).toBe(0.10)
+    // fine is the majority for taken
+    const fine = table.find(e => e.band === 'fine')!
+    expect(fine.weight).toBeGreaterThan(plain.weight)
+  })
+})
+
+describe('QUALITY_BANDS', () => {
+  const bands = Object.keys(QUALITY_BANDS) as QualityBand[]
+
+  it('no band produces a trait above MAX_TRAIT', () => {
+    for (const band of bands) {
+      for (const bonus of QUALITY_BANDS[band].bonuses) {
+        expect(Math.abs(bonus), `${band} bonus`).toBeLessThanOrEqual(MAX_TRAIT)
+      }
+    }
+  })
+
+  it("no band's bonuses sum above 2", () => {
+    for (const band of bands) {
+      const sum = QUALITY_BANDS[band].bonuses.reduce((acc, b) => acc + b, 0)
+      expect(sum, `${band} bonus sum`).toBeLessThanOrEqual(2)
+    }
+  })
+})
+
+describe('traitsFor', () => {
+  it('returns 1 trait for fine when given 3 labels (extra labels are dropped)', () => {
+    const labels = [
+      { label: 'edge is sharp', applies: {} },
+      { label: 'well-balanced', applies: {} },
+      { label: 'extra', applies: {} },
+    ]
+    const traits = traitsFor('fine', labels)
+    expect(traits).toHaveLength(1)
+    expect(traits[0].label).toBe('edge is sharp')
+    expect(traits[0].bonus).toBe(1)
+  })
+
+  it('returns 0 traits for storied when given 0 labels (code does not invent prose)', () => {
+    const traits = traitsFor('storied', [])
+    expect(traits).toHaveLength(0)
+  })
+
+  it('returns 0 traits for plain (plain has no traits)', () => {
+    const traits = traitsFor('plain', [{ label: 'you have rope', applies: {} }])
+    expect(traits).toHaveLength(0)
+  })
+
+  it('assigns the right bonuses for rare — [1, 0]', () => {
+    const labels = [
+      { label: 'first', applies: {} },
+      { label: 'second', applies: {} },
+    ]
+    const traits = traitsFor('rare', labels)
+    expect(traits).toHaveLength(2)
+    expect(traits[0].bonus).toBe(1)
+    expect(traits[1].bonus).toBe(0)
+  })
+})
+
+describe('rollQuality', () => {
+  it('is deterministic under a seeded rng', () => {
+    const rng1 = lcgRng(42)
+    const rng2 = lcgRng(42)
+    for (let i = 0; i < 20; i++) {
+      expect(rollQuality('underfoot', rng1)).toBe(rollQuality('underfoot', rng2))
+    }
+  })
+
+  it('a roll of 0 always returns plain for underfoot (first band, weight 0.55)', () => {
+    const rng = counterRng([0])
+    expect(rollQuality('underfoot', rng)).toBe('plain')
+  })
+
+  it('a roll just below the cumulative weight boundary picks the right band', () => {
+    // underfoot: plain=0.55, good=0.28 → cumulative at good boundary = 0.83
+    // roll of 0.829 should land in good
+    const rng = counterRng([0.829])
+    expect(rollQuality('underfoot', rng)).toBe('good')
+  })
+
+  it('a roll of 0.999 returns storied for underfoot (floating-point guard path)', () => {
+    const rng = counterRng([0.999])
+    expect(rollQuality('underfoot', rng)).toBe('storied')
+  })
+
+  it('10,000 seeded rolls land within a few percent of declared weights for each provenance', () => {
+    const provenances = Object.keys(PROVENANCE_TABLES) as Provenance[]
+    const N = 10_000
+    const tolerance = 0.03 // 3 percentage points
+
+    for (const provenance of provenances) {
+      const rng = lcgRng(1337)
+      const counts: Partial<Record<QualityBand, number>> = {}
+      for (let i = 0; i < N; i++) {
+        const band = rollQuality(provenance, rng)
+        counts[band] = (counts[band] ?? 0) + 1
+      }
+      for (const entry of PROVENANCE_TABLES[provenance]) {
+        const actual = (counts[entry.band] ?? 0) / N
+        expect(
+          Math.abs(actual - entry.weight),
+          `${provenance}/${entry.band}: got ${actual.toFixed(4)}, expected ${entry.weight}`
+        ).toBeLessThan(tolerance)
+      }
+    }
+  })
+})
+
+describe('worthOf', () => {
+  it('sums trait bonuses for an item', () => {
+    const item = {
+      id: 'sword',
+      name: 'Sword',
+      note: '',
+      traits: [
+        { label: 'edge is sharp', bonus: 1, applies: {} },
+        { label: 'well-balanced', bonus: 0, applies: {} },
+      ],
+      consumable: false,
+      origin: null,
+      gainedAt: 0,
+    }
+    expect(worthOf(item)).toBe(1)
+  })
+
+  it('returns 0 for an item with no traits', () => {
+    const item = {
+      id: 'rope',
+      name: 'Rope',
+      note: '',
+      traits: [],
+      consumable: false,
+      origin: null,
+      gainedAt: 0,
+    }
+    expect(worthOf(item)).toBe(0)
+  })
+})
+
+describe('describeQuality', () => {
+  it('plain returns the no-bonus description', () => {
+    const desc = describeQuality('plain', 0)
+    expect(desc).toContain('plain')
+    expect(desc).toContain('no bonus')
+  })
+
+  it('good with worth 0 calls it a named reason for the DM', () => {
+    const desc = describeQuality('good', 0)
+    expect(desc).toContain('good')
+    expect(desc).toContain('+0')
+    expect(desc).toContain('named reason')
+  })
+
+  it('storied with worth 2 reports the total on the die', () => {
+    const desc = describeQuality('storied', 2)
+    expect(desc).toContain('storied')
+    expect(desc).toContain('+2')
+    expect(desc).toContain('+0')
+    expect(desc).toContain('+2 on the die total')
+  })
+
+  it('fine with worth 1 reports the total', () => {
+    const desc = describeQuality('fine', 1)
+    expect(desc).toContain('fine')
+    expect(desc).toContain('+1 on the die total')
+  })
+})

--- a/src/app/dicebound/domain/loot.ts
+++ b/src/app/dicebound/domain/loot.ts
@@ -1,0 +1,117 @@
+/**
+ * Quality bands and provenance-weighted rolling for items.
+ *
+ * The spec says "the model proposes a quality band; code assigns the numbers."
+ * That wording was revised with Nick: the model does not propose a band. It
+ * names the thing and says where it came from; code rolls the band from a table
+ * weighted by that provenance. There is no field for requesting a better item.
+ */
+import type { Applicability, Item, Trait } from './kit'
+
+export type Rng = () => number
+
+export type Provenance = 'underfoot' | 'given' | 'bought' | 'taken' | 'hoard'
+export type QualityBand = 'plain' | 'good' | 'fine' | 'rare' | 'storied'
+
+export const QUALITY_BANDS: Record<QualityBand, { traits: number; bonuses: number[] }> = {
+  plain:   { traits: 0, bonuses: [] },
+  good:    { traits: 1, bonuses: [0] },
+  fine:    { traits: 1, bonuses: [1] },
+  rare:    { traits: 2, bonuses: [1, 0] },
+  storied: { traits: 2, bonuses: [2, 0] },
+}
+
+// Five provenances, weights ported from tap-tap-adventure's RARITY_TABLES.
+// All tables must sum to exactly 1.0.
+export const PROVENANCE_TABLES: Record<Provenance, { band: QualityBand; weight: number }[]> = {
+  underfoot: [
+    { band: 'plain',   weight: 0.55 },
+    { band: 'good',    weight: 0.28 },
+    { band: 'fine',    weight: 0.12 },
+    { band: 'rare',    weight: 0.04 },
+    { band: 'storied', weight: 0.01 },
+  ],
+  given: [
+    { band: 'plain',   weight: 0.40 },
+    { band: 'good',    weight: 0.35 },
+    { band: 'fine',    weight: 0.20 },
+    { band: 'rare',    weight: 0.04 },
+    { band: 'storied', weight: 0.01 },
+  ],
+  bought: [
+    { band: 'plain',   weight: 0.45 },
+    { band: 'good',    weight: 0.35 },
+    { band: 'fine',    weight: 0.15 },
+    { band: 'rare',    weight: 0.04 },
+    { band: 'storied', weight: 0.01 },
+  ],
+  taken: [
+    { band: 'plain',   weight: 0.10 },
+    { band: 'good',    weight: 0.30 },
+    { band: 'fine',    weight: 0.40 },
+    { band: 'rare',    weight: 0.15 },
+    { band: 'storied', weight: 0.05 },
+  ],
+  hoard: [
+    { band: 'plain',   weight: 0.20 },
+    { band: 'good',    weight: 0.35 },
+    { band: 'fine',    weight: 0.30 },
+    { band: 'rare',    weight: 0.12 },
+    { band: 'storied', weight: 0.03 },
+  ],
+}
+
+/** Roll the quality band. rng is passed in — domain/ may not call Math.random. */
+export function rollQuality(provenance: Provenance, rng: Rng): QualityBand {
+  const table = PROVENANCE_TABLES[provenance]
+  const roll = rng()
+  let cumulative = 0
+  for (const entry of table) {
+    cumulative += entry.weight
+    if (roll < cumulative) return entry.band
+  }
+  // Floating-point guard: return the last entry if we overshot.
+  return table[table.length - 1].band
+}
+
+/**
+ * Assign bonuses from the band to the labels the model wrote.
+ *
+ * Extra labels are dropped — the band decides how many traits survive, not the
+ * model's list length. Missing labels are not invented — code does not write
+ * prose, so a band with 2 traits and 0 labels returns 0 traits.
+ */
+export function traitsFor(
+  band: QualityBand,
+  labels: { label: string; applies: Applicability }[]
+): Trait[] {
+  const { traits: count, bonuses } = QUALITY_BANDS[band]
+  return labels.slice(0, count).map((l, i) => ({
+    label: l.label,
+    bonus: bonuses[i] ?? 0,
+    applies: l.applies,
+  }))
+}
+
+/** Total modifier this item contributes to the die. */
+export function worthOf(item: Item): number {
+  return item.traits.reduce((sum, t) => sum + t.bonus, 0)
+}
+
+/**
+ * One line for the DM to quote back when describing the item.
+ *
+ * A plain rope is "+0 on the die — it makes climbing attemptable, not easier."
+ * A storied blade is "+2 and +0 on the die — two reasons it matters."
+ * The number is the thing the DM is not allowed to decide.
+ */
+export function describeQuality(band: QualityBand, worth: number): string {
+  const { bonuses } = QUALITY_BANDS[band]
+  if (bonuses.length === 0) return `plain — no bonus on the die; it makes things possible, not easier`
+  const bonusStr = bonuses.map(b => (b >= 0 ? `+${b}` : `${b}`)).join(' and ')
+  const worthStr = worth >= 0 ? `+${worth}` : `${worth}`
+  const suffix = worth === 0
+    ? 'a named reason for the DM to allow a roll'
+    : `${worthStr} on the die total`
+  return `${band} — ${bonusStr} on the die; ${suffix}`
+}


### PR DESCRIPTION
## Summary

- Adds `src/app/dicebound/domain/loot.ts` with `QualityBand`, `Provenance` types, `PROVENANCE_TABLES`, and `rollQuality` / `traitsFor` / `worthOf` / `describeQuality` functions
- The model names the item and says where it came from; code rolls the quality band from a provenance-weighted table — no field for requesting a better item
- Adds `src/app/dicebound/domain/__tests__/loot.test.ts` with 20 tests covering all acceptance criteria (table sums, majority outcomes, trait caps, traitsFor slicing, determinism, and 10k statistical roll checks)
- Updates `docs/dicebound-phase-2.md` Inventory section to reflect the revised wording agreed with Nick
- Part of epic #3521

## Test plan

- [x] All provenance tables sum to 1.0 (toBeCloseTo)
- [x] `plain` is majority for `underfoot` (0.55 > all others)
- [x] `plain` weight 0.10 for `taken`, not the majority
- [x] No band produces a trait bonus above MAX_TRAIT (2), no band bonuses sum above 2
- [x] `traitsFor` with 3 labels on `fine` returns 1 trait (sliced)
- [x] `traitsFor` with 0 labels on `storied` returns 0 traits
- [x] `rollQuality` deterministic under seeded lcg rng
- [x] 10,000 seeded rolls land within 3% of declared weights for every provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)