### PR TITLE
feat(dicebound): pack and species on the character sheet (closes #3556)

### DIFF
--- a/src/app/dicebound/components/__tests__/kit.test.tsx
+++ b/src/app/dicebound/components/__tests__/kit.test.tsx
@@ -2,10 +2,10 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { Powers, Standing } from '@/app/dicebound/components/kit'
+import { Items, Powers, SpeciesLine, Standing } from '@/app/dicebound/components/kit'
 import { type Campaign, newCampaign } from '@/app/dicebound/domain/campaign'
 import { RANK_THRESHOLDS, blankAttributes } from '@/app/dicebound/domain/character'
-import type { Power } from '@/app/dicebound/domain/kit'
+import type { Item, Power, Species } from '@/app/dicebound/domain/kit'
 import type { Entity } from '@/app/dicebound/domain/world'
 
 afterEach(cleanup)
@@ -52,6 +52,25 @@ const power = (over: Partial<Power> = {}): Power => ({
   cost: '',
   source: 'keeper-imra',
   gainedAt: 60,
+  ...over,
+})
+
+const species = (over: Partial<Species> = {}): Species => ({
+  name: 'Forest Cat',
+  note: 'grew up in the canopy',
+  trait: { label: 'nimble in branches', bonus: 1, applies: {} },
+  drawback: { label: 'easily distracted by birds', bonus: -1, applies: {} },
+  ...over,
+})
+
+const item = (over: Partial<Item> = {}): Item => ({
+  id: 'rope',
+  name: 'Rope',
+  note: 'coiled hemp, twenty metres',
+  traits: [{ label: 'you have rope', bonus: 0, applies: {} }],
+  consumable: false,
+  origin: null,
+  gainedAt: 0,
   ...over,
 })
 
@@ -147,5 +166,96 @@ describe('Powers', () => {
     expect(screen.getByText('Ember Word')).toBeDefined()
     expect(screen.getByText('no charges left')).toBeDefined()
     expect(screen.getByText('Back after you rest')).toBeDefined()
+  })
+})
+
+describe('SpeciesLine', () => {
+  it('renders nothing when species is null', () => {
+    const { container } = render(<SpeciesLine species={null} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows both the trait and the drawback — the cost is the reason the package is interesting', () => {
+    render(<SpeciesLine species={species()} />)
+    expect(screen.getByText(/Forest Cat/)).toBeDefined()
+    expect(screen.getByText(/nimble in branches/)).toBeDefined()
+    expect(screen.getByText(/easily distracted by birds/)).toBeDefined()
+  })
+
+  it('shows species without note when note is empty', () => {
+    render(<SpeciesLine species={species({ note: '' })} />)
+    expect(screen.getByText(/Forest Cat/)).toBeDefined()
+  })
+})
+
+describe('Items', () => {
+  it('renders nothing at all when the pack is empty', () => {
+    // Invariant 17. An empty inventory grid advertises unbuilt systems.
+    const { container } = render(<Items campaign={campaignWith()} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows item name, note, and trait label', () => {
+    render(
+      <Items
+        campaign={campaignWith({
+          kit: { ...campaignWith().kit, items: [item()] },
+        })}
+      />
+    )
+    expect(screen.getByText('Rope')).toBeDefined()
+    expect(screen.getByText(/coiled hemp/)).toBeDefined()
+    expect(screen.getByText(/you have rope/)).toBeDefined()
+  })
+
+  it('shows a +0 item trait label without any number', () => {
+    render(
+      <Items
+        campaign={campaignWith({
+          kit: { ...campaignWith().kit, items: [item()] },
+        })}
+      />
+    )
+    expect(screen.getByText(/you have rope/)).toBeDefined()
+    // "+0" must not appear anywhere — a column of zeros reads as a game that
+    // ran out of things to give.
+    expect(screen.queryByText('+0')).toBeNull()
+  })
+
+  it('shows the bonus when it is not zero', () => {
+    render(
+      <Items
+        campaign={campaignWith({
+          kit: {
+            ...campaignWith().kit,
+            items: [item({ traits: [{ label: 'sharp edge', bonus: 1, applies: {} }] })],
+          },
+        })}
+      />
+    )
+    expect(screen.getByText('+1')).toBeDefined()
+  })
+
+  it('resolves origin to a name rather than a slug', () => {
+    render(
+      <Items
+        campaign={campaignWith({
+          kit: { ...campaignWith().kit, items: [item({ origin: 'keeper-imra' })] },
+          world: { ...campaignWith().world, entities: { 'keeper-imra': imra } },
+        })}
+      />
+    )
+    expect(screen.getByText('From Keeper Imra')).toBeDefined()
+  })
+
+  it('drops the from-line rather than printing a slug when the entity is gone', () => {
+    render(
+      <Items
+        campaign={campaignWith({
+          kit: { ...campaignWith().kit, items: [item({ origin: 'keeper-imra' })] },
+        })}
+      />
+    )
+    expect(screen.queryByText(/keeper-imra/)).toBeNull()
   })
 })

--- a/src/app/dicebound/components/kit.tsx
+++ b/src/app/dicebound/components/kit.tsx
@@ -28,7 +28,7 @@
  */
 import type { Campaign } from '@/app/dicebound/domain/campaign'
 import { earnedRanks } from '@/app/dicebound/domain/character'
-import { type Power, levelFor } from '@/app/dicebound/domain/kit'
+import { type Item, type Power, type Species, levelFor } from '@/app/dicebound/domain/kit'
 import type { World } from '@/app/dicebound/domain/world'
 
 function Heading({ children }: { children: React.ReactNode }) {
@@ -78,6 +78,96 @@ export function Powers({ campaign }: { campaign: Campaign }) {
         ))}
       </ul>
     </section>
+  )
+}
+
+/**
+ * Species beside the concept, not in a list.
+ *
+ * It is what the character is, so it lives in the header next to the sentence
+ * they wrote. Both the trait and the drawback are named — the cost is the reason
+ * the package is interesting, and hiding it would make species read as a free bonus.
+ */
+export function SpeciesLine({ species }: { species: Species | null }) {
+  if (!species) return null
+
+  const traitStr = species.trait.label
+  const drawbackStr = species.drawback.label
+
+  return (
+    <p className="mt-1 text-sm text-on-surface-variant">
+      <span className="font-semibold text-on-surface">{species.name}</span>
+      {species.note ? ` — ${species.note}` : ''}
+      {'. '}
+      <span>{traitStr}</span>
+      <span className="mx-1 text-on-surface-variant/50">·</span>
+      <span className="text-on-surface-variant/80">{drawbackStr}</span>
+    </p>
+  )
+}
+
+/**
+ * The pack — what the character is currently carrying.
+ *
+ * Item name, note, and each trait label. The bonus number appears only when it
+ * is not zero: most items are +0 and that is the design, but a column of "+0"
+ * reads as a game that has run out of things to give; the label alone reads as
+ * a description of a rope.
+ *
+ * Nothing renders when the pack is empty. Invariant 17.
+ */
+export function Items({ campaign }: { campaign: Campaign }) {
+  const { items } = campaign.kit
+  if (items.length === 0) return null
+
+  return (
+    <section>
+      <Heading>What you carry</Heading>
+      <p className="mt-1 text-xs text-on-surface-variant/70">
+        {items.length} of 12 slots
+      </p>
+      <ul className="mt-3 flex flex-col gap-3">
+        {items.map(item => (
+          <ItemRow key={item.id} item={item} world={campaign.world} />
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function ItemRow({ item, world }: { item: Item; world: World }) {
+  const from = item.origin ? (world.entities[item.origin]?.name ?? null) : null
+
+  return (
+    <li className="border-l-2 border-outline-variant/40 pl-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+        <p className="text-sm font-semibold text-on-surface">{item.name}</p>
+        {item.charges && (
+          <span className="tabular-nums text-xs text-on-surface-variant">
+            {item.charges.now}/{item.charges.max} uses
+          </span>
+        )}
+      </div>
+
+      {item.note && <p className="mt-0.5 text-xs text-on-surface-variant">{item.note}</p>}
+
+      {item.traits.length > 0 && (
+        <ul className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-on-surface-variant/70">
+          {item.traits.map(trait => (
+            <li key={trait.label}>
+              {trait.label}
+              {trait.bonus !== 0 && (
+                <span className="ml-1 font-mono text-ds-tertiary">
+                  {trait.bonus > 0 ? `+${trait.bonus}` : `${trait.bonus}`}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {from && <p className="mt-1 text-xs text-on-surface-variant/60">From {from}</p>}
+    </li>
   )
 }
 

--- a/src/app/dicebound/components/sheet.tsx
+++ b/src/app/dicebound/components/sheet.tsx
@@ -25,7 +25,7 @@ import {
 import type { Campaign } from '@/app/dicebound/domain/campaign'
 import { RANK_THRESHOLDS, type SkillRecord, usesToNextRank } from '@/app/dicebound/domain/character'
 
-import { Powers, Standing } from './kit'
+import { Items, Powers, SpeciesLine, Standing } from './kit'
 import { WorldPanel } from './world'
 
 function sign(value: number): string {
@@ -44,6 +44,7 @@ export function Sheet({ campaign }: { campaign: Campaign }) {
       <header>
         <h2 className="font-headline text-headline-md text-on-surface">{character.name}</h2>
         <p className="mt-1 text-body-md text-on-surface-variant">{character.concept}</p>
+        <SpeciesLine species={campaign.kit.species} />
         <Standing campaign={campaign} />
         {character.reading && (
           <p className="mt-3 border-l-2 border-ds-tertiary/50 pl-3 text-sm italic text-on-surface-variant">
@@ -97,6 +98,7 @@ export function Sheet({ campaign }: { campaign: Campaign }) {
         )}
       </section>
 
+      <Items campaign={campaign} />
       <Powers campaign={campaign} />
 
       <WorldPanel campaign={campaign} />


### PR DESCRIPTION
## Summary

- Adds `SpeciesLine` component to `kit.tsx` — renders species name, note, trait, and drawback in the sheet header beside the concept; returns null when species is null (invariant 17)
- Adds `Items` and `ItemRow` components to `kit.tsx` — renders the character's pack as a "What you carry" section; suppresses +0 bonus numbers, resolves origin slugs to entity names, and returns null when the pack is empty (invariant 17)
- Updates `sheet.tsx` to place `SpeciesLine` after the concept paragraph and `Items` before `Powers` in the sheet flow
- Adds 9 new tests covering all new behaviour; all 17 tests in the file pass

Part of #3521

## Test plan

- [ ] `SpeciesLine` renders null when species is null
- [ ] `SpeciesLine` shows name, trait, and drawback
- [ ] `SpeciesLine` omits the dash clause when note is empty
- [ ] `Items` renders null when pack is empty
- [ ] `Items` shows name, note, and trait label
- [ ] `Items` suppresses "+0" bonus
- [ ] `Items` shows non-zero bonus formatted correctly
- [ ] `Items` resolves origin slug to entity name
- [ ] `Items` drops the from-line when entity is missing from world graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)