### PR TITLE
feat(micro-land): invasive species enemy release effect (#3363)

### DIFF
--- a/src/app/micro-land/domain/__tests__/invasive-species.test.ts
+++ b/src/app/micro-land/domain/__tests__/invasive-species.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Invasive species — enemy release effect.
+ *
+ * Invasive species with invasive: true breed faster (cooldown × 0.67) and
+ * are more resistant to disease (effective immunity +0.56 above baseline).
+ *
+ * Tests cover:
+ *   1. sanitizeBlueprint preserves invasive: true/false/absent.
+ *   2. Invasive species produce more offspring than non-invasive over N seconds.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import type { SimEvent } from '@/app/micro-land/domain/sim/creature-sim'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import { lifespanOf } from '@/app/micro-land/domain/traits'
+import { TUNING } from '@/app/micro-land/domain/tuning'
+import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+// ---------------------------------------------------------------------------
+// 1. Blueprint flag tests
+// ---------------------------------------------------------------------------
+
+describe('invasive — sanitizeBlueprint', () => {
+  const base = {
+    name: 'Invader',
+    tags: ['meat'] as const,
+    art: {
+      palette: { a: '#ff6600' },
+      frames: [['aaa', 'aaa', 'aaa']],
+      frameMs: 200,
+      faceMotion: false,
+    },
+    move: { kind: 'walk' as const, speed: 0 },
+    diet: { eats: [] as const, hungerRate: 0.01, lifespanSeconds: 900 },
+    senses: { sight: 4 },
+  }
+
+  it('preserves invasive: true', () => {
+    const bp = sanitizeBlueprint({ ...base, invasive: true }, { summoned: true })
+    expect(bp.invasive).toBe(true)
+  })
+
+  it('preserves invasive: false', () => {
+    const bp = sanitizeBlueprint({ ...base, invasive: false }, { summoned: true })
+    expect(bp.invasive).toBe(false)
+  })
+
+  it('defaults invasive to false when absent', () => {
+    const bp = sanitizeBlueprint(base, { summoned: true })
+    expect(bp.invasive).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function flatWorld(): WorldState {
+  const w = createWorld(99)
+  for (let y = WORLD_H - 4; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.dirt
+  }
+  w.dormant = true
+  w.elapsed = 1 // avoid t=0 disease outbreak trigger
+  return w
+}
+
+/**
+ * A rooted plant blueprint — plants breed alone (no partner needed), so the
+ * only variable between runs is the cooldown. hungerRate=0 means hunger never
+ * accumulates, so breedCost doesn't cap births.
+ */
+function invasivePlant(invasive: boolean): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: invasive ? 'InvasiveMoss' : 'NativeMoss',
+      tags: ['plant'],
+      art: {
+        palette: { a: '#44aa44' },
+        frames: [['aaa', 'aaa', 'aaa']],
+        frameMs: 200,
+        faceMotion: false,
+      },
+      move: { kind: 'root', speed: 0 },
+      diet: {
+        eats: [],
+        hungerRate: 0,
+        lifespanSeconds: 900,
+        breedAt: 0.1,
+      },
+      senses: { sight: 4 },
+      invasive,
+    },
+    { summoned: true }
+  )
+}
+
+/** Set a creature to full adult readiness: well-fed, mature, off cooldown. */
+function readyAdult(c: Creature, bp: CreatureBlueprint): Creature {
+  c.hunger = 0
+  c.ageSeconds = lifespanOf(c, bp) * TUNING.lifespanScale * 0.3
+  c.breedCooldown = 0
+  return c
+}
+
+// ---------------------------------------------------------------------------
+// 2. Invasive breeds faster
+//
+// Using rooted plants: they breed alone, have zero hunger rate (so breedCost
+// does not accumulate to block further breeding), and their offspring spread
+// across the world. The 0.67× cooldown multiplier creates a measurable birth
+// count difference over 60 seconds.
+// ---------------------------------------------------------------------------
+
+describe('invasive — faster reproduction', () => {
+  it('invasive plant produces more births than non-invasive over 60 s', () => {
+    const wInvasive = flatWorld()
+    const wNative = flatWorld()
+
+    const bpInvasive = invasivePlant(true)
+    const bpNative = invasivePlant(false)
+
+    registerBlueprint(wInvasive, bpInvasive)
+    registerBlueprint(wNative, bpNative)
+
+    // One plant each, ready to spread
+    const c1 = spawnCreature(wInvasive, bpInvasive, 80, WORLD_H - 5)!
+    const c2 = spawnCreature(wNative, bpNative, 80, WORLD_H - 5)!
+    readyAdult(c1, bpInvasive)
+    readyAdult(c2, bpNative)
+
+    const rng = makeRng(7)
+    const eventsInvasive: SimEvent[] = []
+    const eventsNative: SimEvent[] = []
+
+    // 60 s at 60 Hz
+    for (let i = 0; i < 3600; i++) {
+      tickCreatures(wInvasive, 1 / 60, rng, 1, eventsInvasive)
+      tickCreatures(wNative, 1 / 60, rng, 1, eventsNative)
+    }
+
+    const invasiveBirths = eventsInvasive.filter(e => e.kind === 'born' && e.blueprintId === bpInvasive.id).length
+    const nativeBirths = eventsNative.filter(e => e.kind === 'born' && e.blueprintId === bpNative.id).length
+
+    // Invasive should breed noticeably faster due to 0.67x cooldown multiplier
+    expect(invasiveBirths).toBeGreaterThan(nativeBirths)
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -595,6 +595,7 @@ export function sanitizeBlueprint(
     polluter: b.polluter === true,
     carnivorousPlant: b.carnivorousPlant === true,
     slowMetabolism: b.slowMetabolism === true,
+    invasive: b.invasive === true,
     traitDefaults:
       b.traitDefaults && typeof b.traitDefaults === 'object'
         ? {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -625,7 +625,8 @@ export function tickCreatures(
       c.sick -= dt
       if (c.sick <= 0) {
         c.sick = 0
-        const immunity = (c.traits as { immunity?: number }).immunity ?? 0.2
+        const rawImmunity = (c.traits as { immunity?: number }).immunity ?? 0.2
+        const immunity = bp.invasive ? Math.min(1, rawImmunity + 0.56) : rawImmunity
         if (rng() >= immunity * 0.8 + 0.2) {
           kill(w, c, bp, dead, events, 'diseased')
           continue
@@ -1042,7 +1043,8 @@ export function tickCreatures(
           c.breedCooldown =
             TUNING.breedCooldown *
             ((c.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1) *
-            (bp.slowMetabolism ? 2 : 1)
+            (bp.slowMetabolism ? 2 : 1) *
+            (bp.invasive ? 0.67 : 1)
           payForChild(w, c, bp, bw, bh, helpers)
           if (mate) {
             mate.children++
@@ -1256,7 +1258,9 @@ export function tickCreatures(
     )
     if (animals.length > 0) {
       const victim = animals[Math.floor(rng() * animals.length)]
-      const immunity = (victim.traits as { immunity?: number }).immunity ?? 0.2
+      const victimBp = w.blueprints[victim.blueprintId]
+      const rawImmunity = (victim.traits as { immunity?: number }).immunity ?? 0.2
+      const immunity = victimBp?.invasive ? Math.min(1, rawImmunity + 0.56) : rawImmunity
       if (rng() > immunity) {
         victim.sick = TUNING.diseaseDuration
       }
@@ -1710,7 +1714,9 @@ function look(
       const gdx = Math.max(0, Math.abs(deltaX(cx, other.x + ow / 2)) - (bw + ow) / 2)
       const gdy = Math.max(0, Math.abs(other.y + oh / 2 - (c.y + bh / 2)) - (bh + oh) / 2)
       if (gdx * gdx + gdy * gdy > spreadReach * spreadReach) continue
-      const otherImmunity = (other.traits as { immunity?: number }).immunity ?? 0.2
+      const otherBp = w.blueprints[other.blueprintId]
+      const rawOtherImmunity = (other.traits as { immunity?: number }).immunity ?? 0.2
+      const otherImmunity = otherBp?.invasive ? Math.min(1, rawOtherImmunity + 0.56) : rawOtherImmunity
       if (rng() < TUNING.diseaseSpreadChance * (1 - otherImmunity)) {
         if (!other.sick) {
           events.push({ kind: 'sick', blueprintId: other.blueprintId, x: other.x, y: other.y })
@@ -1962,7 +1968,8 @@ function payForChild(
   parent.breedCooldown =
     (TUNING.breedCooldown *
       ((parent.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1) *
-      (bp.slowMetabolism ? 2 : 1)) /
+      (bp.slowMetabolism ? 2 : 1) *
+      (bp.invasive ? 0.67 : 1)) /
     auraBoost(w, parent, bp, bw, bh, helpers)
   if (parent.mood === 'mate') {
     parent.mood = 'wander'

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -433,6 +433,20 @@ export interface CreatureBlueprint {
    * applies anywhere, but it is most meaningful in nutrient-scarce environments.
    */
   slowMetabolism?: boolean
+  /**
+   * Invasive species benefit from enemy release — the absence of co-evolved
+   * predators and parasites in their introduced range.
+   *
+   * Effects:
+   *   - Breed cooldown × 0.67 (1.5× faster reproduction rate)
+   *   - Effective disease immunity boosted by +0.56 (base 0.2 → 0.76),
+   *     representing 70% reduced disease susceptibility
+   *
+   * The effect is unconditional (no region tracking yet). It models the
+   * population explosion seen in successful invasions before native ecosystems
+   * adapt: cane toads, zebra mussels, kudzu vine.
+   */
+  invasive?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `invasive` blueprint flag (types.ts, blueprint.ts)
- Breed cooldown × 0.67 — 1.5× faster reproduction rate in the absence of natural enemies
- Effective disease immunity +0.56 (base 0.2 → 0.76), representing 70% reduced disease susceptibility
- Unconditional effect pending region tracking — models the initial population explosion in new ranges

## Real-world basis
Invasive species succeed partly through "enemy release" — arriving without co-evolved predators, parasites, and pathogens. Cane toads, zebra mussels, and kudzu vine all show characteristic population explosions before native communities adapt.

## Test plan
- [x] Flag preservation: `sanitizeBlueprint` propagates `invasive: true/false/absent`
- [x] Faster breeding: invasive species produces more births than native over 60 s

Supersedes #3639. Closes #3363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)