### PR TITLE
feat(micro-land): lateral line hydrodynamic sensing — pressure waves in water (#3428)

### DIFF
--- a/src/app/micro-land/domain/__tests__/lateral-line.test.ts
+++ b/src/app/micro-land/domain/__tests__/lateral-line.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Lateral line hydrodynamic sensing.
+ *
+ * A creature with lateralLine: true detects nearby creatures within
+ * LATERAL_LINE_RADIUS=5 tiles regardless of camouflage — but ONLY when
+ * standing on a water or mud tile.
+ *
+ * Test geometry:
+ *   predator at x=100, art width=3 ('aaa' padded to 3×3 by ART_MIN)
+ *   prey at x=107, art width=3 → edge gap = 107-103 = 4 tiles, d² = 16
+ *
+ * Prey has traits.camouflage=0.99 (not cryptic — independent of tile hue):
+ *   detFactor(still, camo=0.99) = max(0.15, 0.5-0.99×0.375) = 0.15
+ *   With sight=5, hunger=1, roam=1.3: foodSight=5×(1+2×1×1.3)=18, foodSight²=324
+ *   efs²(normal) = 324 × 0.15² = 7.29 → d²=16 > 7.29 → NOT detected
+ *   efs²(bypass) = 324 × 0.5²  = 81   → d²=16 < 81  → DETECTED
+ *
+ * World tile determines whether lateral line fires:
+ *   mud  → lateral line active (d²=16 < LATERAL_LINE_RADIUS²=25) → prey detected
+ *   dirt → lateral line inactive → prey hidden (camo=0.99, d²>efs²)
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import {
+  createWorld,
+  registerBlueprint,
+  spawnCreature,
+} from '@/app/micro-land/domain/sim/world'
+import type { CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+function worldWithTile(tileId: 'dirt' | 'mud'): WorldState {
+  const w = createWorld(42)
+  const idx = MATERIAL_INDEX[tileId]
+  for (let y = WORLD_H - 8; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = idx
+  }
+  w.dormant = true
+  w.elapsed = 1
+  return w
+}
+
+// Predator: sight=5, speed=0 (stationary — prevents wandering into detection range).
+// hunger=1, roam=1.3 (meat-eater default from spawnCreature).
+// foodSight = 5 × (1 + 2 × 1 × 1.3) = 18, foodSight² = 324.
+// With camo=0 (bypass): efs² = 324 × 0.25 = 81 → detects prey at d²=16.
+// With camo=0.99 (no bypass): efs² = 324 × 0.15² = 7.29 → misses prey at d²=16.
+// speed=0 is critical: a mobile predator can wander within 2-3 tiles in 24 ticks,
+// bringing d² below efs²(camo=0.99)=7.29 and causing a spurious detection.
+function predBp(lateralLine: boolean): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: lateralLine ? 'FishPred' : 'NormalPred',
+      tags: ['predator'],
+      art: { palette: { a: '#0000ff' }, frames: [['aaa']], frameMs: 200, faceMotion: false },
+      move: { kind: 'walk', speed: 0 }, // stationary — test the sense logic, not movement
+      diet: { eats: ['meat'], hungerRate: 0.01, lifespanSeconds: 900 },
+      senses: { sight: 5 },
+      lateralLine,
+    },
+    { summoned: true }
+  )
+}
+
+// Prey: high trait camouflage (0.99) — independent of tile hue so it works on
+// any floor. d²=16 > efs²(camo=0.99)=7.29 → invisible to normal predator.
+function camouPrey(): CreatureBlueprint {
+  return sanitizeBlueprint(
+    {
+      name: 'HiddenPrey',
+      tags: ['meat'],
+      art: { palette: { a: '#888888' }, frames: [['aaa']], frameMs: 200, faceMotion: false },
+      move: { kind: 'walk', speed: 0 },
+      diet: { eats: [], hungerRate: 0, lifespanSeconds: 900 },
+      senses: { sight: 1 },
+      traitDefaults: { camouflage: 0.99 },
+    },
+    { summoned: true }
+  )
+}
+
+function checkDetection(
+  pred: CreatureBlueprint,
+  prey: CreatureBlueprint,
+  tileId: 'dirt' | 'mud'
+): boolean {
+  const w = worldWithTile(tileId)
+  registerBlueprint(w, pred)
+  registerBlueprint(w, prey)
+
+  const py = WORLD_H - 11
+  // Prey at x=107: right edge of pred body (100+3=103) to left edge of prey body (107) = 4-tile gap.
+  // d² = 4² = 16. LATERAL_LINE_RADIUS=5, radius²=25. 16 < 25 → lateral line fires.
+  spawnCreature(w, prey, 107, py)
+  spawnCreature(w, pred, 100, py)
+
+  const preyC = w.creatures.find(c => c.blueprintId === prey.id)!
+  const predC = w.creatures.find(c => c.blueprintId === pred.id)!
+  predC.hunger = 1.0
+
+  const rng = makeRng(42)
+  for (let i = 0; i < 24; i++) tickCreatures(w, 1 / 60, rng, 1, [])
+  return predC.targetId === preyC.id
+}
+
+// ---------------------------------------------------------------------------
+// Blueprint sanitization tests
+// ---------------------------------------------------------------------------
+
+describe('lateralLine — sanitizeBlueprint', () => {
+  const base = {
+    name: 'Fish',
+    tags: ['predator'] as const,
+    art: { palette: { a: '#0000ff' }, frames: [['aaa']], frameMs: 200, faceMotion: false },
+    move: { kind: 'walk' as const, speed: 0 },
+    diet: { eats: ['meat'] as const, hungerRate: 0, lifespanSeconds: 900 },
+    senses: { sight: 4 },
+  }
+
+  it('defaults to false', () => {
+    expect(sanitizeBlueprint(base, { summoned: true }).lateralLine).toBe(false)
+  })
+
+  it('preserved when true', () => {
+    expect(
+      sanitizeBlueprint({ ...base, lateralLine: true }, { summoned: true }).lateralLine
+    ).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Simulation detection tests
+// ---------------------------------------------------------------------------
+
+describe('lateralLine — detection', () => {
+  it('lateral-line predator in mud detects high-camo prey at 4-tile gap that normal predator cannot', () => {
+    const fishPred = predBp(true)
+    const normalPred = predBp(false)
+    const prey = camouPrey()
+
+    // camo=0.99 (tile-independent) → efs²=7.29, d²=16 > 7.29 → normal pred misses
+    // lateral line on mud → sensorBypass → camo=0 → efs²=81, d²=16 < 81 → fish detects
+    const normalDetects = checkDetection(normalPred, prey, 'mud')
+    const fishDetects = checkDetection(fishPred, prey, 'mud')
+
+    expect(normalDetects).toBe(false) // camo=0.99 prey outside normal efs²=7.29, d²=16
+    expect(fishDetects).toBe(true) // lateral line bypasses camouflage in mud
+  })
+
+  it('lateral-line predator on DIRT does NOT detect the same prey (needs water/mud medium)', () => {
+    const fishPred = predBp(true)
+    const prey = camouPrey()
+    // On dirt: lateral line inactive → camo=0.99 → efs²=7.29, d²=16 > 7.29 → NOT detected.
+    const fishDetectsOnDirt = checkDetection(fishPred, prey, 'dirt')
+    expect(fishDetectsOnDirt).toBe(false)
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -605,6 +605,7 @@ export function sanitizeBlueprint(
     electroreceptive: b.electroreceptive === true,
     warmBlooded: b.warmBlooded === true,
     infraredVision: b.infraredVision === true,
+    lateralLine: b.lateralLine === true,
     brainSize:
       typeof b.brainSize === 'number' && b.brainSize >= 0 && b.brainSize <= 1
         ? b.brainSize

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -157,6 +157,8 @@ const CHROMATO_FADE_S = 2 / 60
  */
 const DISRUPTION_NEAR_TILES = 4
 
+const LATERAL_LINE_RADIUS = 5 // tiles — hydrodynamic pressure sensing range
+
 /**
  * Beyond DISRUPTION_NEAR_TILES, a disruptive-pattern creature is only
  * detectable at this fraction of the predator's normal detection radius.
@@ -1630,9 +1632,20 @@ function look(
       // is fully exposed (pigment cells incoherent). Override camouflage to 0.
       const chromaFade = (other as { chromatophoreFade?: number }).chromatophoreFade ?? 0
       // Sensory modalities that bypass visual camouflage entirely
+      // lateral line: bypasses camouflage within short range in water/mud tiles
+      const predFootX = Math.floor(c.x + bw / 2)
+      const predFootY = Math.floor(c.y + bh)
+      const predTile = tileAt(w, predFootX, predFootY)
+      const predMat = MATERIAL_BY_INDEX[predTile]
+      const inWaterOrMud = predMat?.id === 'water' || predMat?.id === 'mud'
+      const lateralLineSense =
+        bp.lateralLine === true &&
+        inWaterOrMud &&
+        d2 < LATERAL_LINE_RADIUS * LATERAL_LINE_RADIUS
       const sensorBypass =
         bp.electroreceptive === true || // detects bioelectric fields
-        (bp.infraredVision === true && obp.warmBlooded === true) // detects heat
+        (bp.infraredVision === true && obp.warmBlooded === true) || // detects heat
+        lateralLineSense // detects water pressure waves
       const baseCamouflage = sensorBypass
         ? 0
         : chromaFade > 0
@@ -1684,9 +1697,20 @@ function look(
       const territoryR = (c.traits.territorial ?? 0.5) * 10
       const intruderChromaFade = (other as { chromatophoreFade?: number }).chromatophoreFade ?? 0
       // Sensory modalities that bypass visual camouflage entirely
+      // lateral line: bypasses camouflage within short range in water/mud tiles
+      const intPredFootX = Math.floor(c.x + bw / 2)
+      const intPredFootY = Math.floor(c.y + bh)
+      const intPredTile = tileAt(w, intPredFootX, intPredFootY)
+      const intPredMat = MATERIAL_BY_INDEX[intPredTile]
+      const intInWaterOrMud = intPredMat?.id === 'water' || intPredMat?.id === 'mud'
+      const intLateralLineSense =
+        bp.lateralLine === true &&
+        intInWaterOrMud &&
+        d2 < LATERAL_LINE_RADIUS * LATERAL_LINE_RADIUS
       const intruderSensorBypass =
         bp.electroreceptive === true || // detects bioelectric fields
-        (bp.infraredVision === true && obp.warmBlooded === true) // detects heat
+        (bp.infraredVision === true && obp.warmBlooded === true) || // detects heat
+        intLateralLineSense // detects water pressure waves
       const intruderCamoBase = intruderSensorBypass
         ? 0
         : intruderChromaFade > 0

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -512,6 +512,17 @@ export interface CreatureBlueprint {
    * metabolic rate despite being only 2% of body mass.
    */
   brainSize?: number
+  /**
+   * Fish-type creatures with a lateral line organ detect water pressure waves
+   * and micro-turbulence from nearby moving creatures. The lateral line
+   * bypasses visual camouflage within a short radius — but only when the
+   * predator is in a water or mud tile (the medium that transmits the
+   * pressure signal).
+   *
+   * Models how blind cave fish still school and hunt, and why predatory fish
+   * in murky water find prey that would be visually invisible.
+   */
+  lateralLine?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `lateralLine` blueprint flag
- Within `LATERAL_LINE_RADIUS = 5` tiles, lateral-line creatures detect all prey at `baseCamouflage = 0`
- Only active when the predator is standing on a **water** or **mud** tile (the transmission medium)
- Works alongside `electroreceptive` and `infraredVision` as a third camouflage-bypass modality

## Real-world basis
All fish and many amphibians have lateral line organs — mechanoreceptors that detect pressure waves in water. Blind cave fish use the lateral line to school, hunt, and navigate with zero light. In murky river water where visual range is 10 cm, a pike detects a minnow at 2 metres through lateral line alone.

## Test plan
- [x] Flag preservation: defaults to `false`, preserved when `true`
- [x] Lateral-line predator in **mud** detects cryptic prey at 5 tiles that a normal predator misses
- [x] Same lateral-line predator on **dirt** (no water medium) cannot detect the same prey

Closes #3428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)