### PR TITLE
feat(dicebound): species applies automatically, pack shows in sheet (closes #3553)

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -1540,7 +1540,7 @@ function sheetBlock(campaign: Campaign): string {
   return `THE CHARACTER
 ${c.name} — ${c.concept}
 Attributes: ${attributes}
-Earned skills: ${skills}${windowBlock(campaign)}${powersBlock(campaign.kit)}`
+Earned skills: ${skills}${windowBlock(campaign)}${powersBlock(campaign.kit)}${packBlock(campaign.kit)}`
 }
 
 /**
@@ -1604,6 +1604,38 @@ function powersBlock(kit: Kit): string {
   })
 
   return `\nThings they can do (call use_power with the id, and they still roll afterwards):\n${lines.join('\n')}`
+}
+
+/**
+ * What the character is carrying, shown to the DM so it can name items in roll_check.
+ *
+ * Trait labels are shown; their numbers are not. A DM shown "+2" narrates around
+ * the +2; one shown "the edge is sharp" narrates around a knife.
+ */
+function packBlock(kit: Kit): string {
+  const lines: string[] = []
+
+  if (kit.species) {
+    const { name, note, trait, drawback } = kit.species
+    lines.push(
+      `\nSpecies: ${name} — ${note}. ${trait.label} (upside). ${drawback.label} (drawback — applies automatically, always).`
+    )
+  }
+
+  if (kit.items.length === 0) return lines.join('')
+
+  const itemLines = kit.items.map(item => {
+    const traitList = item.traits.map(t => t.label).join(', ')
+    const traitsStr = traitList ? ` — ${traitList}` : ''
+    const charges = item.charges ? ` (${item.charges.now}/${item.charges.max} uses)` : ''
+    return `  ${item.id} "${item.name}"${charges}${traitsStr}`
+  })
+
+  lines.push(
+    `\nThey are carrying (name the id in roll_check's items when it genuinely applies — the game decides what it is worth):\n${itemLines.join('\n')}`
+  )
+
+  return lines.join('')
 }
 
 function format(value: number): string {

--- a/src/app/dicebound/domain/__tests__/kit.test.ts
+++ b/src/app/dicebound/domain/__tests__/kit.test.ts
@@ -345,6 +345,43 @@ describe('kitModifiers', () => {
     expect(mods.map(m => m.label)).toContain('the great sword')
     expect(mods.reduce((sum, m) => sum + m.value, 0)).toBeLessThanOrEqual(KIT_BONUS_CAP)
   })
+
+  it('applies a species trait automatically, without naming it', () => {
+    const kit = emptyKit()
+    const kitWithSpecies = {
+      ...kit,
+      species: validateSpecies({
+        name: 'Forest Cat',
+        note: 'grew up in trees',
+        trait: { label: 'nimble on branches', bonus: 1, applies: { attributes: ['dexterity'] } },
+        drawback: { label: 'easily distracted by birds', bonus: 1, applies: { attributes: ['wisdom'] } },
+      })!,
+    }
+    // Trait applies to dexterity even with no items named.
+    expect(kitModifiers(kitWithSpecies, [], 'dexterity', null)).toEqual([
+      { label: 'nimble on branches', value: 1 },
+    ])
+    // Drawback applies to wisdom.
+    expect(kitModifiers(kitWithSpecies, [], 'wisdom', null)).toEqual([
+      { label: 'easily distracted by birds', value: -1 },
+    ])
+    // Neither applies to strength.
+    expect(kitModifiers(kitWithSpecies, [], 'strength', null)).toEqual([])
+  })
+
+  it('shows all four reasons when four items are at the ceiling', () => {
+    const kit = kitWith(
+      { id: 'a', name: 'A', quality: 'fine', traits: [{ label: 'reason-a' }] },
+      { id: 'b', name: 'B', quality: 'fine', traits: [{ label: 'reason-b' }] },
+      { id: 'c', name: 'C', quality: 'fine', traits: [{ label: 'reason-c' }] },
+      { id: 'd', name: 'D', quality: 'fine', traits: [{ label: 'reason-d' }] },
+    )
+    const mods = kitModifiers(kit, ['a', 'b', 'c', 'd'], 'strength', null)
+    // All four labels must appear.
+    expect(mods.map(m => m.label)).toEqual(expect.arrayContaining(['reason-a', 'reason-b', 'reason-c', 'reason-d']))
+    // Total must not exceed the cap.
+    expect(mods.reduce((s, m) => s + m.value, 0)).toBeLessThanOrEqual(KIT_BONUS_CAP)
+  })
 })
 
 /** A world holding one actor the player met an hour into the story. */

--- a/src/app/dicebound/domain/kit.ts
+++ b/src/app/dicebound/domain/kit.ts
@@ -519,6 +519,18 @@ export function kitModifiers(
     }
   }
 
+  // Species applies automatically — no id required.
+  // The trait and the drawback both count, on every check they apply to.
+  if (kit.species) {
+    const { trait, drawback } = kit.species
+    if (traitApplies(trait, attribute, skill)) {
+      out.push({ label: trait.label, value: trait.bonus })
+    }
+    if (traitApplies(drawback, attribute, skill)) {
+      out.push({ label: drawback.label, value: drawback.bonus })
+    }
+  }
+
   return capKit(out)
 }
 
@@ -563,19 +575,29 @@ function capKit(modifiers: { label: string; value: number }[]): { label: string;
   const ordered = [...modifiers].sort((a, b) => Math.abs(b.value) - Math.abs(a.value))
   const kept: { label: string; value: number }[] = []
   let running = 0
+  let capped = false
 
   for (const modifier of ordered) {
+    if (capped) {
+      kept.push({ label: modifier.label, value: 0 })
+      continue
+    }
     const next = running + modifier.value
     if (Math.abs(next) > KIT_BONUS_CAP) {
       const room = KIT_BONUS_CAP - Math.abs(running)
-      if (room <= 0) break
+      if (room <= 0) {
+        kept.push({ label: modifier.label, value: 0 })
+        capped = true
+        continue
+      }
       const trimmed = modifier.value > 0 ? room : -room
       kept.push({ label: modifier.label, value: trimmed })
       running += trimmed
-      break
+      capped = true
+    } else {
+      kept.push(modifier)
+      running = next
     }
-    kept.push(modifier)
-    running = next
   }
 
   return kept


### PR DESCRIPTION
## Summary

- **Species auto-applies** — `kitModifiers` now processes `kit.species` after the items loop. The trait and drawback each apply to any check they match via `traitApplies`, without the DM needing to name an id.
- **capKit keeps all named items** — When the cap is reached, remaining modifiers appear at value 0 instead of being dropped with `break`. The die card shows every reason even when some contribute nothing to the number.
- **sheetBlock gains packBlock** — A new `packBlock(kit)` function renders the species line (name, note, trait label, drawback label) and the item list (id, name, charges, trait labels — numbers omitted). It is appended to `sheetBlock` so the DM can see what the character carries and name items in `roll_check`'s `items[]`.

Part of #3521.

## Test plan

- [x] `applies a species trait automatically, without naming it` — verifies trait applies to the right attribute, drawback applies to its attribute, neither applies to an unrelated attribute
- [x] `shows all four reasons when four items are at the ceiling` — verifies all four labels appear in output and total stays at or below `KIT_BONUS_CAP`
- [x] All 65 kit.test.ts tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)