### PR TITLE
feat(micro-land): riparian root bank stabilization (#3450)

### DIFF
--- a/src/app/micro-land/domain/__tests__/root-bank-stabilizer.test.ts
+++ b/src/app/micro-land/domain/__tests__/root-bank-stabilizer.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Root bank stabilization: riparian plants bind loose sand into stable dirt
+ * within their root zone, modelling willow/alder erosion prevention.
+ *
+ * ROOT_STABILIZE_PROB = 0.0005/tick per adjacent tile. With 5 tiles and 60Hz,
+ * expected conversions ≈ 5 × 0.0005 × 60 × T per second. At T = 60 s:
+ * expected ≈ 9 conversions — near-certainty that at least one converts.
+ *
+ * P(no conversion in 60 s at one tile) = (1 - 0.0005)^3600 ≈ 0.165.
+ * P(no conversion at all, 5 tiles) = 0.165^5 ≈ 0.0001 — safely negligible.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import type { CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+/** A world with a sand floor for stabilizer plants to reclaim. */
+function sandWorld(): WorldState {
+  const w = createWorld(1234)
+  for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.sand
+  }
+  w.dormant = true
+  w.elapsed = 1
+  return w
+}
+
+/** A root plant blueprint with the given extra options. */
+function riparian(extra: Record<string, unknown> = {}): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: 'Test Willow',
+      tags: ['plant'],
+      art: {
+        palette: { a: '#44aa44' },
+        frames: [['aaa', 'aaa', 'aaa']],
+        frameMs: 200,
+        faceMotion: false,
+      },
+      move: { kind: 'root' },
+      diet: { eats: [], hungerRate: 0, lifespanSeconds: 900 },
+      senses: { sight: 0 },
+      ...extra,
+    },
+    { summoned: true }
+  )
+}
+
+/** Walker that should NOT stabilize soil. */
+function walker(extra: Record<string, unknown> = {}): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: 'Test Walker',
+      tags: ['meat'],
+      art: {
+        palette: { a: '#884422' },
+        frames: [['aaa', 'aaa', 'aaa']],
+        frameMs: 200,
+        faceMotion: false,
+      },
+      move: { kind: 'walk', speed: 0 },
+      diet: { eats: [], hungerRate: 0, lifespanSeconds: 900 },
+      senses: { sight: 0 },
+      ...extra,
+    },
+    { summoned: true }
+  )
+}
+
+/** Run `seconds` of simulation. */
+function runSim(w: WorldState, seconds: number): void {
+  const rng = makeRng(42)
+  for (let i = 0; i < seconds * 60; i++) tickCreatures(w, 1 / 60, rng, 1, [])
+}
+
+describe('root bank stabilizer', () => {
+  it('rootBankStabilizer flag is preserved through sanitizeBlueprint', () => {
+    expect(riparian({ rootBankStabilizer: true }).rootBankStabilizer).toBe(true)
+    expect(riparian({ rootBankStabilizer: false }).rootBankStabilizer).toBe(false)
+    expect(riparian().rootBankStabilizer).toBe(false)
+  })
+
+  it('root plant with rootBankStabilizer converts adjacent sand to dirt over 60 s', () => {
+    const w = sandWorld()
+    const bp = riparian({ rootBankStabilizer: true })
+    registerBlueprint(w, bp)
+
+    // Spawn in the sand zone (plants settle onto ground below)
+    spawnCreature(w, bp, 40, WORLD_H - 16)
+    runSim(w, 60)
+
+    let foundDirt = false
+    for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+      for (let x = 0; x < WORLD_W; x++) {
+        if (w.tiles[y * WORLD_W + x] === MATERIAL_INDEX.dirt) {
+          foundDirt = true
+        }
+      }
+    }
+    expect(foundDirt).toBe(true)
+  })
+
+  it('root plant without flag leaves sand unchanged', () => {
+    const w = sandWorld()
+    const bp = riparian() // rootBankStabilizer=false
+    registerBlueprint(w, bp)
+
+    spawnCreature(w, bp, 40, WORLD_H - 16)
+    runSim(w, 60)
+
+    let foundDirt = false
+    for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+      for (let x = 0; x < WORLD_W; x++) {
+        if (w.tiles[y * WORLD_W + x] === MATERIAL_INDEX.dirt) {
+          foundDirt = true
+        }
+      }
+    }
+    expect(foundDirt).toBe(false)
+  })
+
+  it('walker with rootBankStabilizer does not stabilize sand (root plants only)', () => {
+    // The flag only applies to move.kind==='root' creatures.
+    const w = sandWorld()
+    const bp = walker({ rootBankStabilizer: true })
+    registerBlueprint(w, bp)
+
+    spawnCreature(w, bp, 40, WORLD_H - 16)
+    runSim(w, 60)
+
+    let foundDirt = false
+    for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+      for (let x = 0; x < WORLD_W; x++) {
+        if (w.tiles[y * WORLD_W + x] === MATERIAL_INDEX.dirt) {
+          foundDirt = true
+        }
+      }
+    }
+    expect(foundDirt).toBe(false)
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -588,6 +588,7 @@ export function sanitizeBlueprint(
     disruptivePattern: b.disruptivePattern === true,
     clearingMaintainer: b.clearingMaintainer === true,
     eyespots: b.eyespots === true,
+    rootBankStabilizer: b.rootBankStabilizer === true,
     traitDefaults:
       b.traitDefaults && typeof b.traitDefaults === 'object'
         ? {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -107,6 +107,13 @@ const BITE_PAD = 0.5
 const SOIL_ENRICH_PROB = 0.002
 
 /**
+ * Probability per tick per adjacent tile that a root-bank-stabilizing plant
+ * binds a loose sand tile into dirt. At 60Hz and a 5-tile sweep this gives
+ * ~18% per second per tile — fast enough to be visible in tests within 60 s.
+ */
+const ROOT_STABILIZE_PROB = 0.0005
+
+/**
  * Within this many tiles, disruptive patterns give no detection benefit —
  * the outline is legible at close range regardless of the pattern.
  */
@@ -857,6 +864,21 @@ export function tickCreatures(
       const scy = Math.floor(c.y + body.dy + body.h)
       if (tileAt(w, scx, scy) === MATERIAL_INDEX.dirt && Math.random() < SOIL_ENRICH_PROB) {
         setTile(w, scx, scy, MATERIAL_INDEX.mud)
+      }
+    }
+
+    // Root bank stabilization: riparian plants bind loose soil by slowly
+    // converting adjacent sand tiles into stable dirt within their root zone.
+    // Models willows and alders locking in riverbank soil with their roots.
+    // Works only for rooted plants — walkers don't hold soil in place.
+    if (bp.rootBankStabilizer && bp.move.kind === 'root') {
+      const rx = Math.floor(c.x + body.dx + body.w / 2)
+      const ry = Math.floor(c.y + body.dy + body.h)
+      for (let dx = -2; dx <= 2; dx++) {
+        const tx = wrapX(rx + dx)
+        if (tileAt(w, tx, ry) === MATERIAL_INDEX.sand && Math.random() < ROOT_STABILIZE_PROB) {
+          setTile(w, tx, ry, MATERIAL_INDEX.dirt)
+        }
       }
     }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -350,6 +350,16 @@ export interface CreatureBlueprint {
    * Models the real-world bite marks found on butterfly wings at eyespot locations.
    */
   eyespots?: boolean
+  /**
+   * Rooted plants that physically bind loose soil with their root systems,
+   * preventing erosion of the substrate they are anchored in.
+   *
+   * Each tick, the plant has a small chance to convert adjacent sand tiles
+   * (within 2 tiles horizontally) into stable dirt — modelling the way riparian
+   * trees lock in riverbank soil and prevent slumping. Only applies to
+   * `move.kind === 'root'` creatures. Models willows, alders, mangroves.
+   */
+  rootBankStabilizer?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `rootBankStabilizer?: boolean` to `CreatureBlueprint` (types.ts, blueprint.ts)
- Rooted plants with this flag slowly convert adjacent sand tiles (within ±2 horizontal tiles at root level) to dirt each tick
- Models willows, alders, and mangroves binding riverbank soil with their root systems
- Only applies to `move.kind === 'root'` creatures — walkers cannot hold soil in place
- `ROOT_STABILIZE_PROB = 0.0005/tick` per tile

Closes #3450

## Test plan

- [x] `root-bank-stabilizer.test.ts` — 4 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)