### PR TITLE
feat(micro-land): allelopathic plants — novel weapon chemical suppression (#3365)

### DIFF
--- a/src/app/micro-land/domain/__tests__/allelopathic.test.ts
+++ b/src/app/micro-land/domain/__tests__/allelopathic.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Allelopathic plants — novel weapon advantage.
+ *
+ * An allelopathic plant suppresses the breeding rate of nearby non-resistant
+ * plants (breedCooldown × 1.3). Plants with novelCompoundResistant: true
+ * are immune.
+ *
+ * Tests:
+ *   1. sanitizeBlueprint preserves allelopathic and novelCompoundResistant.
+ *   2. A plant next to an allelopathic competitor produces fewer births than
+ *      one next to a non-allelopathic competitor of equal size.
+ *   3. A novelCompoundResistant plant is unaffected by an allelopathic neighbor.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import type { SimEvent } from '@/app/micro-land/domain/sim/creature-sim'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import type { CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+// ---------------------------------------------------------------------------
+// 1. Blueprint tests
+// ---------------------------------------------------------------------------
+
+describe('allelopathic — sanitizeBlueprint', () => {
+  const base = {
+    name: 'TestPlant',
+    tags: ['plant'] as const,
+    art: { palette: { a: '#00ff00' }, frames: [['aaa', 'aaa', 'aaa']], frameMs: 200, faceMotion: false },
+    move: { kind: 'root' as const, speed: 0 },
+    diet: { eats: [] as const, hungerRate: 0, lifespanSeconds: 900 },
+    senses: { sight: 4 },
+  }
+
+  it('preserves allelopathic: true', () => {
+    expect(sanitizeBlueprint({ ...base, allelopathic: true }, { summoned: true }).allelopathic).toBe(true)
+  })
+
+  it('defaults allelopathic to false', () => {
+    expect(sanitizeBlueprint(base, { summoned: true }).allelopathic).toBe(false)
+  })
+
+  it('preserves novelCompoundResistant: true', () => {
+    expect(sanitizeBlueprint({ ...base, novelCompoundResistant: true }, { summoned: true }).novelCompoundResistant).toBe(true)
+  })
+
+  it('defaults novelCompoundResistant to false', () => {
+    expect(sanitizeBlueprint(base, { summoned: true }).novelCompoundResistant).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Sim helpers
+// ---------------------------------------------------------------------------
+
+function mudWorld(): WorldState {
+  const w = createWorld(55)
+  for (let y = WORLD_H - 8; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.mud
+  }
+  w.dormant = true
+  w.elapsed = 1
+  return w
+}
+
+function makePlant(name: string, opts: Record<string, unknown> = {}): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name,
+      tags: ['plant'],
+      art: { palette: { a: '#228b22' }, frames: [['aaa', 'aaa', 'aaa']], frameMs: 200, faceMotion: false },
+      move: { kind: 'root', speed: 0 },
+      diet: { eats: [], hungerRate: 0, lifespanSeconds: 900, breedAt: 0.0 },
+      senses: { sight: 1 },
+      traitDefaults: { fertility: 1.0 },
+      ...opts,
+    },
+    { summoned: true }
+  )
+}
+
+function countBirths(blueprintId: string, events: SimEvent[]): number {
+  return events.filter(e => e.kind === 'born' && e.blueprintId === blueprintId).length
+}
+
+// ---------------------------------------------------------------------------
+// 2. Allelopathic suppression test
+// ---------------------------------------------------------------------------
+
+describe('allelopathic — suppression', () => {
+  it('plant next to allelopathic competitor breeds slower than next to non-allelopathic', { timeout: 30000 }, () => {
+    const wSuppressed = mudWorld()
+    const wFree = mudWorld()
+
+    // The victim plant (same species in both worlds)
+    const victim = makePlant('Victim')
+
+    // The competitor — allelopathic in one world, not in the other
+    const allelopathicComp = makePlant('Allelopathic', { allelopathic: true })
+    const normalComp = makePlant('Normal')
+
+    registerBlueprint(wSuppressed, victim)
+    registerBlueprint(wSuppressed, allelopathicComp)
+    registerBlueprint(wFree, victim)
+    registerBlueprint(wFree, normalComp)
+
+    const py = WORLD_H - 11
+    // Place victim plant at x=80, allelopathic/normal plant 5 tiles to the right (within ALLELOPATHY_RADIUS=8)
+    spawnCreature(wSuppressed, victim, 80, py)
+    spawnCreature(wSuppressed, allelopathicComp, 85, py)
+    spawnCreature(wFree, victim, 80, py)
+    spawnCreature(wFree, normalComp, 85, py)
+
+    // Force breedCooldown to 0 so they can breed immediately
+    for (const c of wSuppressed.creatures) c.breedCooldown = 0
+    for (const c of wFree.creatures) c.breedCooldown = 0
+
+    const rng = makeRng(42)
+    const eventsSuppressed: SimEvent[] = []
+    const eventsFree: SimEvent[] = []
+
+    // 180 s at 60 Hz
+    for (let i = 0; i < 10800; i++) {
+      tickCreatures(wSuppressed, 1 / 60, rng, 1, eventsSuppressed)
+      tickCreatures(wFree, 1 / 60, rng, 1, eventsFree)
+    }
+
+    const suppressedBirths = countBirths(victim.id, eventsSuppressed)
+    const freeBirths = countBirths(victim.id, eventsFree)
+
+    expect(freeBirths).toBeGreaterThan(suppressedBirths)
+  })
+
+  it('novelCompoundResistant plant is not suppressed by allelopathic neighbor', { timeout: 30000 }, () => {
+    const wResistant = mudWorld()
+    const wVulnerable = mudWorld()
+
+    const resistant = makePlant('Resistant', { novelCompoundResistant: true })
+    const vulnerable = makePlant('Vulnerable')
+    const allelopathicComp = makePlant('Allelopathic', { allelopathic: true })
+
+    registerBlueprint(wResistant, resistant)
+    registerBlueprint(wResistant, allelopathicComp)
+    registerBlueprint(wVulnerable, vulnerable)
+
+    // Need a separate allelopathic blueprint for the second world
+    const allelopathicComp2 = makePlant('Allelopathic2', { allelopathic: true })
+    registerBlueprint(wVulnerable, allelopathicComp2)
+
+    const py = WORLD_H - 11
+    spawnCreature(wResistant, resistant, 80, py)
+    spawnCreature(wResistant, allelopathicComp, 85, py)
+    spawnCreature(wVulnerable, vulnerable, 80, py)
+    spawnCreature(wVulnerable, allelopathicComp2, 85, py)
+
+    for (const c of wResistant.creatures) c.breedCooldown = 0
+    for (const c of wVulnerable.creatures) c.breedCooldown = 0
+
+    const rng = makeRng(42)
+    const eventsResistant: SimEvent[] = []
+    const eventsVulnerable: SimEvent[] = []
+
+    for (let i = 0; i < 10800; i++) {
+      tickCreatures(wResistant, 1 / 60, rng, 1, eventsResistant)
+      tickCreatures(wVulnerable, 1 / 60, rng, 1, eventsVulnerable)
+    }
+
+    const resistantBirths = countBirths(resistant.id, eventsResistant)
+    const vulnerableBirths = countBirths(vulnerable.id, eventsVulnerable)
+
+    // Resistant should breed at least as often as vulnerable (and likely more)
+    expect(resistantBirths).toBeGreaterThanOrEqual(vulnerableBirths)
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -595,6 +595,8 @@ export function sanitizeBlueprint(
     polluter: b.polluter === true,
     carnivorousPlant: b.carnivorousPlant === true,
     slowMetabolism: b.slowMetabolism === true,
+    allelopathic: b.allelopathic === true,
+    novelCompoundResistant: b.novelCompoundResistant === true,
     traitDefaults:
       b.traitDefaults && typeof b.traitDefaults === 'object'
         ? {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -130,6 +130,8 @@ const ROOT_STABILIZE_PROB = 0.0005
  */
 const POLLUTION_PROB = 0.001
 
+const ALLELOPATHY_RADIUS = 8 // tiles — allelopathic suppression reach
+
 /**
  * Seconds between chromatophore hue updates. At 5 s the creature adapts
  * roughly twice a minute — fast enough to matter ecologically, slow enough
@@ -1110,8 +1112,30 @@ export function tickCreatures(
               const plantFertilityFactor = bp.carnivorousPlant
                 ? Math.max(0.1, 2.0 - fertilityAt(w, footX, footY))
                 : fertilityAt(w, footX, footY)
+
+              // allelopathy suppression: nearby allelopathic different-species plants
+              // slow our breeding by 30%
+              let allelopathyFactor = 1
+              if (!bp.novelCompoundResistant) {
+                const ax = c.x + bw / 2
+                const ay = c.y + bh / 2
+                const nearbyN = gather(ax, ALLELOPATHY_RADIUS + bw / 2)
+                for (let i = 0; i < nearbyN; i++) {
+                  const other = found[i]
+                  if (other.id === c.id) continue
+                  const obp = w.blueprints[other.blueprintId]
+                  if (!obp?.allelopathic || obp.id === bp.id) continue
+                  const odx = other.x + (obp.art.frames[0][0]?.length ?? 1) / 2 - ax
+                  const ody = other.y + (obp.art.frames[0]?.length ?? 1) / 2 - ay
+                  if (odx * odx + ody * ody < ALLELOPATHY_RADIUS * ALLELOPATHY_RADIUS) {
+                    allelopathyFactor = 1.3
+                    break
+                  }
+                }
+              }
+
               c.breedCooldown =
-                (TUNING.plantSpreadCooldown * crowdingPenalty) /
+                (TUNING.plantSpreadCooldown * crowdingPenalty * allelopathyFactor) /
                 (auraBoost(w, c, bp, bw, bh, helpers) *
                   plantFertilityFactor *
                   seasonFactor)

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -433,6 +433,25 @@ export interface CreatureBlueprint {
    * applies anywhere, but it is most meaningful in nutrient-scarce environments.
    */
   slowMetabolism?: boolean
+  /**
+   * Allelopathic plants secrete chemicals that suppress the growth of nearby
+   * competitors. Any rooted plant within `ALLELOPATHY_RADIUS` tiles whose
+   * blueprint does NOT have `novelCompoundResistant: true` gets a 30% breed-
+   * cooldown penalty (breedCooldown × 1.3) applied each tick.
+   *
+   * Models garlic mustard, black walnut juglone, and invasive Phragmites
+   * secreting allelopathic compounds into the soil.
+   */
+  allelopathic?: boolean
+  /**
+   * This plant has evolved or already carries resistance to allelopathic
+   * compounds in its habitat. Nearby allelopathic plants do not suppress its
+   * growth rate.
+   *
+   * In an invasive-species context, this trait can spread through a native
+   * plant population exposed to an allelopathic invader over many generations.
+   */
+  novelCompoundResistant?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `allelopathic` blueprint flag: plants secrete compounds suppressing nearby competitors
- Adds `novelCompoundResistant` blueprint flag: immunity to allelopathic suppression
- Suppressed plants within `ALLELOPATHY_RADIUS = 8` tiles get `breedCooldown × 1.3` (30% slower)
- Same-species allelopathy excluded (intraspecific competition is modelled separately)

## Real-world basis
Garlic mustard, black walnut (juglone), and Phragmites australis produce allelopathic compounds that native plants have never encountered. This "novel weapon hypothesis" helps explain why some invasive plants devastate native plant communities — not just competition, but active chemical warfare.

## Test plan
- [x] Flag preservation: `sanitizeBlueprint` propagates `allelopathic` and `novelCompoundResistant`
- [x] Suppression: plant next to allelopathic competitor has fewer births over 180 s
- [x] Resistance: `novelCompoundResistant` plant breeds at normal rate despite allelopathic neighbor

Closes #3365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)