### PR TITLE
feat(micro-land): competitive exclusion — high-ability competitors suppress co-occurring species (#3364)

### DIFF
--- a/src/app/micro-land/domain/__tests__/competitive-exclusion.test.ts
+++ b/src/app/micro-land/domain/__tests__/competitive-exclusion.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Competitive exclusion — high competitive ability suppresses co-occurring species.
+ *
+ * When the sum of competitor `competitiveAbility` values within
+ * COMPETITIVE_EXCLUSION_RADIUS exceeds COMPETITIVE_THRESHOLD, the suppressed
+ * plant's breed cooldown increases. Invasive species (competitiveAbility=2.0)
+ * create more pressure per individual than native species (default 1.0).
+ *
+ * Tests:
+ *   1. competitiveAbility defaults to 1 when absent.
+ *   2. A plant surrounded by high-ability competitors breeds slower than
+ *      one surrounded by equal-ability competitors.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import type { CreatureBlueprint, SimEvent, WorldState } from '@/app/micro-land/domain/types'
+
+function mudWorld(): WorldState {
+  const w = createWorld(5)
+  for (let y = WORLD_H - 8; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.mud
+  }
+  w.dormant = true
+  w.elapsed = 1
+  return w
+}
+
+function plant(name: string, opts: Record<string, unknown> = {}): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name,
+      tags: ['plant'],
+      art: { palette: { a: '#228b22' }, frames: [['aaa', 'aaa', 'aaa']], frameMs: 200, faceMotion: false },
+      move: { kind: 'root', speed: 0 },
+      diet: { eats: [], hungerRate: 0, lifespanSeconds: 900, breedAt: 0.0 },
+      senses: { sight: 1 },
+      ...opts,
+    },
+    { summoned: true }
+  )
+}
+
+describe('competitive exclusion', () => {
+  it('competitiveAbility defaults to 1 when not set', () => {
+    const bp = plant('NeutralPlant')
+    expect(bp.competitiveAbility).toBe(1)
+  })
+
+  it('competitiveAbility is preserved in sanitizeBlueprint', () => {
+    const bp = plant('StrongPlant', { competitiveAbility: 2.0 })
+    expect(bp.competitiveAbility).toBe(2)
+  })
+
+  it('plant surrounded by high-ability competitors breeds slower than one surrounded by equal-ability ones', () => {
+    // World A: victim surrounded by 4 high-ability (2.0) competitors
+    //   → pressure = 4 × 2.0 / 1.0 = 8 > THRESHOLD=3 → penalty applies
+    // World B: victim surrounded by 4 equal-ability (1.0) competitors
+    //   → pressure = 4 × 1.0 / 1.0 = 4 > THRESHOLD=3 → smaller penalty
+    // So world A victim should have fewer births
+
+    const wHigh = mudWorld()
+    const wEqual = mudWorld()
+
+    const victim = plant('Victim')
+    const highAbility = plant('HighAbility', { competitiveAbility: 2.0 })
+    const equalAbility = plant('EqualAbility', { competitiveAbility: 1.0 })
+
+    registerBlueprint(wHigh, victim)
+    registerBlueprint(wHigh, highAbility)
+    registerBlueprint(wEqual, victim)
+    registerBlueprint(wEqual, equalAbility)
+
+    const py = WORLD_H - 11
+    // Victim at x=80, 4 competitors within COMPETITIVE_EXCLUSION_RADIUS=6
+    spawnCreature(wHigh, victim, 80, py)
+    spawnCreature(wHigh, highAbility, 82, py)
+    spawnCreature(wHigh, highAbility, 83, py)
+    spawnCreature(wHigh, highAbility, 84, py)
+    spawnCreature(wHigh, highAbility, 85, py)
+
+    spawnCreature(wEqual, victim, 80, py)
+    spawnCreature(wEqual, equalAbility, 82, py)
+    spawnCreature(wEqual, equalAbility, 83, py)
+    spawnCreature(wEqual, equalAbility, 84, py)
+    spawnCreature(wEqual, equalAbility, 85, py)
+
+    for (const c of wHigh.creatures) c.breedCooldown = 0
+    for (const c of wEqual.creatures) c.breedCooldown = 0
+
+    const rng = makeRng(42)
+    const eventsHigh: SimEvent[] = []
+    const eventsEqual: SimEvent[] = []
+
+    for (let i = 0; i < 10800; i++) {
+      tickCreatures(wHigh, 1 / 60, rng, 1, eventsHigh)
+      tickCreatures(wEqual, 1 / 60, rng, 1, eventsEqual)
+    }
+
+    const highBirths = eventsHigh.filter(e => e.kind === 'born' && e.blueprintId === victim.id).length
+    const equalBirths = eventsEqual.filter(e => e.kind === 'born' && e.blueprintId === victim.id).length
+
+    expect(equalBirths).toBeGreaterThan(highBirths)
+  }, 30000)
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -598,6 +598,10 @@ export function sanitizeBlueprint(
     invasive: b.invasive === true,
     allelopathic: b.allelopathic === true,
     novelCompoundResistant: b.novelCompoundResistant === true,
+    competitiveAbility:
+      typeof b.competitiveAbility === 'number' && b.competitiveAbility > 0
+        ? b.competitiveAbility
+        : 1,
     traitDefaults:
       b.traitDefaults && typeof b.traitDefaults === 'object'
         ? {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -133,6 +133,8 @@ const POLLUTION_PROB = 0.001
 const ALLELOPATHY_RADIUS = 8 // tiles — allelopathic suppression reach
 const BIOTIC_RESISTANCE_RADIUS = 12 // tiles — diversity sensing reach for invasives
 const BIOTIC_RESISTANCE_THRESHOLD = 3 // distinct native species needed for resistance
+const COMPETITIVE_EXCLUSION_RADIUS = 6 // tiles
+const COMPETITIVE_THRESHOLD = 3.0 // sum of competitor ability at which penalty begins
 
 /**
  * Seconds between chromatophore hue updates. At 5 s the creature adapts
@@ -1161,8 +1163,34 @@ export function tickCreatures(
                 }
               }
 
+              // competitive exclusion: high-ability competitors suppress breeding
+              let competitiveExclusionFactor = 1
+              {
+                const myAbility = bp.competitiveAbility ?? 1
+                const ccx = c.x + bw / 2
+                const ccy = c.y + bh / 2
+                const nearbyN3 = gather(ccx, COMPETITIVE_EXCLUSION_RADIUS + bw / 2)
+                let competitorPressure = 0
+                for (let i = 0; i < nearbyN3; i++) {
+                  const other = found[i]
+                  if (other.id === c.id) continue
+                  const obp = w.blueprints[other.blueprintId]
+                  if (!obp || obp.move.kind !== 'root' || obp.id === bp.id) continue
+                  const odx = other.x + (obp.art.frames[0][0]?.length ?? 1) / 2 - ccx
+                  const ody = other.y + (obp.art.frames[0]?.length ?? 1) / 2 - ccy
+                  if (odx * odx + ody * ody < COMPETITIVE_EXCLUSION_RADIUS * COMPETITIVE_EXCLUSION_RADIUS) {
+                    competitorPressure += (obp.competitiveAbility ?? 1)
+                  }
+                }
+                const relativePressure = competitorPressure / Math.max(0.1, myAbility)
+                if (relativePressure > COMPETITIVE_THRESHOLD) {
+                  const excess = Math.min(2, (relativePressure - COMPETITIVE_THRESHOLD) / COMPETITIVE_THRESHOLD)
+                  competitiveExclusionFactor = 1 + 0.5 * excess
+                }
+              }
+
               c.breedCooldown =
-                (TUNING.plantSpreadCooldown * crowdingPenalty * allelopathyFactor * bioticResistanceFactor) /
+                (TUNING.plantSpreadCooldown * crowdingPenalty * allelopathyFactor * bioticResistanceFactor * competitiveExclusionFactor) /
                 (auraBoost(w, c, bp, bw, bh, helpers) *
                   plantFertilityFactor *
                   seasonFactor)

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -466,6 +466,19 @@ export interface CreatureBlueprint {
    * plant population exposed to an allelopathic invader over many generations.
    */
   novelCompoundResistant?: boolean
+  /**
+   * How effectively this species competes with others for shared resources and
+   * space. Contributes to competitive pressure experienced by neighbours of
+   * different species.
+   *
+   * Default 1.0. Invasive generalists typically use 2.0, reflecting broader
+   * niche breadth and resource-use efficiency. Specialists may be < 1.0 in
+   * out-of-niche conditions.
+   *
+   * Used in the competitive exclusion formula: when total competitive pressure
+   * from other species nearby exceeds COMPETITIVE_THRESHOLD, breeding rate drops.
+   */
+  competitiveAbility?: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `competitiveAbility: number` to blueprints (default 1.0; invasive generalists typically 2.0)
- When the sum of competitor ability within 6 tiles divided by own ability exceeds `COMPETITIVE_THRESHOLD = 3.0`, breedCooldown is multiplied by 1.0–1.5
- Stacks with allelopathic and biotic resistance factors (all are multiplicative on breedCooldown)

## Gause's competitive exclusion principle
Two species competing for the same limited resource cannot coexist indefinitely — the one with even a slight advantage will eventually drive the other to extinction in a closed system. In micro-land, this means invasive species (high `competitiveAbility`) will suppress native plants once they establish locally, even without allelopathic chemicals.

## Test plan
- [x] `competitiveAbility` defaults to 1 when absent
- [x] `sanitizeBlueprint` preserves `competitiveAbility: 2.0`
- [x] A plant surrounded by 4 high-ability (2.0) competitors breeds slower than one surrounded by 4 equal-ability (1.0) competitors

Closes #3364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)