### PR TITLE
feat(micro-land): bioturbation reclaims barren tiles to soil (#3449)

### DIFF
--- a/src/app/micro-land/domain/__tests__/bioturbation.test.ts
+++ b/src/app/micro-land/domain/__tests__/bioturbation.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Bioturbation: digging creatures convert infertile tiles (sand, stone, ash, bone)
+ * to dirt as they walk over them, reclaiming barren areas.
+ *
+ * The effect is probabilistic (BIOTURBATION_PROB=0.001 per tick). Tests run enough
+ * ticks for the probability to become near-certain, then check the outcome.
+ *
+ * BIOTURBATION_PROB=0.001 per tick at 60Hz → ~6% per second.
+ * At 60 s (3600 ticks): P(no conversion) = (1 - 0.001)^3600 ≈ 0.027.
+ * Using 60 s gives confidence comparable to the soil-engineer 30 s test
+ * (which uses SOIL_ENRICH_PROB=0.002, twice as high).
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import type { CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+/** A world with an infertile sand floor for bioturbators to reclaim. */
+function sandWorld(): WorldState {
+  const w = createWorld(1234)
+  for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.sand
+  }
+  w.dormant = true
+  w.elapsed = 1
+  return w
+}
+
+/** A world with a stone floor. */
+function stoneWorld(): WorldState {
+  const w = createWorld(1234)
+  for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.stone
+  }
+  w.dormant = true
+  w.elapsed = 1
+  return w
+}
+
+/** A walker blueprint with the given extra options. */
+function digger(extra: Record<string, unknown> = {}): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: 'Test Digger',
+      tags: ['meat'],
+      art: {
+        palette: { a: '#886644' },
+        frames: [['aaa', 'aaa', 'aaa']],
+        frameMs: 200,
+        faceMotion: false,
+      },
+      move: { kind: 'walk', speed: 0 },
+      diet: { eats: [], hungerRate: 0, lifespanSeconds: 900 },
+      senses: { sight: 4 },
+      ...extra,
+    },
+    { summoned: true }
+  )
+}
+
+/** Run `seconds` of simulation. */
+function runSim(w: WorldState, seconds: number): void {
+  const rng = makeRng(42)
+  for (let i = 0; i < seconds * 60; i++) tickCreatures(w, 1 / 60, rng, 1, [])
+}
+
+describe('bioturbation', () => {
+  it('bioturbator flag is preserved through sanitizeBlueprint', () => {
+    expect(digger({ bioturbator: true }).bioturbator).toBe(true)
+    expect(digger({ bioturbator: false }).bioturbator).toBe(false)
+    expect(digger().bioturbator).toBe(false)
+  })
+
+  it('bioturbator on sand converts at least one tile to dirt over 60 s', () => {
+    const w = sandWorld()
+    const bp = digger({ bioturbator: true })
+    registerBlueprint(w, bp)
+
+    spawnCreature(w, bp, 40, WORLD_H - 16)
+    runSim(w, 60)
+
+    let foundDirt = false
+    for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+      for (let x = 0; x < WORLD_W; x++) {
+        if (w.tiles[y * WORLD_W + x] === MATERIAL_INDEX.dirt) {
+          foundDirt = true
+        }
+      }
+    }
+    expect(foundDirt).toBe(true)
+  })
+
+  it('non-bioturbator on sand leaves the tile unchanged', () => {
+    const w = sandWorld()
+    const bp = digger() // bioturbator=false
+    registerBlueprint(w, bp)
+
+    spawnCreature(w, bp, 40, WORLD_H - 16)
+    runSim(w, 60)
+
+    let foundDirt = false
+    for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+      for (let x = 0; x < WORLD_W; x++) {
+        if (w.tiles[y * WORLD_W + x] === MATERIAL_INDEX.dirt) {
+          foundDirt = true
+        }
+      }
+    }
+    expect(foundDirt).toBe(false)
+  })
+
+  it('bioturbator on stone converts to dirt', () => {
+    const w = stoneWorld()
+    const bp = digger({ bioturbator: true })
+    registerBlueprint(w, bp)
+
+    spawnCreature(w, bp, 40, WORLD_H - 16)
+    runSim(w, 60)
+
+    let foundDirt = false
+    for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+      for (let x = 0; x < WORLD_W; x++) {
+        if (w.tiles[y * WORLD_W + x] === MATERIAL_INDEX.dirt) {
+          foundDirt = true
+        }
+      }
+    }
+    expect(foundDirt).toBe(true)
+  })
+
+  it('bioturbator does not convert dirt tiles (only infertile substrates)', () => {
+    // Bioturbation is not soil engineering — it should not change dirt to anything.
+    const w = createWorld(1234)
+    for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+      for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.dirt
+    }
+    w.dormant = true
+    w.elapsed = 1
+
+    const bp = digger({ bioturbator: true })
+    registerBlueprint(w, bp)
+    spawnCreature(w, bp, 40, WORLD_H - 16)
+    runSim(w, 30)
+
+    // All floor tiles should still be dirt (not mud or any other change).
+    let allDirt = true
+    for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+      for (let x = 0; x < WORLD_W; x++) {
+        if (w.tiles[y * WORLD_W + x] !== MATERIAL_INDEX.dirt) {
+          allDirt = false
+        }
+      }
+    }
+    expect(allDirt).toBe(true)
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -587,6 +587,7 @@ export function sanitizeBlueprint(
     cryptic: b.cryptic === true,
     disruptivePattern: b.disruptivePattern === true,
     clearingMaintainer: b.clearingMaintainer === true,
+    bioturbator: b.bioturbator === true,
     traitDefaults:
       b.traitDefaults && typeof b.traitDefaults === 'object'
         ? {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -107,6 +107,14 @@ const BITE_PAD = 0.5
 const SOIL_ENRICH_PROB = 0.002
 
 /**
+ * Probability per tick that a bioturbating creature converts the infertile tile
+ * it is standing on (sand, stone, ash, bone) into dirt. At 60Hz this gives
+ * a ~6% chance per second — slower than soil enrichment because bringing
+ * barren substrate to productive soil is a larger physical transformation.
+ */
+const BIOTURBATION_PROB = 0.001
+
+/**
  * Within this many tiles, disruptive patterns give no detection benefit —
  * the outline is legible at close range regardless of the pattern.
  */
@@ -850,6 +858,27 @@ export function tickCreatures(
       const scy = Math.floor(c.y + body.dy + body.h)
       if (tileAt(w, scx, scy) === MATERIAL_INDEX.dirt && Math.random() < SOIL_ENRICH_PROB) {
         setTile(w, scx, scy, MATERIAL_INDEX.mud)
+      }
+    }
+
+    // Bioturbation: digging creatures mix infertile substrate (sand, stone, ash,
+    // bone) into productive soil (dirt) by physically breaking up and turning
+    // over the ground beneath them. Models the earthworm / mole / ant effect:
+    // subsoil material is brought to the surface where plants can use it.
+    // Complements soil engineering — bioturbation reclaims barren areas while
+    // soil engineering enriches existing soil.
+    if (bp.bioturbator) {
+      const scx = Math.floor(c.x + body.dx + body.w / 2)
+      const scy = Math.floor(c.y + body.dy + body.h)
+      const foot = tileAt(w, scx, scy)
+      if (
+        (foot === MATERIAL_INDEX.sand ||
+          foot === MATERIAL_INDEX.stone ||
+          foot === MATERIAL_INDEX.ash ||
+          foot === MATERIAL_INDEX.bone) &&
+        Math.random() < BIOTURBATION_PROB
+      ) {
+        setTile(w, scx, scy, MATERIAL_INDEX.dirt)
       }
     }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -341,6 +341,16 @@ export interface CreatureBlueprint {
    * Only targets plants younger than SEEDLING_MAX_AGE seconds.
    */
   clearingMaintainer?: boolean
+  /**
+   * Digging creatures that physically mix soil layers, bringing buried nutrients
+   * and infertile substrate to the surface where plants can use them.
+   *
+   * When the creature walks over sand, stone, ash, or bone tiles, there is a
+   * small chance per tick the tile is converted to dirt — reclaiming barren
+   * areas. Complements soilEngineer (which enriches dirt→mud); bioturbators
+   * reclaim the layer beneath. Models earthworms, moles, ants, crabs.
+   */
+  bioturbator?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `bioturbator?: boolean` to `CreatureBlueprint` (types.ts, blueprint.ts)
- When a bioturbator walks over infertile tiles (sand, stone, ash, bone), small per-tick probability converts the tile to dirt — reclaiming barren substrate
- Constant `BIOTURBATION_PROB = 0.001/tick` (~6%/s); slower than soil enrichment because converting barren rock to soil is a larger transformation
- Complements `soilEngineer` (which enriches dirt→mud); bioturbators work the layer beneath
- 5 tests: flag preserved, sand→dirt, non-bioturbator unchanged, stone→dirt, dirt unchanged

Closes #3449

## Test plan

- [x] `bioturbation.test.ts` — 5 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)