### PR TITLE
fix(dicebound): the sheet stops claiming +1 is the ceiling

### DIFF
--- a/src/app/dicebound/components/__tests__/sheet.test.tsx
+++ b/src/app/dicebound/components/__tests__/sheet.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Sheet } from '@/app/dicebound/components/sheet'
+import type { SkillId } from '@/app/dicebound/domain/attributes'
+import { type Campaign, newCampaign } from '@/app/dicebound/domain/campaign'
+import {
+  RANK_THRESHOLDS,
+  type SkillRecord,
+  blankAttributes,
+} from '@/app/dicebound/domain/character'
+
+afterEach(cleanup)
+
+function campaignWith(skills: Partial<Record<SkillId, SkillRecord>>): Campaign {
+  return newCampaign(
+    'a fishing town',
+    { name: 'Ilda', concept: 'a salvager', reading: '', attributes: blankAttributes(), skills },
+    0,
+    null
+  )
+}
+
+describe('Sheet skill progress', () => {
+  it('counts toward the first rank before the skill exists', () => {
+    render(<Sheet campaign={campaignWith({ balance: { uses: 2, rank: 0 } })} />)
+
+    expect(screen.getByText(`2/${RANK_THRESHOLDS[0]}`)).toBeTruthy()
+  })
+
+  it('keeps counting after the first rank lands — +1 is not the ceiling', () => {
+    // The bug this protects against: the counter was gated on an unranked skill
+    // and pinned to the first threshold, so a +1 skill showed no progress at
+    // all. Rank 2 is eight uses in, and a player five checks into that climb
+    // could see nothing to distinguish them from a player who had just earned
+    // the rank — which makes the whole progression read as capped at +1.
+    render(<Sheet campaign={campaignWith({ balance: { uses: 5, rank: 1 } })} />)
+
+    expect(screen.getByText(`5/${RANK_THRESHOLDS[1]}`)).toBeTruthy()
+  })
+
+  it('counts toward the third rank as well, on the real threshold', () => {
+    render(<Sheet campaign={campaignWith({ balance: { uses: 10, rank: 2 } })} />)
+
+    expect(screen.getByText(`10/${RANK_THRESHOLDS[2]}`)).toBeTruthy()
+  })
+
+  it('shows nothing to chase once the skill is maxed', () => {
+    render(<Sheet campaign={campaignWith({ balance: { uses: RANK_THRESHOLDS[2], rank: 3 } })} />)
+
+    expect(screen.queryByText(new RegExp(`^${RANK_THRESHOLDS[2]}/`))).toBeNull()
+  })
+
+  it('never offers progress on an innate rank, which cannot be practised', () => {
+    // Size is what the character is. A counter under it would promise that
+    // enough Size checks eventually make you bigger.
+    render(<Sheet campaign={campaignWith({ size: { uses: 4, rank: -2 } })} />)
+
+    expect(screen.getByText('innate')).toBeTruthy()
+    expect(screen.queryByText(/^4\//)).toBeNull()
+  })
+})

--- a/src/app/dicebound/components/sheet.tsx
+++ b/src/app/dicebound/components/sheet.tsx
@@ -12,7 +12,8 @@
  * Skills in progress are shown too, greyed, with the progress toward the next
  * rank. Hiding them until they land would make ranks feel like they arrive at
  * random; showing the counter turns "the DM keeps asking me to balance" into
- * a goal the player can see coming.
+ * a goal the player can see coming. The counter keeps running after the first
+ * rank lands, for the same reason — see `SkillRow`.
  */
 import {
   ATTRIBUTES,
@@ -23,7 +24,7 @@ import {
   type SkillId,
 } from '@/app/dicebound/domain/attributes'
 import type { Campaign } from '@/app/dicebound/domain/campaign'
-import { RANK_THRESHOLDS, type SkillRecord, usesToNextRank } from '@/app/dicebound/domain/character'
+import { type SkillRecord, usesToNextRank } from '@/app/dicebound/domain/character'
 
 import { Powers, Standing } from './kit'
 import { WorldPanel } from './world'
@@ -144,15 +145,28 @@ function SkillRow({ skill, record }: { skill: SkillId; record: SkillRecord }) {
   // so it belongs on the sheet as a number rather than as an em dash.
   const active = record.rank !== 0
   // Innate ranks never advance, so they never show progress toward a next one.
+  // `usesToNextRank` returns null at max rank too, which is the other case with
+  // nothing left to count toward.
   const remaining = innate ? null : usesToNextRank(record.uses)
 
   return (
     <li className="flex items-baseline justify-between gap-3">
       <span className={`text-sm ${active ? 'text-on-surface' : 'text-on-surface-variant/70'}`}>
         {SKILLS[skill].name}
-        {!active && remaining !== null && (
+        {/*
+          Shown at every rank, not only before the first one. This used to be
+          gated on `!active` against a hardcoded `RANK_THRESHOLDS[0]`, which
+          meant the counter vanished the moment a skill reached +1 — and since
+          rank 2 is 8 uses and rank 3 is 18, the five or ten checks spent
+          climbing toward them were invisible on the one screen that exists to
+          record what the player did. A sheet that shows 3/3 and then nothing
+          reads as a game where +1 is the ceiling. The denominator is derived
+          from `usesToNextRank` rather than named, so it follows the thresholds
+          wherever they land next.
+        */}
+        {remaining !== null && (
           <span className="ml-2 text-xs text-on-surface-variant/60">
-            {record.uses}/{RANK_THRESHOLDS[0]}
+            {record.uses}/{record.uses + remaining}
           </span>
         )}
       </span>


### PR DESCRIPTION
Started from a question — "is it currently possible to get more than +1 in a skill?" It is: ranks land at 3, 8 and 18 uses. But the sheet gave a player no way to know that.

## The bug

`SkillRow` gated the progress counter on the skill being *unranked*, against a hardcoded first threshold:

```tsx
{!active && remaining !== null && <span>{record.uses}/{RANK_THRESHOLDS[0]}</span>}
```

It counted 0/3, 1/3, 2/3 — and disappeared the moment the rank landed. Ranks 2 and 3 are eight and eighteen uses away, so the five or ten checks spent climbing toward them showed nothing at all on the one screen that exists to record what the player did. Five checks into the climb looks identical to having just earned the rank.

The file header already stated the intent this violated: *"showing the counter turns 'the DM keeps asking me to balance' into a goal the player can see coming."* That was true until the goal was reached once.

## The fix

The counter runs at every rank, and the denominator comes from `usesToNextRank` instead of being named, so it follows `RANK_THRESHOLDS` wherever those land next. `usesToNextRank` was already being called and its result thrown away as a null check.

Unchanged: nothing renders for an innate rank, which cannot be practised, and nothing at max rank, which has nothing left to chase. Both already returned null. Styling is the same muted counter that was there before — no new affordance, it just keeps running.

**No mechanical change.** `rankFor` and `RANK_THRESHOLDS` are untouched. +2 was always reachable; it was invisible.

## Test

New `sheet.test.tsx`, five cases, covering the first rank, the climb past it, the third threshold, the maxed skill, and the innate. The second one is the regression:

```
✓ keeps counting after the first rank lands — +1 is not the ceiling
```

## What the harness says about the underlying question

A 20-turn run on `main` (with the SKILL CREDIT section from #3597):

```
turns with a check            6/20
turns that failed             0/20

checks crediting a skill       6/6
checks crediting none           0%
  Hand/Eye Coordination (seeded)  3u +1
  Resolve (seeded)           3u +1
  Balance (seeded)           3u +1
  Quickness                  3u +1
  Rapport                    1u +0
```

Zero failed turns, so the run reads clean. Two things worth separating from this PR:

- **Nothing is being dropped.** 6 of 6 checks credited a skill — `applicableSkill` threw away nothing. The slow climb is arithmetic: six checks spread over four skills puts rank 2 roughly fifty turns out.
- **The seeded skills were never called.** Hand/Eye, Resolve and Balance sit at exactly the 3 uses creation gave them. Across 20 turns the DM reached for four skills the character was never seeded with and none of the three the player's sentence bought. That's the more interesting finding and it needs a prompt change, not a display one — filed as a follow-up conversation, not in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
