### PR TITLE
feat(micro-land): invasive species enemy release effect (#3363)

### DIFF
--- a/src/app/micro-land/domain/__tests__/invasive-species.test.ts
+++ b/src/app/micro-land/domain/__tests__/invasive-species.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Invasive species — enemy release effect.
+ *
+ * Invasive species with invasive: true breed faster (cooldown × 0.67) and
+ * are more resistant to disease (effective immunity +0.56 above baseline).
+ *
+ * Tests cover:
+ *   1. sanitizeBlueprint preserves invasive: true/false/absent.
+ *   2. Invasive species produce more offspring than non-invasive over N seconds.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import type { SimEvent } from '@/app/micro-land/domain/sim/creature-sim'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import { lifespanOf } from '@/app/micro-land/domain/traits'
+import { TUNING } from '@/app/micro-land/domain/tuning'
+import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+// ---------------------------------------------------------------------------
+// 1. Blueprint flag tests
+// ---------------------------------------------------------------------------
+
+describe('invasive — sanitizeBlueprint', () => {
+  const base = {
+    name: 'Invader',
+    tags: ['meat'] as const,
+    art: {
+      palette: { a: '#ff6600' },
+      frames: [['aaa', 'aaa', 'aaa']],
+      frameMs: 200,
+      faceMotion: false,
+    },
+    move: { kind: 'walk' as const, speed: 0 },
+    diet: { eats: [] as const, hungerRate: 0.01, lifespanSeconds: 900 },
+    senses: { sight: 4 },
+  }
+
+  it('preserves invasive: true', () => {
+    const bp = sanitizeBlueprint({ ...base, invasive: true }, { summoned: true })
+    expect(bp.invasive).toBe(true)
+  })
+
+  it('preserves invasive: false', () => {
+    const bp = sanitizeBlueprint({ ...base, invasive: false }, { summoned: true })
+    expect(bp.invasive).toBe(false)
+  })
+
+  it('defaults invasive to false when absent', () => {
+    const bp = sanitizeBlueprint(base, { summoned: true })
+    expect(bp.invasive).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function flatWorld(): WorldState {
+  const w = createWorld(99)
+  for (let y = WORLD_H - 4; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.dirt
+  }
+  w.dormant = true
+  w.elapsed = 1 // avoid t=0 disease outbreak trigger
+  return w
+}
+
+/**
+ * A rooted plant blueprint — plants breed alone (no partner needed), so the
+ * only variable between runs is the cooldown. hungerRate=0 means hunger never
+ * accumulates, so breedCost doesn't cap births.
+ */
+function invasivePlant(invasive: boolean): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: invasive ? 'InvasiveMoss' : 'NativeMoss',
+      tags: ['plant'],
+      art: {
+        palette: { a: '#44aa44' },
+        frames: [['aaa', 'aaa', 'aaa']],
+        frameMs: 200,
+        faceMotion: false,
+      },
+      move: { kind: 'root', speed: 0 },
+      diet: {
+        eats: [],
+        hungerRate: 0,
+        lifespanSeconds: 900,
+        breedAt: 0.1,
+      },
+      senses: { sight: 4 },
+      invasive,
+    },
+    { summoned: true }
+  )
+}
+
+/** Set a creature to full adult readiness: well-fed, mature, off cooldown. */
+function readyAdult(c: Creature, bp: CreatureBlueprint): Creature {
+  c.hunger = 0
+  c.ageSeconds = lifespanOf(c, bp) * TUNING.lifespanScale * 0.3
+  c.breedCooldown = 0
+  return c
+}
+
+// ---------------------------------------------------------------------------
+// 2. Invasive breeds faster
+//
+// Using rooted plants: they breed alone, have zero hunger rate (so breedCost
+// does not accumulate to block further breeding), and their offspring spread
+// across the world. The 0.67× cooldown multiplier creates a measurable birth
+// count difference over 60 seconds.
+// ---------------------------------------------------------------------------
+
+describe('invasive — faster reproduction', () => {
+  it('invasive plant produces more births than non-invasive over 60 s', () => {
+    const wInvasive = flatWorld()
+    const wNative = flatWorld()
+
+    const bpInvasive = invasivePlant(true)
+    const bpNative = invasivePlant(false)
+
+    registerBlueprint(wInvasive, bpInvasive)
+    registerBlueprint(wNative, bpNative)
+
+    // One plant each, ready to spread
+    const c1 = spawnCreature(wInvasive, bpInvasive, 80, WORLD_H - 5)!
+    const c2 = spawnCreature(wNative, bpNative, 80, WORLD_H - 5)!
+    readyAdult(c1, bpInvasive)
+    readyAdult(c2, bpNative)
+
+    const rng = makeRng(7)
+    const eventsInvasive: SimEvent[] = []
+    const eventsNative: SimEvent[] = []
+
+    // 60 s at 60 Hz
+    for (let i = 0; i < 3600; i++) {
+      tickCreatures(wInvasive, 1 / 60, rng, 1, eventsInvasive)
+      tickCreatures(wNative, 1 / 60, rng, 1, eventsNative)
+    }
+
+    const invasiveBirths = eventsInvasive.filter(e => e.kind === 'born' && e.blueprintId === bpInvasive.id).length
+    const nativeBirths = eventsNative.filter(e => e.kind === 'born' && e.blueprintId === bpNative.id).length
+
+    // Invasive should breed noticeably faster due to 0.67x cooldown multiplier
+    expect(invasiveBirths).toBeGreaterThan(nativeBirths)
+  })
+})

--- a/src/app/micro-land/domain/__tests__/slow-metabolism.test.ts
+++ b/src/app/micro-land/domain/__tests__/slow-metabolism.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Slow metabolism — extreme K-strategist survival adaptation.
+ *
+ * Creatures with slowMetabolism: true burn energy at 10% of normal rate
+ * (metabolicRate multiplier = 0.1). This lets cave-adapted species survive
+ * in nutrient-scarce environments.
+ *
+ * Tests cover:
+ *   1. sanitizeBlueprint preserves slowMetabolism: true/false/absent.
+ *   2. A slow-metabolism creature starves much more slowly than a normal one.
+ *   3. A slow-metabolism creature is not yet dead after N seconds where the
+ *      normal creature has starved.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+// ---------------------------------------------------------------------------
+// 1. Blueprint flag tests
+// ---------------------------------------------------------------------------
+
+describe('slowMetabolism — sanitizeBlueprint', () => {
+  const base = {
+    name: 'CaveOlm',
+    tags: ['meat'] as const,
+    art: {
+      palette: { a: '#ffffff' },
+      frames: [['aaa', 'aaa', 'aaa']],
+      frameMs: 200,
+      faceMotion: false,
+    },
+    move: { kind: 'walk' as const, speed: 0 },
+    diet: { eats: [] as const, hungerRate: 0.02, lifespanSeconds: 900 },
+    senses: { sight: 4 },
+  }
+
+  it('preserves slowMetabolism: true', () => {
+    const bp = sanitizeBlueprint({ ...base, slowMetabolism: true }, { summoned: true })
+    expect(bp.slowMetabolism).toBe(true)
+  })
+
+  it('preserves slowMetabolism: false', () => {
+    const bp = sanitizeBlueprint({ ...base, slowMetabolism: false }, { summoned: true })
+    expect(bp.slowMetabolism).toBe(false)
+  })
+
+  it('defaults slowMetabolism to false when absent', () => {
+    const bp = sanitizeBlueprint(base, { summoned: true })
+    expect(bp.slowMetabolism).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2–3. Simulation tests
+// ---------------------------------------------------------------------------
+
+/** A stone world so creatures can stand on something. */
+function stoneWorld() {
+  const w = createWorld(42)
+  for (let y = WORLD_H - 4; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.stone
+  }
+  w.dormant = true
+  w.elapsed = 1
+  return w
+}
+
+function creatureBp(slowMetabolism: boolean): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: slowMetabolism ? 'CaveOlm' : 'Surface',
+      tags: ['meat'],
+      art: {
+        palette: { a: '#cccccc' },
+        frames: [['aaa', 'aaa', 'aaa']],
+        frameMs: 200,
+        faceMotion: false,
+      },
+      move: { kind: 'walk', speed: 0 },
+      // Effective hunger rate = hungerRate × HUNGER_RATE_SCALE (0.1)
+      // hungerRate=0.2 → effective 0.02/s → normal creature hits hunger=1 in ~50s
+      // slow-metabolism applies ×0.1 → effective 0.002/s → hits hunger=1 in ~500s
+      diet: { eats: [], hungerRate: 0.2, starveSeconds: 3, lifespanSeconds: 900 },
+      senses: { sight: 1 },
+      slowMetabolism,
+    },
+    { summoned: true }
+  )
+}
+
+describe('slowMetabolism — simulation', () => {
+  it('slow-metabolism creature accumulates hunger 10× slower than normal', () => {
+    const wNormal = stoneWorld()
+    const wSlow = stoneWorld()
+
+    const bpNormal = creatureBp(false)
+    const bpSlow = creatureBp(true)
+
+    registerBlueprint(wNormal, bpNormal)
+    registerBlueprint(wSlow, bpSlow)
+
+    const py = WORLD_H - 7
+    spawnCreature(wNormal, bpNormal, 80, py)
+    spawnCreature(wSlow, bpSlow, 80, py)
+
+    const cNormal = wNormal.creatures[0]!
+    const cSlow = wSlow.creatures[0]!
+
+    // Both start fully fed
+    cNormal.hunger = 0
+    cSlow.hunger = 0
+
+    const rng = makeRng(1)
+    // Run 30 s (1800 ticks at 60 Hz)
+    for (let i = 0; i < 1800; i++) {
+      tickCreatures(wNormal, 1 / 60, rng, 1, [])
+      tickCreatures(wSlow, 1 / 60, rng, 1, [])
+    }
+
+    // Normal creature should be quite hungry after 30 s (hungerRate=0.02 × 30=0.6)
+    expect(cNormal.hunger).toBeGreaterThan(0.4)
+
+    // Slow-metabolism creature should be ~10× less hungry
+    expect(cSlow.hunger).toBeLessThan(cNormal.hunger / 5)
+  })
+
+  it('normal creature starves but slow-metabolism creature survives the same period', { timeout: 15000 }, () => {
+    // Run 65 s. The normal creature reaches hunger=1 (around ~50-60 s depending
+    // on rest cycles) and, with starveSeconds=3, dies before 65 s. The
+    // slow-metabolism creature (×0.1 rate) won't reach hunger=1 in this window.
+    const wNormal = stoneWorld()
+    const wSlow = stoneWorld()
+
+    const bpNormal = creatureBp(false)
+    const bpSlow = creatureBp(true)
+
+    registerBlueprint(wNormal, bpNormal)
+    registerBlueprint(wSlow, bpSlow)
+
+    const py = WORLD_H - 7
+    spawnCreature(wNormal, bpNormal, 80, py)
+    spawnCreature(wSlow, bpSlow, 80, py)
+
+    wNormal.creatures[0]!.hunger = 0
+    wSlow.creatures[0]!.hunger = 0
+
+    const rng = makeRng(1)
+    // 65 s × 60 ticks/s = 3900 ticks
+    for (let i = 0; i < 3900; i++) {
+      tickCreatures(wNormal, 1 / 60, rng, 1, [])
+      tickCreatures(wSlow, 1 / 60, rng, 1, [])
+    }
+
+    // Normal creature should have starved (removed from world)
+    const normalAlive = wNormal.creatures.find(c => c.blueprintId === bpNormal.id)
+    expect(normalAlive).toBeUndefined()
+
+    // Slow-metabolism creature should still be alive
+    const slowAlive = wSlow.creatures.find(c => c.blueprintId === bpSlow.id)
+    expect(slowAlive).toBeDefined()
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -594,6 +594,7 @@ export function sanitizeBlueprint(
     polluter: b.polluter === true,
     carnivorousPlant: b.carnivorousPlant === true,
     slowMetabolism: b.slowMetabolism === true,
+    invasive: b.invasive === true,
     traitDefaults:
       b.traitDefaults && typeof b.traitDefaults === 'object'
         ? {

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -593,6 +593,7 @@ export function sanitizeBlueprint(
     rootBankStabilizer: b.rootBankStabilizer === true,
     polluter: b.polluter === true,
     carnivorousPlant: b.carnivorousPlant === true,
+    slowMetabolism: b.slowMetabolism === true,
     traitDefaults:
       b.traitDefaults && typeof b.traitDefaults === 'object'
         ? {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -644,9 +644,10 @@ export function tickCreatures(
     const restSlowdown = c.mood === 'rest' ? 0.5 : 1
 
     const symbiosisFed = c.symbiosisTimer > 0 ? 0.8 : 1
+    const metabolicRate = bp.slowMetabolism ? 0.1 : 1
     c.hunger = Math.min(
       1,
-      c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * symbiosisFed * dt
+      c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * symbiosisFed * metabolicRate * dt
     )
     if (c.hunger >= 1) {
       c.starving += dt
@@ -989,7 +990,8 @@ export function tickCreatures(
           speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + 1
           c.breedCooldown =
             TUNING.breedCooldown *
-            ((c.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1)
+            ((c.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1) *
+            (bp.slowMetabolism ? 2 : 1)
           payForChild(w, c, bp, bw, bh, helpers)
           if (mate) {
             mate.children++
@@ -1898,7 +1900,8 @@ function payForChild(
   parent.hunger = Math.min(1, parent.hunger + TUNING.breedCost)
   parent.breedCooldown =
     (TUNING.breedCooldown *
-      ((parent.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1)) /
+      ((parent.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1) *
+      (bp.slowMetabolism ? 2 : 1)) /
     auraBoost(w, parent, bp, bw, bh, helpers)
   if (parent.mood === 'mate') {
     parent.mood = 'wander'

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -610,7 +610,8 @@ export function tickCreatures(
       c.sick -= dt
       if (c.sick <= 0) {
         c.sick = 0
-        const immunity = (c.traits as { immunity?: number }).immunity ?? 0.2
+        const rawImmunity = (c.traits as { immunity?: number }).immunity ?? 0.2
+        const immunity = bp.invasive ? Math.min(1, rawImmunity + 0.56) : rawImmunity
         if (rng() >= immunity * 0.8 + 0.2) {
           kill(w, c, bp, dead, events, 'diseased')
           continue
@@ -991,7 +992,8 @@ export function tickCreatures(
           c.breedCooldown =
             TUNING.breedCooldown *
             ((c.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1) *
-            (bp.slowMetabolism ? 2 : 1)
+            (bp.slowMetabolism ? 2 : 1) *
+            (bp.invasive ? 0.67 : 1)
           payForChild(w, c, bp, bw, bh, helpers)
           if (mate) {
             mate.children++
@@ -1205,7 +1207,9 @@ export function tickCreatures(
     )
     if (animals.length > 0) {
       const victim = animals[Math.floor(rng() * animals.length)]
-      const immunity = (victim.traits as { immunity?: number }).immunity ?? 0.2
+      const victimBp = w.blueprints[victim.blueprintId]
+      const rawImmunity = (victim.traits as { immunity?: number }).immunity ?? 0.2
+      const immunity = victimBp?.invasive ? Math.min(1, rawImmunity + 0.56) : rawImmunity
       if (rng() > immunity) {
         victim.sick = TUNING.diseaseDuration
       }
@@ -1649,7 +1653,9 @@ function look(
       const gdx = Math.max(0, Math.abs(deltaX(cx, other.x + ow / 2)) - (bw + ow) / 2)
       const gdy = Math.max(0, Math.abs(other.y + oh / 2 - (c.y + bh / 2)) - (bh + oh) / 2)
       if (gdx * gdx + gdy * gdy > spreadReach * spreadReach) continue
-      const otherImmunity = (other.traits as { immunity?: number }).immunity ?? 0.2
+      const otherBp = w.blueprints[other.blueprintId]
+      const rawOtherImmunity = (other.traits as { immunity?: number }).immunity ?? 0.2
+      const otherImmunity = otherBp?.invasive ? Math.min(1, rawOtherImmunity + 0.56) : rawOtherImmunity
       if (rng() < TUNING.diseaseSpreadChance * (1 - otherImmunity)) {
         if (!other.sick) {
           events.push({ kind: 'sick', blueprintId: other.blueprintId, x: other.x, y: other.y })
@@ -1901,7 +1907,8 @@ function payForChild(
   parent.breedCooldown =
     (TUNING.breedCooldown *
       ((parent.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1) *
-      (bp.slowMetabolism ? 2 : 1)) /
+      (bp.slowMetabolism ? 2 : 1) *
+      (bp.invasive ? 0.67 : 1)) /
     auraBoost(w, parent, bp, bw, bh, helpers)
   if (parent.mood === 'mate') {
     parent.mood = 'wander'

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -418,6 +418,20 @@ export interface CreatureBlueprint {
    * applies anywhere, but it is most meaningful in nutrient-scarce environments.
    */
   slowMetabolism?: boolean
+  /**
+   * Invasive species benefit from enemy release — the absence of co-evolved
+   * predators and parasites in their introduced range.
+   *
+   * Effects:
+   *   - Breed cooldown × 0.67 (1.5× faster reproduction rate)
+   *   - Effective disease immunity boosted by +0.56 (base 0.2 → 0.76),
+   *     representing 70% reduced disease susceptibility
+   *
+   * The effect is unconditional (no region tracking yet). It models the
+   * population explosion seen in successful invasions before native ecosystems
+   * adapt: cane toads, zebra mussels, kudzu vine.
+   */
+  invasive?: boolean
 }
 
 /**

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -408,6 +408,16 @@ export interface CreatureBlueprint {
    * Models sundews, pitcher plants, butterworts on acidic bogs and volcanic rock.
    */
   carnivorousPlant?: boolean
+  /**
+   * Drastically reduced basal metabolic rate — inspired by cave-adapted
+   * species (cave olm, cave fish) that can survive months without food.
+   *
+   * When true, the hunger increment is multiplied by 0.1, making the creature
+   * burn energy at 10% of the normal rate. Reproduction rate is also halved
+   * (these are extreme K-strategists). No special tile requirement — the flag
+   * applies anywhere, but it is most meaningful in nutrient-scarce environments.
+   */
+  slowMetabolism?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `invasive` blueprint flag (types.ts, blueprint.ts)
- Breed cooldown × 0.67 — 1.5× faster reproduction rate in the absence of natural enemies
- Effective disease immunity +0.56 (base 0.2 → 0.76), representing 70% reduced disease susceptibility
- Effect is unconditional pending a region/biome system — models the initial population explosion in new ranges

## Real-world basis
Invasive species succeed partly through "enemy release" — arriving without co-evolved predators, parasites, and pathogens. Cane toads, zebra mussels, and kudzu vine all show characteristic population explosions before native communities adapt.

## Test plan
- [x] Flag preservation: `sanitizeBlueprint` propagates `invasive: true/false/absent`  
- [x] Faster breeding: invasive species produces more births than native over 60 s

Closes #3363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)