### PR TITLE
feat(micro-land): slow metabolism — extreme K-strategist survival adaptation (#3436)

### DIFF
--- a/src/app/micro-land/domain/__tests__/slow-metabolism.test.ts
+++ b/src/app/micro-land/domain/__tests__/slow-metabolism.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Slow metabolism — extreme K-strategist survival adaptation.
+ *
+ * Creatures with slowMetabolism: true burn energy at 10% of normal rate
+ * (metabolicRate multiplier = 0.1). This lets cave-adapted species survive
+ * in nutrient-scarce environments.
+ *
+ * Tests cover:
+ *   1. sanitizeBlueprint preserves slowMetabolism: true/false/absent.
+ *   2. A slow-metabolism creature starves much more slowly than a normal one.
+ *   3. A slow-metabolism creature is not yet dead after N seconds where the
+ *      normal creature has starved.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+// ---------------------------------------------------------------------------
+// 1. Blueprint flag tests
+// ---------------------------------------------------------------------------
+
+describe('slowMetabolism — sanitizeBlueprint', () => {
+  const base = {
+    name: 'CaveOlm',
+    tags: ['meat'] as const,
+    art: {
+      palette: { a: '#ffffff' },
+      frames: [['aaa', 'aaa', 'aaa']],
+      frameMs: 200,
+      faceMotion: false,
+    },
+    move: { kind: 'walk' as const, speed: 0 },
+    diet: { eats: [] as const, hungerRate: 0.02, lifespanSeconds: 900 },
+    senses: { sight: 4 },
+  }
+
+  it('preserves slowMetabolism: true', () => {
+    const bp = sanitizeBlueprint({ ...base, slowMetabolism: true }, { summoned: true })
+    expect(bp.slowMetabolism).toBe(true)
+  })
+
+  it('preserves slowMetabolism: false', () => {
+    const bp = sanitizeBlueprint({ ...base, slowMetabolism: false }, { summoned: true })
+    expect(bp.slowMetabolism).toBe(false)
+  })
+
+  it('defaults slowMetabolism to false when absent', () => {
+    const bp = sanitizeBlueprint(base, { summoned: true })
+    expect(bp.slowMetabolism).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2–3. Simulation tests
+// ---------------------------------------------------------------------------
+
+/** A stone world so creatures can stand on something. */
+function stoneWorld() {
+  const w = createWorld(42)
+  for (let y = WORLD_H - 4; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.stone
+  }
+  w.dormant = true
+  w.elapsed = 1
+  return w
+}
+
+function creatureBp(slowMetabolism: boolean): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: slowMetabolism ? 'CaveOlm' : 'Surface',
+      tags: ['meat'],
+      art: {
+        palette: { a: '#cccccc' },
+        frames: [['aaa', 'aaa', 'aaa']],
+        frameMs: 200,
+        faceMotion: false,
+      },
+      move: { kind: 'walk', speed: 0 },
+      // Effective hunger rate = hungerRate × HUNGER_RATE_SCALE (0.1)
+      // hungerRate=0.2 → effective 0.02/s → normal creature hits hunger=1 in ~50s
+      // slow-metabolism applies ×0.1 → effective 0.002/s → hits hunger=1 in ~500s
+      diet: { eats: [], hungerRate: 0.2, starveSeconds: 3, lifespanSeconds: 900 },
+      senses: { sight: 1 },
+      slowMetabolism,
+    },
+    { summoned: true }
+  )
+}
+
+describe('slowMetabolism — simulation', () => {
+  it('slow-metabolism creature accumulates hunger 10× slower than normal', () => {
+    const wNormal = stoneWorld()
+    const wSlow = stoneWorld()
+
+    const bpNormal = creatureBp(false)
+    const bpSlow = creatureBp(true)
+
+    registerBlueprint(wNormal, bpNormal)
+    registerBlueprint(wSlow, bpSlow)
+
+    const py = WORLD_H - 7
+    spawnCreature(wNormal, bpNormal, 80, py)
+    spawnCreature(wSlow, bpSlow, 80, py)
+
+    const cNormal = wNormal.creatures[0]!
+    const cSlow = wSlow.creatures[0]!
+
+    // Both start fully fed
+    cNormal.hunger = 0
+    cSlow.hunger = 0
+
+    const rng = makeRng(1)
+    // Run 30 s (1800 ticks at 60 Hz)
+    for (let i = 0; i < 1800; i++) {
+      tickCreatures(wNormal, 1 / 60, rng, 1, [])
+      tickCreatures(wSlow, 1 / 60, rng, 1, [])
+    }
+
+    // Normal creature should be quite hungry after 30 s (hungerRate=0.02 × 30=0.6)
+    expect(cNormal.hunger).toBeGreaterThan(0.4)
+
+    // Slow-metabolism creature should be ~10× less hungry
+    expect(cSlow.hunger).toBeLessThan(cNormal.hunger / 5)
+  })
+
+  it('normal creature starves but slow-metabolism creature survives the same period', { timeout: 15000 }, () => {
+    // Run 65 s. The normal creature reaches hunger=1 (around ~50-60 s depending
+    // on rest cycles) and, with starveSeconds=3, dies before 65 s. The
+    // slow-metabolism creature (×0.1 rate) won't reach hunger=1 in this window.
+    const wNormal = stoneWorld()
+    const wSlow = stoneWorld()
+
+    const bpNormal = creatureBp(false)
+    const bpSlow = creatureBp(true)
+
+    registerBlueprint(wNormal, bpNormal)
+    registerBlueprint(wSlow, bpSlow)
+
+    const py = WORLD_H - 7
+    spawnCreature(wNormal, bpNormal, 80, py)
+    spawnCreature(wSlow, bpSlow, 80, py)
+
+    wNormal.creatures[0]!.hunger = 0
+    wSlow.creatures[0]!.hunger = 0
+
+    const rng = makeRng(1)
+    // 65 s × 60 ticks/s = 3900 ticks
+    for (let i = 0; i < 3900; i++) {
+      tickCreatures(wNormal, 1 / 60, rng, 1, [])
+      tickCreatures(wSlow, 1 / 60, rng, 1, [])
+    }
+
+    // Normal creature should have starved (removed from world)
+    const normalAlive = wNormal.creatures.find(c => c.blueprintId === bpNormal.id)
+    expect(normalAlive).toBeUndefined()
+
+    // Slow-metabolism creature should still be alive
+    const slowAlive = wSlow.creatures.find(c => c.blueprintId === bpSlow.id)
+    expect(slowAlive).toBeDefined()
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -593,6 +593,7 @@ export function sanitizeBlueprint(
     rootBankStabilizer: b.rootBankStabilizer === true,
     polluter: b.polluter === true,
     carnivorousPlant: b.carnivorousPlant === true,
+    slowMetabolism: b.slowMetabolism === true,
     traitDefaults:
       b.traitDefaults && typeof b.traitDefaults === 'object'
         ? {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -644,9 +644,10 @@ export function tickCreatures(
     const restSlowdown = c.mood === 'rest' ? 0.5 : 1
 
     const symbiosisFed = c.symbiosisTimer > 0 ? 0.8 : 1
+    const metabolicRate = bp.slowMetabolism ? 0.1 : 1
     c.hunger = Math.min(
       1,
-      c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * symbiosisFed * dt
+      c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * symbiosisFed * metabolicRate * dt
     )
     if (c.hunger >= 1) {
       c.starving += dt
@@ -989,7 +990,8 @@ export function tickCreatures(
           speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + 1
           c.breedCooldown =
             TUNING.breedCooldown *
-            ((c.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1)
+            ((c.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1) *
+            (bp.slowMetabolism ? 2 : 1)
           payForChild(w, c, bp, bw, bh, helpers)
           if (mate) {
             mate.children++
@@ -1898,7 +1900,8 @@ function payForChild(
   parent.hunger = Math.min(1, parent.hunger + TUNING.breedCost)
   parent.breedCooldown =
     (TUNING.breedCooldown *
-      ((parent.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1)) /
+      ((parent.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1) *
+      (bp.slowMetabolism ? 2 : 1)) /
     auraBoost(w, parent, bp, bw, bh, helpers)
   if (parent.mood === 'mate') {
     parent.mood = 'wander'

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -408,6 +408,16 @@ export interface CreatureBlueprint {
    * Models sundews, pitcher plants, butterworts on acidic bogs and volcanic rock.
    */
   carnivorousPlant?: boolean
+  /**
+   * Drastically reduced basal metabolic rate — inspired by cave-adapted
+   * species (cave olm, cave fish) that can survive months without food.
+   *
+   * When true, the hunger increment is multiplied by 0.1, making the creature
+   * burn energy at 10% of the normal rate. Reproduction rate is also halved
+   * (these are extreme K-strategists). No special tile requirement — the flag
+   * applies anywhere, but it is most meaningful in nutrient-scarce environments.
+   */
+  slowMetabolism?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `slowMetabolism` blueprint flag (types.ts, blueprint.ts)
- When `true`, hunger increments at 10% of normal rate (`metabolicRate = 0.1`)
- Breed cooldown is doubled — these are extreme K-strategists with slow reproduction
- Biome-agnostic: works anywhere, most meaningful once cave tiles are introduced

## Motivation (issue #3436)
Cave-adapted species like the olm (*Proteus anguinus*) can survive 10+ years without food. Implemented as a general metabolic modifier rather than a cave-specific flag so it's testable now and composable with future cave biome work.

## Test plan
- [x] Flag preservation: `sanitizeBlueprint` propagates `slowMetabolism: true/false/absent`
- [x] Hunger rate: slow-metabolism creature accumulates hunger 10× slower over 30 s
- [x] Survival: normal creature starves in ~55 s; slow-metabolism creature is still alive

Closes #3436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)