### PR TITLE
feat(micro-land): biotic resistance — diverse native communities slow invasions (#3367)

### DIFF
--- a/src/app/micro-land/domain/__tests__/biotic-resistance.test.ts
+++ b/src/app/micro-land/domain/__tests__/biotic-resistance.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Biotic resistance — diverse native communities slow invasive colonization.
+ *
+ * An invasive plant surrounded by >= BIOTIC_RESISTANCE_THRESHOLD = 3 distinct
+ * native species gets breedCooldown × 1.5. In a native-species-poor area it
+ * breeds at normal speed.
+ *
+ * Tests:
+ *   1. Invasive plant in diverse native community (3+ species) breeds slower
+ *      than the same invasive alone (no native species nearby).
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import type { SimEvent } from '@/app/micro-land/domain/sim/creature-sim'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import type { CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+function mudWorld(): WorldState {
+  const w = createWorld(17)
+  for (let y = WORLD_H - 8; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.mud
+  }
+  w.dormant = true
+  w.elapsed = 1
+  return w
+}
+
+function makePlant(name: string, opts: Record<string, unknown> = {}): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name,
+      tags: ['plant'],
+      art: { palette: { a: '#228b22' }, frames: [['aaa', 'aaa', 'aaa']], frameMs: 200, faceMotion: false },
+      move: { kind: 'root', speed: 0 },
+      diet: { eats: [], hungerRate: 0, lifespanSeconds: 900, breedAt: 0.0 },
+      senses: { sight: 1 },
+      ...opts,
+    },
+    { summoned: true }
+  )
+}
+
+describe('biotic resistance', () => {
+  it('invasive plant breeds slower in a diverse native community than in an empty area', { timeout: 30000 }, () => {
+    const wDiverse = mudWorld()   // invasive + 3 native species nearby
+    const wEmpty = mudWorld()     // invasive alone (no natives)
+
+    const invasive = makePlant('Invader', { invasive: true })
+    registerBlueprint(wDiverse, invasive)
+    registerBlueprint(wEmpty, invasive)
+
+    // Add 3 distinct native species to the diverse world
+    const native1 = makePlant('Native1')
+    const native2 = makePlant('Native2')
+    const native3 = makePlant('Native3')
+    registerBlueprint(wDiverse, native1)
+    registerBlueprint(wDiverse, native2)
+    registerBlueprint(wDiverse, native3)
+
+    const py = WORLD_H - 11
+    // Invasive at x=80 in both worlds
+    spawnCreature(wDiverse, invasive, 80, py)
+    spawnCreature(wEmpty, invasive, 80, py)
+
+    // Place 3 native plants within BIOTIC_RESISTANCE_RADIUS=12 in the diverse world
+    // Use x=83, 87, 91 — all within 12 tiles of x=80
+    spawnCreature(wDiverse, native1, 83, py)
+    spawnCreature(wDiverse, native2, 87, py)
+    spawnCreature(wDiverse, native3, 91, py)
+
+    // Force immediate breeding start
+    for (const c of wDiverse.creatures) c.breedCooldown = 0
+    for (const c of wEmpty.creatures) c.breedCooldown = 0
+
+    const rng = makeRng(42)
+    const eventsDiverse: SimEvent[] = []
+    const eventsEmpty: SimEvent[] = []
+
+    // 180 s at 60 Hz
+    for (let i = 0; i < 10800; i++) {
+      tickCreatures(wDiverse, 1 / 60, rng, 1, eventsDiverse)
+      tickCreatures(wEmpty, 1 / 60, rng, 1, eventsEmpty)
+    }
+
+    const diverseBirths = eventsDiverse.filter(e => e.kind === 'born' && e.blueprintId === invasive.id).length
+    const emptyBirths = eventsEmpty.filter(e => e.kind === 'born' && e.blueprintId === invasive.id).length
+
+    // The invasive in the diverse community should have had fewer births
+    expect(emptyBirths).toBeGreaterThan(diverseBirths)
+  })
+})

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -130,6 +130,9 @@ const ROOT_STABILIZE_PROB = 0.0005
  */
 const POLLUTION_PROB = 0.001
 
+const BIOTIC_RESISTANCE_RADIUS = 12 // tiles — diversity sensing reach for invasives
+const BIOTIC_RESISTANCE_THRESHOLD = 3 // distinct native species needed for resistance
+
 /**
  * Seconds between chromatophore hue updates. At 5 s the creature adapts
  * roughly twice a minute — fast enough to matter ecologically, slow enough
@@ -1112,8 +1115,32 @@ export function tickCreatures(
               const plantFertilityFactor = bp.carnivorousPlant
                 ? Math.max(0.1, 2.0 - fertilityAt(w, footX, footY))
                 : fertilityAt(w, footX, footY)
+
+              // biotic resistance: diverse native communities slow invasive colonization
+              let bioticResistanceFactor = 1
+              if (bp.invasive) {
+                const bx = c.x + bw / 2
+                const by = c.y + bh / 2
+                const nearbyN2 = gather(bx, BIOTIC_RESISTANCE_RADIUS + bw / 2)
+                const nativeSpeciesNearby = new Set<string>()
+                for (let i = 0; i < nearbyN2; i++) {
+                  const other = found[i]
+                  if (other.id === c.id) continue
+                  const obp = w.blueprints[other.blueprintId]
+                  if (!obp || obp.invasive) continue // only count non-invasive (native) species
+                  const odx = other.x + (obp.art.frames[0][0]?.length ?? 1) / 2 - bx
+                  const ody = other.y + (obp.art.frames[0]?.length ?? 1) / 2 - by
+                  if (odx * odx + ody * ody < BIOTIC_RESISTANCE_RADIUS * BIOTIC_RESISTANCE_RADIUS) {
+                    nativeSpeciesNearby.add(other.blueprintId)
+                  }
+                }
+                if (nativeSpeciesNearby.size >= BIOTIC_RESISTANCE_THRESHOLD) {
+                  bioticResistanceFactor = 1.5 // 50% slower in diverse native communities
+                }
+              }
+
               c.breedCooldown =
-                (TUNING.plantSpreadCooldown * crowdingPenalty) /
+                (TUNING.plantSpreadCooldown * crowdingPenalty * bioticResistanceFactor) /
                 (auraBoost(w, c, bp, bw, bh, helpers) *
                   plantFertilityFactor *
                   seasonFactor)


### PR DESCRIPTION
## Summary
- Invasive plants sense how many distinct native species are within `BIOTIC_RESISTANCE_RADIUS = 12` tiles
- When ≥ `BIOTIC_RESISTANCE_THRESHOLD = 3` native species are present, invasive breed cooldown × 1.5 (50% slower colonisation)
- No new blueprint flags needed — uses the existing `invasive` flag

## Real-world basis
The diversity–invasibility relationship is one of ecology's most replicated findings: species-rich native plant communities are substantially more resistant to invasion than depauperate or degraded ones. The mechanism is niche saturation — diverse communities leave fewer empty ecological "slots" for invaders to exploit. Restoration ecologists routinely use diversity seeding as an invasion management tool.

## Test plan
- [x] Invasive plant in a 3-species native community breeds slower than the same invasive alone over 180 s

Closes #3367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)