### PR TITLE
feat(micro-land): countershading (+0.25 flat camouflage bonus) (#3347)

### DIFF
--- a/src/app/micro-land/domain/__tests__/countershading.test.ts
+++ b/src/app/micro-land/domain/__tests__/countershading.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Countershading: dark dorsal / pale ventral coloration that cancels shadow
+ * depth cues, giving a fixed +0.25 camouflage bonus regardless of tile or hue.
+ *
+ * Unlike cryptic coloration (tile-dependent) or the camouflage trait (heritable),
+ * countershading is a structural bonus that is constant across all tiles and
+ * persists even when the population is not under selection.
+ *
+ * Detection geometry (sight=60, hunger=1, roamOf=1, desperation=1):
+ *   foodSight = 60 * (1 + HUNGER_REACH * 1 * 1) = 60 * 3 = 180
+ *   still plain (camo=0):        detFactor = 0.5,   efs = 90,  efs² = 8100
+ *   still countershaded (camo=0.25): detFactor = max(0.15, 0.5-0.25×0.375) = 0.406, efs = 73, efs² = 5329
+ *
+ *   Gap of 82: d² = 6724.
+ *     plain: 6724 < 8100 → detected ✓
+ *     countershaded: 6724 > 5329 → NOT detected ✓
+ *
+ *   Predator at x=100, prey at x=185 → gapX = |185-100| - (3+3)/2 = 85-3 = 82. ✓
+ *   Both at py=WORLD_H-11 so gapY=0.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import type { CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+function groundWorld(): WorldState {
+  const w = createWorld(1234)
+  for (let y = WORLD_H - 8; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.dirt
+  }
+  w.dormant = true
+  w.elapsed = 1 // avoid disease-outbreak edge case at elapsed=0
+  return w
+}
+
+function pred(): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: 'Pred',
+      tags: ['predator'],
+      art: { palette: { a: '#ff0000' }, frames: [['aaa']], frameMs: 200, faceMotion: false },
+      move: { kind: 'walk', speed: 0 },
+      diet: { eats: ['meat'], hungerRate: 0.01, lifespanSeconds: 900 },
+      senses: { sight: 60 },
+    },
+    { summoned: true }
+  )
+}
+
+function prey(extra: Record<string, unknown> = {}): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: 'Prey',
+      tags: ['meat'],
+      art: { palette: { a: '#888888' }, frames: [['aaa']], frameMs: 200, faceMotion: false },
+      move: { kind: 'walk', speed: 0 }, // stationary → "still" detFactor applies
+      diet: { eats: [], hungerRate: 0, lifespanSeconds: 900 },
+      senses: { sight: 0 },
+      traitDefaults: { camouflage: 0 }, // pin to camo=0 so the geometry in the comment is exact
+      ...extra,
+    },
+    { summoned: true }
+  )
+}
+
+function runSensePasses(w: WorldState, n: number): void {
+  const rng = makeRng(42)
+  for (let i = 0; i < n * 6; i++) tickCreatures(w, 1 / 60, rng, 1, [])
+}
+
+describe('countershading', () => {
+  it('countershaded flag is preserved through sanitizeBlueprint', () => {
+    expect(prey({ countershaded: true }).countershaded).toBe(true)
+    expect(prey({ countershaded: false }).countershaded).toBe(false)
+    expect(prey().countershaded).toBe(false)
+  })
+
+  it('plain still prey at gap=82 is detected (efs=90 > 82)', () => {
+    const w = groundWorld()
+    const predBp = pred()
+    const preyBp = prey({ countershaded: false })
+    registerBlueprint(w, predBp)
+    registerBlueprint(w, preyBp)
+
+    const py = WORLD_H - 11
+    spawnCreature(w, predBp, 100, py)
+    spawnCreature(w, preyBp, 185, py) // gapX = 185-100-3 = 82
+
+    const predC = w.creatures.find(c => c.blueprintId === predBp.id)!
+    const preyC = w.creatures.find(c => c.blueprintId === preyBp.id)!
+    predC.hunger = 1.0
+
+    runSensePasses(w, 4)
+
+    expect(predC.targetId).toBe(preyC.id)
+  })
+
+  it('countershaded still prey at gap=82 evades detection (efs=73 < 82)', () => {
+    const w = groundWorld()
+    const predBp = pred()
+    const preyBp = prey({ countershaded: true })
+    registerBlueprint(w, predBp)
+    registerBlueprint(w, preyBp)
+
+    const py = WORLD_H - 11
+    spawnCreature(w, predBp, 100, py)
+    spawnCreature(w, preyBp, 185, py) // same gap = 82
+
+    const predC = w.creatures.find(c => c.blueprintId === predBp.id)!
+    predC.hunger = 1.0
+
+    runSensePasses(w, 4)
+
+    expect(predC.targetId).toBeNull()
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -587,6 +587,7 @@ export function sanitizeBlueprint(
     cryptic: b.cryptic === true,
     disruptivePattern: b.disruptivePattern === true,
     clearingMaintainer: b.clearingMaintainer === true,
+    countershaded: b.countershaded === true,
     traitDefaults:
       b.traitDefaults && typeof b.traitDefaults === 'object'
         ? {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1382,7 +1382,7 @@ function look(
       // at its feet) rather than its vertical centre. Centre is always air for a
       // walking creature, which would make the colour match meaningless — the
       // relevant substrate is always the one the creature is resting against.
-      const camouflage = obp.cryptic
+      const baseCamouflage = obp.cryptic
         ? Math.max(
             other.traits.camouflage,
             crypticCamouflage(
@@ -1394,6 +1394,10 @@ function look(
             )
           )
         : other.traits.camouflage
+      // Countershading: dark-top/pale-belly structure eliminates shadow depth cues,
+      // making the body appear flat and harder to resolve at any angle.
+      // A fixed structural bonus — it does not depend on tile colour or evolution.
+      const camouflage = obp.countershaded === true ? Math.min(1, baseCamouflage + 0.25) : baseCamouflage
       const detFactor = still
         ? Math.max(0.15, 0.5 - camouflage * 0.375) // 0.5 (camo=0) → 0.2 (camo=0.8)
         : 1 - camouflage * 0.3 // 1.0 (camo=0) → 0.76 (camo=0.8)
@@ -1423,7 +1427,7 @@ function look(
       obp.move.kind !== 'root' // not a plant
     ) {
       const territoryR = (c.traits.territorial ?? 0.5) * 10
-      const intruderCamo = obp.cryptic
+      const intruderCamoBase = obp.cryptic
         ? Math.max(
             other.traits.camouflage,
             crypticCamouflage(
@@ -1435,6 +1439,9 @@ function look(
             )
           )
         : other.traits.camouflage
+      const intruderCamo = obp.countershaded === true
+        ? Math.min(1, intruderCamoBase + 0.25)
+        : intruderCamoBase
       const effectiveTerritoryR = territoryR * (1 - intruderCamo * 0.5)
       if (d2 < effectiveTerritoryR * effectiveTerritoryR && d2 < preyDist) {
         preyDist = d2

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -341,6 +341,16 @@ export interface CreatureBlueprint {
    * Only targets plants younger than SEEDLING_MAX_AGE seconds.
    */
   clearingMaintainer?: boolean
+  /**
+   * Dark dorsal surface and pale ventral surface that cancel out the shadow cast
+   * by overhead lighting, making the body appear flat and harder to resolve as
+   * three-dimensional prey.
+   *
+   * Adds a fixed +0.25 to the effective camouflage score independent of the
+   * cryptic tile-matching system — structural concealment that does not evolve
+   * away in a single generation. The most common coloration pattern in vertebrates.
+   */
+  countershaded?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `countershaded?: boolean` to `CreatureBlueprint` (types.ts, blueprint.ts)
- In `look()`: `camouflage = obp.countershaded ? min(1, baseCamouflage + 0.25) : baseCamouflage`, applied after the cryptic tile-hue calculation
- Models dark dorsal / pale ventral coloration (countershading) that cancels shadow depth cues — structural concealment independent of tile or hue matching
- 3 tests: flag preserved, plain prey detected at gap=82, countershaded prey evades at same gap

Closes #3347

## Test plan

- [x] `countershading.test.ts` — 3 tests passing
- [x] All prior camouflage tests (cryptic-coloration, disruptive-pattern) still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)