### PR TITLE
feat(micro-land): elder wisdom — knowledge gap when elders die (#3455)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -608,6 +608,7 @@ export function sanitizeBlueprint(
     lateralLine: b.lateralLine === true,
     polarizedVision: b.polarizedVision === true,
     canLearnFoodWashing: !!b.canLearnFoodWashing,
+    elderWisdom: !!b.elderWisdom,
     brainSize:
       typeof b.brainSize === 'number' && b.brainSize >= 0 && b.brainSize <= 1
         ? b.brainSize

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -351,6 +351,8 @@ const STALKER = builtin('stalker', {
   glow: 0,
   // Intelligent pack hunter — capable of social learning and food preparation.
   canLearnFoodWashing: true,
+  // Pack elders carry route knowledge — their death creates a knowledge gap.
+  elderWisdom: true,
 })
 
 const DRIFTER_JELLY = builtin('drifter-jelly', {
@@ -415,6 +417,9 @@ const GULPER = builtin('gulper', {
   death: { becomes: null, particleColor: '#3f5f8a', particleCount: 12 },
   aura: null,
   glow: 0,
+  // Matriarchal pod structure — elder females lead the group to seasonal feeding
+  // grounds. Their death leaves the pod disoriented (models orca grandmother effect).
+  elderWisdom: true,
 })
 
 const CINDER_WYRM = builtin('cinder-wyrm', {
@@ -579,6 +584,8 @@ const WOOLLY = builtin('woolly', {
   glow: 0,
   // Social herd grazer — learns food preparation by watching herd-mates.
   canLearnFoodWashing: true,
+  // Herd matriarchs remember the safest grazing routes — knowledge lost with them.
+  elderWisdom: true,
 })
 
 const DRIFTMOLE = builtin('driftmole', {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -315,6 +315,19 @@ function isNearWater(w: WorldState, c: Creature): boolean {
   return false
 }
 
+/**
+ * True when this creature qualifies as an elder for its species.
+ *
+ * "Elder" = the last 35% of a creature's natural lifespan, and only for species
+ * that have opted into the elder-knowledge mechanic via `bp.elderWisdom`. Elders
+ * get an enhanced sight bonus, always emit food-location scents, and younger kin
+ * nearby learn by proximity. When all elders of a species die, the population
+ * suffers a knowledge gap until new elders emerge.
+ */
+function isElder(c: Creature, bp: CreatureBlueprint): boolean {
+  return (bp.elderWisdom ?? false) && c.ageSeconds > bp.diet.lifespanSeconds * 0.65
+}
+
 export interface SimEvent {
   /**
    * `eaten` is from the victim's side (this species lost one); `ate` is from the
@@ -1413,7 +1426,57 @@ function look(
       : 0
   const diurnalPenalty =
     Math.max(0, diurnal > 0 ? diurnal * nightFactor : -diurnal * (1 - nightFactor)) * 0.5
-  const sight = sightOf(c, bp) * (1 - diurnalPenalty)
+  const baseSight = sightOf(c, bp) * (1 - diurnalPenalty)
+
+  /**
+   * Elder wisdom sight adjustment.
+   *
+   * Elders know where food is — 1.4× sight from accumulated territory knowledge.
+   * Young creatures near an elder learn by proximity — 1.2× sight. Young creatures
+   * with no living elder of their species anywhere suffer a knowledge gap — 0.85×
+   * sight until new elders emerge. Only applies for species with elderWisdom: true.
+   *
+   * The "any elder alive" scan is O(n) but runs only when needed (non-elder of an
+   * elderWisdom species), which is a small subset of the population. The sense
+   * pass is already O(n²), so one extra O(n) scan is acceptable.
+   */
+  let elderWisdomMultiplier = 1
+  if (bp.elderWisdom) {
+    if (isElder(c, bp)) {
+      // Elders get enhanced sight — they know the territory.
+      elderWisdomMultiplier = 1.4
+    } else {
+      // Young creature: check if any elder of this species is alive.
+      let elderAlive = false
+      let elderNearby = false
+      const baseSight2 = baseSight * baseSight
+      for (const other of w.creatures) {
+        if (other.id === c.id || other.blueprintId !== c.blueprintId) continue
+        const obp = w.blueprints[other.blueprintId]
+        if (!obp) continue
+        if (isElder(other, obp)) {
+          elderAlive = true
+          // Check if this elder is within sight range for proximity learning.
+          const edx = deltaX(cx, other.x)
+          const edy = other.y - cy
+          if (edx * edx + edy * edy <= baseSight2) {
+            elderNearby = true
+            break // near an elder — no need to keep scanning
+          }
+        }
+      }
+      if (elderNearby) {
+        // Learning by proximity — the elder is right here.
+        elderWisdomMultiplier = 1.2
+      } else if (!elderAlive) {
+        // Knowledge gap — no elder of this species left in the world.
+        elderWisdomMultiplier = 0.85
+      }
+      // If elders exist but none are nearby: no bonus, no penalty.
+    }
+  }
+
+  const sight = baseSight * elderWisdomMultiplier
   const sight2 = sight * sight
 
   /**
@@ -1482,6 +1545,10 @@ function look(
           w.scents.length < 200
         ) {
           w.scents.push({ x: c.x, y: c.y, blueprintId: c.blueprintId, decaySeconds: 10 })
+        }
+        // Elder wisdom: elders always share food location regardless of cooperation.
+        if (isElder(c, bp) && bp.elderWisdom && w.scents.length < 200) {
+          w.scents.push({ x: c.x, y: c.y, blueprintId: c.blueprintId, decaySeconds: 15 })
         }
         c.mood = 'eat'
         c.targetId = null
@@ -1653,6 +1720,12 @@ function look(
           w.scents.length < 200
         ) {
           w.scents.push({ x: c.x, y: c.y, blueprintId: c.blueprintId, decaySeconds: 10 })
+        }
+        // Elder wisdom: elders always share food location with kin regardless of
+        // cooperation level. Their scents last longer (15 s vs 10 s) — the elder's
+        // knowledge of the territory persists in the world after each meal.
+        if (isElder(c, bp) && bp.elderWisdom && w.scents.length < 200) {
+          w.scents.push({ x: c.x, y: c.y, blueprintId: c.blueprintId, decaySeconds: 15 })
         }
         c.mood = 'eat'
         c.targetId = null

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -544,6 +544,20 @@ export interface CreatureBlueprint {
    * Default false; only meaningful for intelligent social animals.
    */
   canLearnFoodWashing?: boolean
+  /**
+   * Species-level opt-in to the elder knowledge mechanic.
+   *
+   * When true, creatures in the last 35% of their natural lifespan
+   * (`ageSeconds > lifespanSeconds * 0.65`) are "elders" who carry accumulated
+   * cultural knowledge: rare migration routes, drought-time water sources, safe
+   * foraging patches. Elders get a 1.4× sight bonus and always emit food-location
+   * scents after eating (regardless of cooperation level). Younger members near
+   * an elder learn by proximity (+1.2× sight). When no elder of the species
+   * survives anywhere, the population enters a knowledge gap (0.85× sight) until
+   * new elders emerge. Models elephant matriarch and orca grandmother effects.
+   * Default false; only meaningful for long-lived social animals.
+   */
+  elderWisdom?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements the elder knowledge value mechanic for the micro-land simulation. Models elephant matriarch knowledge and orca grandmother effects as described in issue #3455.

- **New `elderWisdom?: boolean` blueprint field** — species-level opt-in to the mechanic, sanitized through the existing blueprint pipeline
- **Elder detection** — a creature is an elder when `ageSeconds > lifespanSeconds * 0.65` (last 35% of natural life)
- **Three sight states for `elderWisdom` species:**
  - Elder (is one): 1.4× sight — accumulated territory knowledge
  - Young, near an elder: 1.2× sight — learning by proximity
  - Young, no elder alive anywhere: 0.85× sight — knowledge gap until new elders emerge
- **Enhanced scent emission** — elders emit 15 s food-location scents after every meal (vs 10 s for cooperative scents), unconditional on cooperation trait
- **Enabled on 3 built-in species:** Stalker (pack hunter), Woolly (herd grazer), Gulper (aquatic pod predator)

## Architecture

All changes respect the key invariants:
1. Creature is data — `isElder()` reads the blueprint, no species-specific branching
2. Every decision reads the blueprint — `bp.elderWisdom` gates all behavior
3. New field added to `types.ts` interface AND `blueprint.ts` sanitizer

The "any elder alive" scan is O(n) but only runs for non-elder creatures of `elderWisdom` species — a small subset. The sense pass is already O(n²) so this is acceptable.

## Test plan

- [ ] Load a world with Stalkers, Woollys, or Gulpers and age the simulation past their 65% lifespan threshold — elders should forage visibly further
- [ ] Verify that young creatures near an elder behave more confidently than isolated ones
- [ ] Remove all old individuals of an elderWisdom species and watch the population struggle until new elders emerge
- [ ] Confirm no behavioral change for non-`elderWisdom` species

Closes #3455

🤖 Generated with [Claude Code](https://claude.com/claude-code)