### PR TITLE
feat(micro-land): juvenile imprinting makes cultural traditions self-sustaining (#3453)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1711,7 +1711,14 @@ function look(
             const dx2 = distX(c.x, other2.x) ** 2
             const dy2 = (c.y - other2.y) ** 2
             if (dx2 + dy2 > sight * sight) continue
-            if (rng() < 0.04) other2.learnedFoodWashing = true
+            // Juvenile imprinting: creatures in the first 15% of their lifespan
+            // learn cultural behaviors from nearby adults at 10× the adult rate.
+            // This models parental-care transmission (orca, chimpanzee research):
+            // once a tradition reaches critical mass, offspring born nearby almost
+            // always acquire it before adulthood, making the tradition self-sustaining.
+            const isJuvenile = other2.ageSeconds < (w.blueprints[other2.blueprintId]?.diet.lifespanSeconds ?? 240) * 0.15
+            const transmissionProb = isJuvenile ? 0.40 : 0.04
+            if (rng() < transmissionProb) other2.learnedFoodWashing = true
           }
         }
         // Cooperative creatures signal food location to kin.


### PR DESCRIPTION
## Summary

Implements [#3453](https://github.com/nickolu/CometCave/issues/3453) — cultural tradition persistence via family transmission.

- **Single-file change** in `src/app/micro-land/domain/sim/creature-sim.ts`
- In the existing cultural transmission loop (food-washing near water), creatures in the **first 15% of their lifespan** now learn the behavior at **40% probability per observation** (10× the adult rate of 4%)
- Juvenile imprinting is computed by comparing `other2.ageSeconds` against `lifespanSeconds * 0.15`, with a fallback lifespan of 240s for species missing the field
- Adult-to-adult transmission rate is unchanged at 4%

## How it makes traditions self-sustaining

Without this change, cultural transmission relied solely on slow adult-to-adult spread (4% per tick when near water). A behavior could easily die out between generations if the social network was sparse.

With juvenile imprinting: once a behavior reaches a local majority, nearly every juvenile born into the group (and spending time near adults) acquires it before reaching adulthood. The tradition persists even if adult-to-adult transmission would otherwise let it fade — mirroring documented orca and chimpanzee cultural learning dynamics.

## Test plan

- [ ] Launch micro-land with a species that has `canLearnFoodWashing: true`
- [ ] Observe that young creatures near food-washing adults acquire the behavior rapidly
- [ ] Confirm adult-to-adult spread is still visible but slower
- [ ] Confirm creatures with `learnedFoodWashing` already set are skipped (existing guard in the loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)