### PR TITLE
feat(micro-land): salinity gradient, osmotic stress, and nursery habitat

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -598,6 +598,9 @@ export function sanitizeBlueprint(
       : b.trapType === 'pitfall' ? 'pitfall'
       : b.trapType === 'sticky' ? 'sticky'
       : undefined,
+    salinityTolerance: b.salinityTolerance && typeof (b.salinityTolerance as Record<string, unknown>).min === 'number' && typeof (b.salinityTolerance as Record<string, unknown>).max === 'number'
+      ? { min: Math.max(0, (b.salinityTolerance as { min: number; max: number }).min), max: Math.min(1, (b.salinityTolerance as { min: number; max: number }).max) }
+      : undefined,
     slowMetabolism: b.slowMetabolism === true,
     invasive: b.invasive === true,
     allelopathic: b.allelopathic === true,

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -384,6 +384,7 @@ const FINLING = builtin('finling', {
   aura: null,
   glow: 0,
   phenology: { breedingGdd: 500 }, // midsummer spawner like many fish species
+  salinityTolerance: { min: 0.3, max: 1.0 },  // euryhaline — tolerates brackish to marine
 })
 
 const EMBER_GRUB = builtin('ember-grub', {
@@ -1628,6 +1629,38 @@ const UNICYCLE_CLOWN = builtin('unicycle-clown', {
   glow: 0,
 })
 
+const SALT_MARSH_REED = builtin('salt-marsh-reed', {
+  name: 'Salt Marsh Reed',
+  blurb: 'Thrives where the river meets the sea. Nothing else will grow here.',
+  size: 2,
+  tags: ['plant', 'grass'],
+  art: {
+    palette: { g: '#4a7a3a', y: '#8a9a3a', t: '#3a6a2a' },
+    frames: [
+      ['g.g.g', 'gyggy', 'ggggg', '.g.g.', '..g..'],
+      ['g.g.g', 'ygggy', 'ggggg', '.g.g.', '..g..'],
+    ],
+    frameMs: 600,
+    faceMotion: false,
+  },
+  body: { mass: 1, bounce: 0, drag: 0.2, buoyancy: 0.8, immuneTo: [] },
+  move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+  diet: {
+    eats: [],
+    fears: [],
+    hungerRate: 0,
+    starveSeconds: 999,
+    breedAt: 0.2,
+    lifespanSeconds: 400,
+  },
+  senses: { sight: 1 },
+  habitat: { needs: null, drowns: false },
+  death: { becomes: null, particleColor: '#4a7a3a', particleCount: 4 },
+  aura: null,
+  glow: 0,
+  salinityTolerance: { min: 0.2, max: 0.7 },  // thrives in brackish mixing zone
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -1636,6 +1669,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   FROSTCAP,
   GLOWVINE,
   SKYBLOOM,
+  SALT_MARSH_REED,
   SNAP_TRAP,
   PITCHER_PLANT,
   SUNDEW,

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -59,6 +59,7 @@ import {
   spawnCreature,
   tickCaveNutrient,
   tickMoisture,
+  tickSalinity,
   tileAt,
 } from './world'
 
@@ -607,6 +608,7 @@ export function tickCreatures(
   w.moisture ??= new Float32Array(WORLD_W * WORLD_H)
   tickMoisture(w, tickCount, dt, rng)
   tickCaveNutrient(w, tickCount, dt)
+  tickSalinity(w, tickCount)
   w.eggs ??= []
   w.nextEggId ??= 1
 
@@ -772,6 +774,27 @@ export function tickCreatures(
       const effectiveBreedingGdd = bp.phenology.breedingGdd + (c.phenoOffset ?? 0)
       const mismatch = Math.abs(effectiveBreedingGdd - 500) / 500
       c.hunger = Math.min(1, c.hunger + mismatch * 0.00008 * dt)
+    }
+    // Osmotic stress: creatures outside their salinity tolerance range
+    // spend energy on osmoregulation. No effect when salinity is not enabled.
+    if (bp.salinityTolerance && w.salinity) {
+      const cx = Math.floor(c.x)
+      const cy = Math.floor(c.y)
+      if (cx >= 0 && cx < WORLD_W && cy >= 0 && cy < WORLD_H) {
+        const tileSalinity = w.salinity[cy * WORLD_W + cx] ?? 0
+        const { min, max } = bp.salinityTolerance
+        if (tileSalinity < min) {
+          const stress = (min - tileSalinity) * 0.0002 * dt
+          c.hunger = Math.min(1, c.hunger + stress)
+        } else if (tileSalinity > max) {
+          const stress = (tileSalinity - max) * 0.0002 * dt
+          c.hunger = Math.min(1, c.hunger + stress)
+        } else if (c.ageSeconds < (bp.diet.lifespanSeconds ?? 240) * 0.15) {
+          // Nursery habitat: juveniles in optimal salinity zone get a feeding bonus.
+          // Models documented estuarine nursery function for juvenile marine fish.
+          c.hunger = Math.max(0, c.hunger - 0.00005 * dt)
+        }
+      }
     }
     if (c.hunger >= 1) {
       c.starving += dt

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -42,7 +42,7 @@ export function createWorld(seed = 1337): WorldState {
   const blueprints: Record<string, CreatureBlueprint> = {}
   for (const bp of BUILTIN_CREATURES) blueprints[bp.id] = bp
 
-  return {
+  const world: WorldState = {
     width: WORLD_W,
     height: WORLD_H,
     tiles,
@@ -71,6 +71,8 @@ export function createWorld(seed = 1337): WorldState {
     nextSpawnerId: 1,
     generators: [],
   }
+  if (TUNING.estuaryOceanFraction > 0) initSalinity(world)
+  return world
 }
 
 // ---------------------------------------------------------------------------
@@ -978,6 +980,54 @@ export function tickCaveNutrient(w: WorldState, tickCount: number, dt: number): 
         if (IS_LIQUID[w.tiles[ti]] === 1) break
       }
     }
+  }
+}
+
+/**
+ * Initialise the salinity overlay based on TUNING.estuaryOceanFraction.
+ * Ocean tiles (right edge) start at 1.0; fresh tiles (left edge) start at 0.0.
+ * Called once on world creation when estuaryOceanFraction > 0.
+ */
+export function initSalinity(w: WorldState): void {
+  if (TUNING.estuaryOceanFraction <= 0) return
+  w.salinity ??= new Float32Array(WORLD_W * WORLD_H)
+  const oceanStart = Math.floor(WORLD_W * (1 - TUNING.estuaryOceanFraction))
+  for (let y = 0; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) {
+      const i = y * WORLD_W + x
+      if (x >= oceanStart) {
+        w.salinity[i] = 1.0
+      } else {
+        w.salinity[i] = 0.0
+      }
+    }
+  }
+}
+
+/**
+ * Diffuse the salinity gradient — runs every 60 ticks to let the gradient
+ * stabilise without dominating the frame budget.
+ * Ocean edge is held at 1.0; fresh (left 20%) at 0.0. Interior diffuses.
+ */
+export function tickSalinity(w: WorldState, tickCount: number): void {
+  if (!w.salinity || TUNING.estuaryOceanFraction <= 0 || tickCount % 60 !== 0) return
+  const oceanStart = Math.floor(WORLD_W * (1 - TUNING.estuaryOceanFraction))
+  const freshEnd = Math.floor(WORLD_W * 0.1)  // leftmost 10% stays fresh
+  const alpha = 0.05  // diffusion rate
+  // Simple averaging diffusion — one pass per update
+  for (let y = 0; y < WORLD_H; y++) {
+    for (let x = freshEnd; x < oceanStart; x++) {
+      const i = y * WORLD_W + x
+      const left = w.salinity[y * WORLD_W + (x - 1)] ?? 0
+      const right = w.salinity[y * WORLD_W + (x + 1)] ?? 0
+      w.salinity[i] += alpha * (left + right - 2 * w.salinity[i])
+      w.salinity[i] = Math.max(0, Math.min(1, w.salinity[i]))
+    }
+  }
+  // Reinforce boundary conditions.
+  for (let y = 0; y < WORLD_H; y++) {
+    for (let x = 0; x < freshEnd; x++) w.salinity[y * WORLD_W + x] = 0
+    for (let x = oceanStart; x < WORLD_W; x++) w.salinity[y * WORLD_W + x] = 1
   }
 }
 

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -135,6 +135,11 @@ export const TUNING_DEFAULTS = {
   generatorRateMultiplier: 1.0,
   /** Max placed spawners the world can hold at once. */
   maxSpawners: 20,
+  /**
+   * Fraction of world width designated as "ocean" on the right edge.
+   * 0 = no estuary (default). 0.15 = rightmost 15% is salt water.
+   */
+  estuaryOceanFraction: 0,
 }
 
 export type TuningKey = keyof typeof TUNING_DEFAULTS
@@ -495,6 +500,15 @@ export const KNOBS: Knob[] = [
     max: 600,
     step: 10,
     unit: 's',
+  },
+  {
+    key: 'estuaryOceanFraction',
+    group: 'world',
+    label: 'Estuary — ocean fraction',
+    help: 'Fraction of the world width that is salt water (right edge). 0 = disabled. 0.15 creates an estuary mixing zone in the middle. Requires world restart to take effect.',
+    min: 0,
+    max: 0.5,
+    step: 0.05,
   },
   {
     key: 'eggHatchSeconds',

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -430,6 +430,12 @@ export interface CreatureBlueprint {
    */
   trapType?: 'snap' | 'pitfall' | 'sticky'
   /**
+   * Salinity tolerance range [min, max] for estuarine creatures.
+   * Creatures outside this range pay an osmotic-stress hunger penalty.
+   * undefined = no salinity constraint (works in any salinity).
+   */
+  salinityTolerance?: { min: number; max: number }
+  /**
    * Drastically reduced basal metabolic rate — inspired by cave-adapted
    * species (cave olm, cave fish) that can survive months without food.
    *
@@ -1137,6 +1143,12 @@ export interface WorldState {
    * and specialist cave plants. Updated by `tickCaveNutrient`.
    */
   caveNutrient?: Float32Array
+  /**
+   * Per-tile salinity, 0 (fresh) to 1 (salt water). Initialized from
+   * world edges when estuaryEnabled, diffused each tick. Creates a mixing
+   * zone (estuary) in the middle of the world.
+   */
+  salinity?: Float32Array
   eggs: Egg[]
   nextEggId: number
   /** Burrows dug by territorial creatures at their home positions. */


### PR DESCRIPTION
Implements #3464, #3465, #3467.

## What

Adds a `salinity` overlay (Float32Array) to WorldState. When `estuaryOceanFraction > 0`, the right portion of the world is marine (1.0) and diffusion creates a brackish mixing zone — an estuary.

## Mechanics

| Feature | Detail |
|---|---|
| Salinity init | Right edge = 1.0 (ocean), left = 0.0 (river), middle diffuses |
| Diffusion | Every 60 ticks, α=0.05 lateral diffusion |
| Osmotic stress | Outside `salinityTolerance`: hunger += deviation × 0.0002 × dt |
| Nursery bonus | Juvenile (< 15% lifespan) in optimal zone: hunger −0.00005 × dt |

## Species configured

- **Finling** — `salinityTolerance: { min: 0.3, max: 1.0 }` (euryhaline marine fish)
- **Salt Marsh Reed** — new plant, `salinityTolerance: { min: 0.2, max: 0.7 }`, thrives in the brackish mixing zone

## Tuning knob

`estuaryOceanFraction` (0–0.5, default 0) — fraction of world width that is ocean. Set to 0.15 to create an estuary.

## Test plan
- [x] Tuning tests pass
- [ ] Vercel CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)