### PR TITLE
feat(dicebound): species at creation from premise (closes #3555)

### DIFF
--- a/src/app/api/v1/dicebound/character/route.ts
+++ b/src/app/api/v1/dicebound/character/route.ts
@@ -25,13 +25,16 @@ import {
   ATTRIBUTE_IDS,
   SKILLS,
   SKILL_IDS,
+  type AttributeId,
   type SkillId,
+  isSkillId,
   skillsOf,
 } from '@/app/dicebound/domain/attributes'
 import { MAX_CONCEPT } from '@/app/dicebound/domain/campaign'
 import {
   ATTRIBUTE_BUDGET,
   type Character,
+  type SkillRecord,
   MAX_ATTRIBUTE,
   MAX_STARTING_SKILLS,
   MIN_ATTRIBUTE,
@@ -39,6 +42,8 @@ import {
   normalizeAttributes,
   startingSkills,
 } from '@/app/dicebound/domain/character'
+import { FALLBACK_SPECIES, type Species, validateSpecies } from '@/app/dicebound/domain/kit'
+import { isPlainObject } from '@/app/dicebound/domain/validate'
 import { NoApiKeyError, callForTool, requireApiKey, toolSchema } from '@/lib/dicebound/anthropic'
 
 export const maxDuration = 60
@@ -114,6 +119,31 @@ const CreationSchema = z.object({
     .describe(
       'One or two short sentences, addressed to the player as "you", naming which words in their description produced which numbers AND which starting skills. This is read aloud at the table — make it warm and specific, not a list.'
     ),
+  species: z
+    .object({
+      name: z.string().describe('The species name. Short. "Forest Cat", "River Otter", not "Feline Humanoid".'),
+      note: z.string().describe('One clause about what this species is. "grew up in the canopy", not an essay.'),
+      trait: z.object({
+        label: z.string().describe('What the good side looks like in the fiction. "nimble in the branches."'),
+        applies: z.object({
+          attributes: z.array(z.enum(ATTRIBUTE_IDS as unknown as [AttributeId, ...AttributeId[]])).optional(),
+          skills: z.array(SkillEnum).optional(),
+        }).optional(),
+      }).describe('The upside — a single trait, bonus assigned by code.'),
+      drawback: z.object({
+        label: z.string().describe('The cost. "easily distracted by birds." Not optional.'),
+        applies: z.object({
+          attributes: z.array(z.enum(ATTRIBUTE_IDS as unknown as [AttributeId, ...AttributeId[]])).optional(),
+          skills: z.array(SkillEnum).optional(),
+        }).optional(),
+      }).describe('The catch — forced negative by the game. A species with no cost is a stat bonus wearing a name.'),
+      skill: SkillEnum.nullable().describe('One skill this being is innately better or worse at. Null if none clearly fits.'),
+      skillRank: z.number().int().min(-1).max(1).describe('+1 or -1. The game assigns the magnitude.'),
+    })
+    .nullable()
+    .describe(
+      'Generate a species only when the premise or concept plainly implies a non-human. Ordinary people get null. The species name, trait, and drawback must all be about being THAT species — not just a personality.'
+    ),
 })
 
 const SYSTEM = `You build player characters for Dicebound, a dice-and-storytelling game played by all ages.
@@ -137,6 +167,14 @@ THE READING
 - Account for the starting skills as well as the numbers, in the same breath and the same voice: "Locksmith gave you clever hands, and a mouth that will not stop." Not a list, not a justification — one line that reads like someone at the table looking you over.
 - This matters more than it looks. Everywhere else this game teaches that skills are earned by using them, so a skill already sitting at rank 1 with nothing said about it reads as a bug. One sentence is the difference between "why do I have this?" and "of course I have this."
 
+THE SPECIES
+- Generate a species ONLY when the premise or concept plainly says the character is non-human. A cat pirate is non-human. A nervous locksmith is not.
+- When you do, name what the species is (short — "Forest Cat"), describe what it is in one clause, write a trait and a drawback that are about BEING that species, and pick one skill it helps or hinders.
+- The game assigns +1 for the trait and −1 for the drawback — you name what they apply to, not what they are worth.
+- A species with no drawback is a stat bonus wearing a species name. Give it something real to lose.
+- Most premises are human stories. When in doubt, send null. An unearned species reads worse than no species.
+- The reading should mention the species in the same breath as the numbers — "the cat in you gives you sharp eyes but a magpie's attention" — one clause, not a paragraph.
+
 THE NAME
 - If the player named their character, use that name exactly.
 - If not, invent one that fits both the character and the kind of world their sentence implies.
@@ -152,6 +190,7 @@ interface CreationInput {
   innate?: { size?: unknown; looks?: unknown }
   skills?: unknown
   reading?: unknown
+  species?: unknown
 }
 
 export async function POST(request: NextRequest) {
@@ -194,18 +233,19 @@ export async function POST(request: NextRequest) {
       },
     })) as CreationInput
 
-    return NextResponse.json({ source: 'model', character: fromInput(input, concept) })
+    const { character, species } = fromInput(input, concept)
+    return NextResponse.json({ source: 'model', character, species })
   } catch (error) {
     if (!(error instanceof NoApiKeyError)) {
       console.error('dicebound character creation failed:', error)
     }
-    return NextResponse.json({ source: 'offline', character: fallbackCharacter(concept) })
+    return NextResponse.json({ source: 'offline', character: fallbackCharacter(concept), species: null })
   } finally {
     clearTimeout(timeout)
   }
 }
 
-function fromInput(input: CreationInput, concept: string): Character {
+function fromInput(input: CreationInput, concept: string): { character: Character; species: Species | null } {
   const name =
     typeof input.name === 'string' && input.name.trim()
       ? input.name.trim().slice(0, 60)
@@ -214,7 +254,28 @@ function fromInput(input: CreationInput, concept: string): Character {
   const size = clampInnate(input.innate?.size)
   const looks = clampInnate(input.innate?.looks)
 
-  return {
+  // Parse species from model output
+  const rawSpecies = isPlainObject(input.species) ? input.species : null
+  let species: Species | null = null
+  let speciesSkillEntry: Partial<Record<SkillId, SkillRecord>> = {}
+
+  if (rawSpecies) {
+    // Validate — falls back to FALLBACK_SPECIES if model returned something bad
+    species = validateSpecies(rawSpecies) ?? FALLBACK_SPECIES[Math.floor(Math.random() * FALLBACK_SPECIES.length)]
+
+    // Innate skill adjustment (±1, code assigns magnitude, model says which skill)
+    if (typeof rawSpecies.skill === 'string' && isSkillId(rawSpecies.skill)) {
+      const skillRank = typeof rawSpecies.skillRank === 'number'
+        ? Math.max(-1, Math.min(1, Math.round(rawSpecies.skillRank)))
+        : 1
+      if (skillRank !== 0) {
+        const skillId = rawSpecies.skill as SkillId
+        speciesSkillEntry = { [skillId]: { uses: 0, rank: skillRank } }
+      }
+    }
+  }
+
+  const character: Character = {
     name,
     concept,
     reading: typeof input.reading === 'string' ? input.reading.trim().slice(0, 400) : '',
@@ -228,8 +289,13 @@ function fromInput(input: CreationInput, concept: string): Character {
       // they were never practised. That is also why they are spread last.
       ...(size !== 0 ? { size: { uses: 0, rank: size } } : {}),
       ...(looks !== 0 ? { looks: { uses: 0, rank: looks } } : {}),
+      // Species skill goes last — but startingSkills drops innates, and species
+      // skills may not be innate. Species skill wins if there's a conflict.
+      ...speciesSkillEntry,
     },
   }
+
+  return { character, species }
 }
 
 function clampInnate(value: unknown): number {

--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -1540,7 +1540,7 @@ function sheetBlock(campaign: Campaign): string {
   return `THE CHARACTER
 ${c.name} — ${c.concept}
 Attributes: ${attributes}
-Earned skills: ${skills}${windowBlock(campaign)}${powersBlock(campaign.kit)}`
+Earned skills: ${skills}${windowBlock(campaign)}${powersBlock(campaign.kit)}${packBlock(campaign.kit)}`
 }
 
 /**
@@ -1604,6 +1604,38 @@ function powersBlock(kit: Kit): string {
   })
 
   return `\nThings they can do (call use_power with the id, and they still roll afterwards):\n${lines.join('\n')}`
+}
+
+/**
+ * What the character is carrying, shown to the DM so it can name items in roll_check.
+ *
+ * Trait labels are shown; their numbers are not. A DM shown "+2" narrates around
+ * the +2; one shown "the edge is sharp" narrates around a knife.
+ */
+function packBlock(kit: Kit): string {
+  const lines: string[] = []
+
+  if (kit.species) {
+    const { name, note, trait, drawback } = kit.species
+    lines.push(
+      `\nSpecies: ${name} — ${note}. ${trait.label} (upside). ${drawback.label} (drawback — applies automatically, always).`
+    )
+  }
+
+  if (kit.items.length === 0) return lines.join('')
+
+  const itemLines = kit.items.map(item => {
+    const traitList = item.traits.map(t => t.label).join(', ')
+    const traitsStr = traitList ? ` — ${traitList}` : ''
+    const charges = item.charges ? ` (${item.charges.now}/${item.charges.max} uses)` : ''
+    return `  ${item.id} "${item.name}"${charges}${traitsStr}`
+  })
+
+  lines.push(
+    `\nThey are carrying (name the id in roll_check's items when it genuinely applies — the game decides what it is worth):\n${itemLines.join('\n')}`
+  )
+
+  return lines.join('')
 }
 
 function format(value: number): string {

--- a/src/app/dicebound/domain/__tests__/kit.test.ts
+++ b/src/app/dicebound/domain/__tests__/kit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  FALLBACK_SPECIES,
   KIT_BONUS_CAP,
   MAX_ITEMS,
   MAX_LEVEL,
@@ -143,6 +144,16 @@ describe('validateSpecies', () => {
 
   it('refuses a species missing either half', () => {
     expect(validateSpecies({ name: 'Cat', trait: { label: 'quick', bonus: 1 } })).toBeNull()
+  })
+})
+
+describe('FALLBACK_SPECIES', () => {
+  it('every fallback has name, trait, and drawback', () => {
+    for (const sp of FALLBACK_SPECIES) {
+      expect(sp.name).toBeTruthy()
+      expect(sp.trait.bonus).toBeGreaterThan(0)
+      expect(sp.drawback.bonus).toBeLessThan(0)
+    }
   })
 })
 

--- a/src/app/dicebound/domain/__tests__/kit.test.ts
+++ b/src/app/dicebound/domain/__tests__/kit.test.ts
@@ -345,6 +345,43 @@ describe('kitModifiers', () => {
     expect(mods.map(m => m.label)).toContain('the great sword')
     expect(mods.reduce((sum, m) => sum + m.value, 0)).toBeLessThanOrEqual(KIT_BONUS_CAP)
   })
+
+  it('applies a species trait automatically, without naming it', () => {
+    const kit = emptyKit()
+    const kitWithSpecies = {
+      ...kit,
+      species: validateSpecies({
+        name: 'Forest Cat',
+        note: 'grew up in trees',
+        trait: { label: 'nimble on branches', bonus: 1, applies: { attributes: ['dexterity'] } },
+        drawback: { label: 'easily distracted by birds', bonus: 1, applies: { attributes: ['wisdom'] } },
+      })!,
+    }
+    // Trait applies to dexterity even with no items named.
+    expect(kitModifiers(kitWithSpecies, [], 'dexterity', null)).toEqual([
+      { label: 'nimble on branches', value: 1 },
+    ])
+    // Drawback applies to wisdom.
+    expect(kitModifiers(kitWithSpecies, [], 'wisdom', null)).toEqual([
+      { label: 'easily distracted by birds', value: -1 },
+    ])
+    // Neither applies to strength.
+    expect(kitModifiers(kitWithSpecies, [], 'strength', null)).toEqual([])
+  })
+
+  it('shows all four reasons when four items are at the ceiling', () => {
+    const kit = kitWith(
+      { id: 'a', name: 'A', quality: 'fine', traits: [{ label: 'reason-a' }] },
+      { id: 'b', name: 'B', quality: 'fine', traits: [{ label: 'reason-b' }] },
+      { id: 'c', name: 'C', quality: 'fine', traits: [{ label: 'reason-c' }] },
+      { id: 'd', name: 'D', quality: 'fine', traits: [{ label: 'reason-d' }] },
+    )
+    const mods = kitModifiers(kit, ['a', 'b', 'c', 'd'], 'strength', null)
+    // All four labels must appear.
+    expect(mods.map(m => m.label)).toEqual(expect.arrayContaining(['reason-a', 'reason-b', 'reason-c', 'reason-d']))
+    // Total must not exceed the cap.
+    expect(mods.reduce((s, m) => s + m.value, 0)).toBeLessThanOrEqual(KIT_BONUS_CAP)
+  })
 })
 
 /** A world holding one actor the player met an hour into the story. */

--- a/src/app/dicebound/domain/kit.ts
+++ b/src/app/dicebound/domain/kit.ts
@@ -176,6 +176,27 @@ export const QUALITY_BANDS: Record<Quality, { bonus: number; traits: number }> =
   storied: { bonus: 2, traits: 2 },
 }
 
+export const FALLBACK_SPECIES: Species[] = [
+  {
+    name: 'Stray',
+    note: 'grew up learning to read rooms quickly',
+    trait: { label: 'reads a room before they walk into one', bonus: 1, applies: { attributes: ['wisdom'] } },
+    drawback: { label: 'slow to trust anyone new', bonus: -1, applies: { attributes: ['charm'] } },
+  },
+  {
+    name: 'Wanderer',
+    note: 'spent years moving through unfamiliar places',
+    trait: { label: 'finds the way even without a map', bonus: 1, applies: { attributes: ['wisdom'] } },
+    drawback: { label: 'never quite settles', bonus: -1, applies: { attributes: ['constitution'] } },
+  },
+  {
+    name: 'Scrapper',
+    note: 'learned early that things do not come easily',
+    trait: { label: 'keeps going when others stop', bonus: 1, applies: { attributes: ['constitution'] } },
+    drawback: { label: 'poor at asking for help', bonus: -1, applies: { attributes: ['charm'] } },
+  },
+]
+
 /**
  * Levels. `1 + earned ranks / 3` — ranks are earned on use, so level cannot be
  * granted. Feed this `earnedRanks(character)` and nothing else: it counts only

--- a/src/app/dicebound/domain/kit.ts
+++ b/src/app/dicebound/domain/kit.ts
@@ -519,6 +519,18 @@ export function kitModifiers(
     }
   }
 
+  // Species applies automatically — no id required.
+  // The trait and the drawback both count, on every check they apply to.
+  if (kit.species) {
+    const { trait, drawback } = kit.species
+    if (traitApplies(trait, attribute, skill)) {
+      out.push({ label: trait.label, value: trait.bonus })
+    }
+    if (traitApplies(drawback, attribute, skill)) {
+      out.push({ label: drawback.label, value: drawback.bonus })
+    }
+  }
+
   return capKit(out)
 }
 
@@ -563,19 +575,29 @@ function capKit(modifiers: { label: string; value: number }[]): { label: string;
   const ordered = [...modifiers].sort((a, b) => Math.abs(b.value) - Math.abs(a.value))
   const kept: { label: string; value: number }[] = []
   let running = 0
+  let capped = false
 
   for (const modifier of ordered) {
+    if (capped) {
+      kept.push({ label: modifier.label, value: 0 })
+      continue
+    }
     const next = running + modifier.value
     if (Math.abs(next) > KIT_BONUS_CAP) {
       const room = KIT_BONUS_CAP - Math.abs(running)
-      if (room <= 0) break
+      if (room <= 0) {
+        kept.push({ label: modifier.label, value: 0 })
+        capped = true
+        continue
+      }
       const trimmed = modifier.value > 0 ? room : -room
       kept.push({ label: modifier.label, value: trimmed })
       running += trimmed
-      break
+      capped = true
+    } else {
+      kept.push(modifier)
+      running = next
     }
-    kept.push(modifier)
-    running = next
   }
 
   return kept


### PR DESCRIPTION
## Summary

- Adds `FALLBACK_SPECIES` array to `kit.ts` — three generic species used when the model returns bad species data
- Adds `species` field to `CreationSchema` in the character creation route, with a nullable object that includes trait, drawback, and optional innate skill
- Updates `fromInput()` to parse species from model output, validate it (falling back to `FALLBACK_SPECIES` if invalid), and apply an optional innate skill rank to the character's skills
- Updates the `SYSTEM` prompt with a "THE SPECIES" section explaining when and how to generate species
- Route now returns `{ source, character, species }` — `species: null` for human concepts and the offline fallback

Part of #3521.

## Test plan

- [x] `npx vitest run src/app/dicebound/domain/__tests__/kit.test.ts` — 66 tests pass, including new `FALLBACK_SPECIES` describe block that asserts every fallback has a name, positive trait bonus, and negative drawback bonus

🤖 Generated with [Claude Code](https://claude.com/claude-code)