### PR TITLE
feat(micro-land): drip water nutrient import — cave bacteria bloom under surface water

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -57,6 +57,7 @@ import {
   settleOnGround,
   solidAt,
   spawnCreature,
+  tickCaveNutrient,
   tickMoisture,
   tileAt,
 } from './world'
@@ -258,6 +259,9 @@ function fertilityAt(w: WorldState, x: number, y: number): number {
       f = 0.4
       break
     case 'stone':
+      // Base fertility on cave nutrient — drip water creates bacterial blooms.
+      f = 0.05 + ((w.caveNutrient?.[yi * WORLD_W + xi] ?? 0) * 1.5)
+      break
     case 'obsidian':
     case 'marble':
       f = 0.3
@@ -594,6 +598,7 @@ export function tickCreatures(
   w.scents ??= []
   w.moisture ??= new Float32Array(WORLD_W * WORLD_H)
   tickMoisture(w, tickCount, dt, rng)
+  tickCaveNutrient(w, tickCount, dt)
   w.eggs ??= []
   w.nextEggId ??= 1
 

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -942,6 +942,45 @@ export function tickMoisture(w: WorldState, tickCount: number, dt: number, rng: 
   }
 }
 
+/**
+ * Update the cave-nutrient field — drip water from surface pools carries
+ * dissolved organic matter down through stone, nourishing cave bacteria.
+ * Runs at the same cadence as tickMoisture (every 30 ticks).
+ */
+export function tickCaveNutrient(w: WorldState, tickCount: number, dt: number): void {
+  if (tickCount % 30 !== 0) return
+  w.caveNutrient ??= new Float32Array(WORLD_W * WORLD_H)
+  const timePassed = 30 / 60
+  const stoneIdx = MATERIAL_INDEX.stone
+  const waterIdx = MATERIAL_INDEX.water
+
+  // Decay all cave nutrient slowly.
+  for (let i = 0; i < WORLD_W * WORLD_H; i++) {
+    if (w.caveNutrient[i] > 0) {
+      w.caveNutrient[i] = Math.max(0, w.caveNutrient[i] - 0.003 * timePassed)
+    }
+  }
+
+  // Drip: for each water tile in the upper half of the world, look downward
+  // for the first stone tile within 40 rows. Check every 4th column to stay cheap.
+  for (let x = 0; x < WORLD_W; x += 4) {
+    for (let y = 0; y < Math.floor(WORLD_H / 2); y++) {
+      if (w.tiles[y * WORLD_W + x] !== waterIdx) continue
+      for (let dy = 1; dy <= 40; dy++) {
+        const ty = y + dy
+        if (ty >= WORLD_H) break
+        const ti = ty * WORLD_W + x
+        if (w.tiles[ti] === stoneIdx) {
+          w.caveNutrient[ti] = Math.min(1, w.caveNutrient[ti] + 0.015 * timePassed)
+          break
+        }
+        // Stop looking if we hit another liquid (no further drip through pooled water)
+        if (IS_LIQUID[w.tiles[ti]] === 1) break
+      }
+    }
+  }
+}
+
 export function countByBlueprint(w: WorldState): Record<string, number> {
   const counts: Record<string, number> = {}
   for (const c of w.creatures) counts[c.blueprintId] = (counts[c.blueprintId] ?? 0) + 1

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1104,6 +1104,13 @@ export interface WorldState {
    * slowly dry out. Plants seed more readily in moist soil.
    */
   moisture: Float32Array
+  /**
+   * Per-tile dissolved organic carbon from surface water drips.
+   * 0 in dry caves; up to 1 under active drip points (where surface water
+   * percolates through stone). Boosts stone tile fertility for cave bacteria
+   * and specialist cave plants. Updated by `tickCaveNutrient`.
+   */
+  caveNutrient?: Float32Array
   eggs: Egg[]
   nextEggId: number
   /** Burrows dug by territorial creatures at their home positions. */


### PR DESCRIPTION
Implements #3435.

## What

Adds a `caveNutrient` overlay (Float32Array, same pattern as `moisture`) that tracks dissolved organic matter from surface water drips. Surface water tiles in the upper half of the world drip nutrients down through stone, reaching the first stone tile within 40 rows.

Stone tiles under active drips accumulate nutrient (up to 1.0), which boosts their fertility from 0.05 (base) to 1.55 (fully saturated). This enables cave-adapted plants to establish and thrive under drip points.

## Mechanics

- **Update cadence:** Every 30 ticks (same as moisture) — scans every 4th column in upper half
- **Drip:** Water tile → look down ≤40 tiles → first stone tile gets +0.015 per update
- **Decay:** 0.003/s — drip cessation starves the cave ecosystem bottom-up
- **Fertility effect:** `stone fertility = 0.05 + (caveNutrient × 1.5)` (was fixed 0.3)

## Ecological model

Without drips, stone tiles are almost barren (fertility 0.05). With active drips, they can sustain productive cave ecosystems (fertility up to 1.55, matching mud). During droughts (reduced surface water), drips stop and cave productivity collapses — matching documented cave ecosystem dynamics.

## Test plan
- [x] Tuning tests pass
- [ ] Vercel CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)