### PR TITLE
feat(micro-land): carnivorous plants colonize nutrient-poor substrate (#3442)

### DIFF
--- a/src/app/micro-land/domain/__tests__/carnivorous-plant.test.ts
+++ b/src/app/micro-land/domain/__tests__/carnivorous-plant.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Carnivorous plant — nutrient-poor habitat specialization.
+ *
+ * Carnivorous plants invert the standard fertility curve: they breed *faster* on
+ * nutrient-poor substrates (stone, sand, ash) and slower on rich soil, giving them
+ * an ecological niche on barren ground that normal plants cannot exploit.
+ *
+ * Breed-cooldown formula: normal → fertilityAt; carnivorous → max(0.1, 2−fertilityAt).
+ *   sand fertility=0.5  → normal factor 0.5, carnivorous 1.5  → carnivorous 3× faster
+ *   mud  fertility=1.3  → normal factor 1.3, carnivorous 0.7  → normal 1.86× faster
+ *
+ * Tests cover:
+ *   1. `sanitizeBlueprint` preserves `carnivorousPlant: true`.
+ *   2. On sand, a carnivorous plant produces significantly more offspring than a
+ *      normal plant in the same time window.
+ *   3. On mud, a carnivorous plant produces fewer offspring than a normal plant
+ *      (inverted curve — rich soil is a disadvantage).
+ *   4. Non-carnivorous plant is unaffected (carnivorousPlant: false uses standard formula).
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import type { SimEvent } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import { lifespanOf } from '@/app/micro-land/domain/traits'
+import { TUNING } from '@/app/micro-land/domain/tuning'
+import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFloor(matIndex: number): WorldState {
+  const w = createWorld(1234)
+  for (let y = WORLD_H - 12; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = matIndex
+  }
+  w.dormant = true
+  // Avoid disease-at-t=0 glitch (same pattern as cryptic-coloration tests).
+  w.elapsed = 1
+  return w
+}
+
+function sandWorld(): WorldState {
+  return makeFloor(MATERIAL_INDEX.sand)
+}
+
+function mudWorld(): WorldState {
+  return makeFloor(MATERIAL_INDEX.mud)
+}
+
+/** A rooted plant with long lifespan so it won't die during tests. */
+function plantBp(extra: Record<string, unknown> = {}): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: 'TestPlant',
+      tags: ['plant'],
+      art: {
+        palette: { a: '#44aa44' },
+        frames: [['aaa', 'aaa', 'aaa']],
+        frameMs: 400,
+        faceMotion: false,
+      },
+      move: { kind: 'root' },
+      diet: { eats: [], hungerRate: 0, breedAt: 0.2, lifespanSeconds: 900 },
+      senses: { sight: 0 },
+      ...extra,
+    },
+    { summoned: true }
+  )
+}
+
+/** Force a creature to adult+ready state so it breeds immediately. */
+function makeReady(c: Creature, bp: CreatureBlueprint): Creature {
+  c.hunger = 0
+  c.ageSeconds = lifespanOf(c, bp) * TUNING.lifespanScale * 0.3
+  c.breedCooldown = 0
+  return c
+}
+
+/**
+ * Run `seconds` of simulation and return birth-event count for the given
+ * blueprint id. Using birth events rather than creature count isolates breeding
+ * from natural death (the parent might die mid-test otherwise).
+ */
+function countBirths(w: WorldState, bpId: string, seconds: number): number {
+  const rng = makeRng(42)
+  const events: SimEvent[] = []
+  for (let i = 0; i < seconds * 60; i++) tickCreatures(w, 1 / 60, rng, 1, events)
+  return events.filter(e => e.kind === 'born' && e.blueprintId === bpId).length
+}
+
+// ---------------------------------------------------------------------------
+// 1. Flag preservation
+// ---------------------------------------------------------------------------
+
+describe('carnivorousPlant flag', () => {
+  it('sanitizeBlueprint preserves carnivorousPlant: true', () => {
+    const bp = plantBp({ carnivorousPlant: true })
+    expect(bp.carnivorousPlant).toBe(true)
+  })
+
+  it('sanitizeBlueprint normalises carnivorousPlant: false', () => {
+    const bp = plantBp({ carnivorousPlant: false })
+    expect(bp.carnivorousPlant).toBe(false)
+  })
+
+  it('sanitizeBlueprint defaults carnivorousPlant to false when absent', () => {
+    const bp = plantBp()
+    expect(bp.carnivorousPlant).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2–3. Breed-rate inversion on different substrates
+//
+// On sand (fertility=0.5): carnivorous factor=1.5 vs normal 0.5 → 3× faster.
+// On mud  (fertility=1.3): carnivorous factor=0.7 vs normal 1.3 → 1.86× slower.
+//
+// We run 60 s (3600 ticks) and compare birth counts. The ratio is large enough
+// that even with RNG variance the ordering should be unambiguous.
+// ---------------------------------------------------------------------------
+
+describe('breed-rate inversion', () => {
+  it('carnivorous plant breeds faster on sand (poor soil) than a normal plant', () => {
+    const carnivorous = plantBp({ carnivorousPlant: true })
+    const normal = plantBp({ name: 'NormalPlant' })
+
+    // Carnivorous plant on sand
+    const wC = sandWorld()
+    registerBlueprint(wC, carnivorous)
+    const cC = spawnCreature(wC, carnivorous, 40, WORLD_H - 15)!
+    makeReady(cC, carnivorous)
+    const bornCarnivorous = countBirths(wC, carnivorous.id, 60)
+
+    // Normal plant on sand
+    const wN = sandWorld()
+    registerBlueprint(wN, normal)
+    const cN = spawnCreature(wN, normal, 40, WORLD_H - 15)!
+    makeReady(cN, normal)
+    const bornNormal = countBirths(wN, normal.id, 60)
+
+    // Carnivorous should produce substantially more offspring on poor soil.
+    // The formula predicts ~3× ratio; we conservatively require carnivorous > normal.
+    expect(bornCarnivorous).toBeGreaterThan(bornNormal)
+  })
+
+  it('carnivorous plant breeds slower on mud (rich soil) than a normal plant', () => {
+    const carnivorous = plantBp({ carnivorousPlant: true })
+    const normal = plantBp({ name: 'NormalPlant' })
+
+    // Carnivorous plant on mud
+    const wC = mudWorld()
+    registerBlueprint(wC, carnivorous)
+    const cC = spawnCreature(wC, carnivorous, 40, WORLD_H - 15)!
+    makeReady(cC, carnivorous)
+    const bornCarnivorous = countBirths(wC, carnivorous.id, 60)
+
+    // Normal plant on mud
+    const wN = mudWorld()
+    registerBlueprint(wN, normal)
+    const cN = spawnCreature(wN, normal, 40, WORLD_H - 15)!
+    makeReady(cN, normal)
+    const bornNormal = countBirths(wN, normal.id, 60)
+
+    // On rich mud, normal plant should out-breed the carnivorous one.
+    expect(bornNormal).toBeGreaterThan(bornCarnivorous)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. Non-carnivorous plant unaffected
+// ---------------------------------------------------------------------------
+
+describe('non-carnivorous plant is unaffected', () => {
+  it('plant with carnivorousPlant: false uses standard fertility on sand', () => {
+    // carnivorousPlant: false should behave identically to the default.
+    const withFlagFalse = plantBp({ carnivorousPlant: false })
+    const withoutFlag = plantBp({ name: 'NoFlag' })
+
+    const w1 = sandWorld()
+    registerBlueprint(w1, withFlagFalse)
+    const c1 = spawnCreature(w1, withFlagFalse, 40, WORLD_H - 15)!
+    makeReady(c1, withFlagFalse)
+    const born1 = countBirths(w1, withFlagFalse.id, 60)
+
+    const w2 = sandWorld()
+    registerBlueprint(w2, withoutFlag)
+    const c2 = spawnCreature(w2, withoutFlag, 40, WORLD_H - 15)!
+    makeReady(c2, withoutFlag)
+    const born2 = countBirths(w2, withoutFlag.id, 60)
+
+    // Both should produce similar birth counts (within ±2 to allow RNG variation).
+    expect(Math.abs(born1 - born2)).toBeLessThanOrEqual(2)
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -591,6 +591,7 @@ export function sanitizeBlueprint(
     countershaded: b.countershaded === true,
     bioturbator: b.bioturbator === true,
     rootBankStabilizer: b.rootBankStabilizer === true,
+    carnivorousPlant: b.carnivorousPlant === true,
     traitDefaults:
       b.traitDefaults && typeof b.traitDefaults === 'object'
         ? {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1019,10 +1019,22 @@ export function tickCreatures(
               }
               const crowdingPenalty = 1 + crowdCount * TUNING.plantCrowdingStrength
 
+              // Soil fertility scales breed cooldown inversely: richer soil →
+              // shorter wait. The foot tile (one row below the body) is the
+              // substrate the plant is actually rooted in; the body centre is
+              // in the air above it and always returns the default 'dirt' value.
+              const footX = Math.floor(c.x + body.dx + body.w / 2)
+              const footY = Math.floor(c.y + body.dy + body.h)
+              // Carnivorous plants invert the fertility curve: they breed faster
+              // on nutrient-poor tiles (stone, sand, ash) and slower on rich
+              // soil, out-competing normal flora on barren ground.
+              const plantFertilityFactor = bp.carnivorousPlant
+                ? Math.max(0.1, 2.0 - fertilityAt(w, footX, footY))
+                : fertilityAt(w, footX, footY)
               c.breedCooldown =
                 (TUNING.plantSpreadCooldown * crowdingPenalty) /
                 (auraBoost(w, c, bp, bw, bh, helpers) *
-                  fertilityAt(w, c.x + bw / 2, c.y + bh / 2) *
+                  plantFertilityFactor *
                   seasonFactor)
             } else {
               // Both of them paid to be here, so both of them pay for it. Charging
@@ -2581,7 +2593,7 @@ function reproduce(
       // picked. Same trap as spawning: the tile under a box is
       // `floor(y + bh - 0.001) + 1`, so `settleOnGround` owns that arithmetic.
       const settled = settleOnGround(w, cx + body.dx, cy + body.dy, body.w, body.h, {
-        requireFertile: true,
+        requireFertile: !bp.carnivorousPlant,
         maxDrop: 10,
       })
       if (settled === null) continue

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -380,6 +380,22 @@ export interface CreatureBlueprint {
    * `move.kind === 'root'` creatures. Models willows, alders, mangroves.
    */
   rootBankStabilizer?: boolean
+  /**
+   * Plants that supplement nutrient-poor substrate by trapping and digesting prey.
+   *
+   * Inverts the fertility curve: carnivorous plants breed *faster* on low-fertility
+   * tiles (stone, sand, ash) and slower on rich soil, out-competing normal flora on
+   * barren ground. They may also root on stone — normally infertile for plants.
+   *
+   * Breed cooldown uses `max(0.1, 2.0 − fertilityAt)` instead of `fertilityAt`:
+   *   stone (f=0.3) → factor 1.7 → ~5.7× faster than normal plants
+   *   sand  (f=0.5) → factor 1.5 → 3×
+   *   dirt  (f=1.0) → factor 1.0 → neutral
+   *   mud   (f=1.3) → factor 0.7 → slower, outcompeted by normal plants
+   *
+   * Models sundews, pitcher plants, butterworts on acidic bogs and volcanic rock.
+   */
+  carnivorousPlant?: boolean
 }
 
 /**


### PR DESCRIPTION
Closes #3442

Rebased on main after riparian stabilization (#3631) merge.

## Summary
- Adds `carnivorousPlant?: boolean` to `CreatureBlueprint`
- Inverts the fertility curve for breed cooldown: `max(0.1, 2.0 − fertilityAt)` instead of `fertilityAt`
  - Stone (f=0.3) → factor 1.7 → ~5.7× faster than normal plants
  - Sand (f=0.5) → factor 1.5 → 3× faster
  - Dirt (f=1.0) → neutral
  - Mud (f=1.3) → factor 0.7 → ~1.9× slower (outcompeted by normal flora)
- Offspring skip the fertile-ground requirement (`requireFertile: !bp.carnivorousPlant`), allowing seedlings to root on stone
- Models sundews, pitcher plants, butterworts on acidic bogs and volcanic rock

**Also fixes a latent bug**: `fertilityAt` was previously read at the body centre (air above the floor), always returning the 'dirt' default (1.0). Now reads the foot tile, the tile the plant actually stands on.

## Test plan
- [x] `sanitizeBlueprint` preserves `carnivorousPlant: true / false / absent`
- [x] On sand, carnivorous plant produces more offspring than normal plant in 60s
- [x] On mud, carnivorous plant produces fewer offspring than normal plant in 60s
- [x] `carnivorousPlant: false` is identical to the default (within RNG variance)
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)