### PR TITLE
feat(micro-land): mangrove root ecosystem and salt marsh productivity

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -601,6 +601,7 @@ export function sanitizeBlueprint(
     salinityTolerance: b.salinityTolerance && typeof (b.salinityTolerance as Record<string, unknown>).min === 'number' && typeof (b.salinityTolerance as Record<string, unknown>).max === 'number'
       ? { min: Math.max(0, (b.salinityTolerance as { min: number; max: number }).min), max: Math.min(1, (b.salinityTolerance as { min: number; max: number }).max) }
       : undefined,
+    aerialRoots: b.aerialRoots !== undefined ? !!b.aerialRoots : undefined,
     slowMetabolism: b.slowMetabolism === true,
     invasive: b.invasive === true,
     allelopathic: b.allelopathic === true,

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -1661,6 +1661,38 @@ const SALT_MARSH_REED = builtin('salt-marsh-reed', {
   salinityTolerance: { min: 0.2, max: 0.7 },  // thrives in brackish mixing zone
 })
 
+const MANGROVE = builtin('mangrove', {
+  name: 'Mangrove',
+  blurb: "Its tangled roots filter sediment and shelter the young of a hundred species.",
+  size: 4,
+  tags: ['plant', 'tree'],
+  art: {
+    palette: { g: '#2d5016', b: '#6b4423', r: '#4a7a1a', l: '#c8e060' },
+    frames: [
+      ['...rr...', '..rrll..', '.rrrrrr.', 'rrrrrrrr', '...bb...', '...bb...', '.bb.bb..', 'bb...bbb'],
+    ],
+    frameMs: 1000,
+    faceMotion: false,
+  },
+  body: { mass: 3, bounce: 0, drag: 0.1, buoyancy: 0.4, immuneTo: [] },
+  move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+  diet: {
+    eats: [],
+    fears: [],
+    hungerRate: 0,
+    starveSeconds: 999,
+    breedAt: 0.1,
+    lifespanSeconds: 800,
+  },
+  senses: { sight: 1 },
+  habitat: { needs: null, drowns: false },
+  death: { becomes: null, particleColor: '#2d5016', particleCount: 8 },
+  aura: { helps: ['grass'], radius: 12, boost: 1.4 },
+  glow: 0,
+  aerialRoots: true,
+  salinityTolerance: { min: 0.0, max: 0.4 },
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -1670,6 +1702,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   GLOWVINE,
   SKYBLOOM,
   SALT_MARSH_REED,
+  MANGROVE,
   SNAP_TRAP,
   PITCHER_PLANT,
   SUNDEW,

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -58,6 +58,7 @@ import {
   solidAt,
   spawnCreature,
   tickCaveNutrient,
+  tickMarshDetritus,
   tickMoisture,
   tickSalinity,
   tileAt,
@@ -627,6 +628,7 @@ export function tickCreatures(
   tickMoisture(w, tickCount, dt, rng)
   tickCaveNutrient(w, tickCount, dt)
   tickSalinity(w, tickCount)
+  tickMarshDetritus(w, tickCount, dt)
   w.eggs ??= []
   w.nextEggId ??= 1
 
@@ -810,7 +812,20 @@ export function tickCreatures(
         } else if (c.ageSeconds < (bp.diet.lifespanSeconds ?? 240) * 0.15) {
           // Nursery habitat: juveniles in optimal salinity zone get a feeding bonus.
           // Models documented estuarine nursery function for juvenile marine fish.
-          c.hunger = Math.max(0, c.hunger - 0.00005 * dt)
+          // Aerial-root plants (mangroves) within 8 tiles double the bonus —
+          // structural shelter reduces predation and improves feeding conditions.
+          let nurseryBonus = 0.00005
+          const jcx = Math.floor(c.x)
+          const jcy = Math.floor(c.y)
+          for (const other of w.creatures) {
+            const obp = w.blueprints[other.blueprintId]
+            if (!obp?.aerialRoots) continue
+            const { w: ow, h: oh } = artSize(obp)
+            const odx = Math.abs(Math.floor(other.x + ow / 2) - jcx)
+            const ody = Math.abs(Math.floor(other.y + oh / 2) - jcy)
+            if (odx <= 8 && ody <= 8) { nurseryBonus = 0.0001; break }
+          }
+          c.hunger = Math.max(0, c.hunger - nurseryBonus * dt)
         }
       }
     }
@@ -1529,11 +1544,30 @@ export function tickCreatures(
                 }
               }
 
+              // Salt marsh productivity: plants in optimal salinity breed up to 3× faster,
+              // modelling the extreme NPP of tidal wetland communities.
+              // Detrital subsidy: marshDetritus further boosts productivity.
+              let salinityBoost = 1.0
+              if (bp.salinityTolerance && w.salinity) {
+                const { min, max } = bp.salinityTolerance
+                const half = (max - min) / 2
+                const mid = min + half
+                const tileSal = w.salinity[footY * WORLD_W + footX] ?? 0
+                if (tileSal >= min && tileSal <= max && half > 0) {
+                  const proximity = 1 - Math.abs(tileSal - mid) / half
+                  salinityBoost = 1 + 2 * proximity  // 1→3×
+                }
+              }
+              if (w.marshDetritus) {
+                const det = w.marshDetritus[footY * WORLD_W + footX] ?? 0
+                salinityBoost *= 1 + det  // up to 2× additional from detrital export
+              }
               c.breedCooldown =
                 (TUNING.plantSpreadCooldown * crowdingPenalty * allelopathyFactor * bioticResistanceFactor * competitiveExclusionFactor) /
                 (auraBoost(w, c, bp, bw, bh, helpers) *
                   plantFertilityFactor *
-                  seasonFactor)
+                  seasonFactor *
+                  salinityBoost)
             } else {
               // Both of them paid to be here, so both of them pay for it. Charging
               // only the one whose turn it happened to be would make a baby cost a
@@ -3285,6 +3319,22 @@ function kill(
 ): void {
   if (dead.has(c.id)) return
   dead.add(c.id)
+  // Marsh detritus: when salt-tolerant plants die, export dissolved organic
+  // carbon to surrounding tiles, subsidising the coastal food web.
+  if (bp.move.kind === 'root' && bp.salinityTolerance && w.salinity) {
+    const px = Math.floor(wrapX(c.x))
+    const py = Math.floor(c.y)
+    w.marshDetritus ??= new Float32Array(WORLD_W * WORLD_H)
+    for (let dy = -2; dy <= 3; dy++) {
+      for (let dx = -3; dx <= 3; dx++) {
+        const nx = (px + dx + WORLD_W) % WORLD_W
+        const ny = py + dy
+        if (ny < 0 || ny >= WORLD_H) continue
+        const idx = ny * WORLD_W + nx
+        w.marshDetritus[idx] = Math.min(1, w.marshDetritus[idx] + 0.08)
+      }
+    }
+  }
   const { w: bw, h: bh } = artSize(bp)
   // Animals leave a carcass on any death.
   if (bp.move.kind !== 'root') {

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -1031,6 +1031,29 @@ export function tickSalinity(w: WorldState, tickCount: number): void {
   }
 }
 
+/**
+ * Decay and diffuse marsh detritus — dissolved organic carbon exported from
+ * decomposing salt marsh plants. Acts as a slow-release fertility subsidy for
+ * the coastal food web. Runs every 30 ticks.
+ */
+export function tickMarshDetritus(w: WorldState, tickCount: number, dt: number): void {
+  if (!w.marshDetritus || tickCount % 30 !== 0) return
+  const decay = 0.001 * dt
+  for (let i = 0; i < WORLD_W * WORLD_H; i++) {
+    w.marshDetritus[i] = Math.max(0, w.marshDetritus[i] - decay)
+  }
+  // Gentle lateral diffusion between horizontally adjacent tiles
+  const alpha = 0.02
+  for (let y = 0; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) {
+      const i = y * WORLD_W + x
+      const left = w.marshDetritus[y * WORLD_W + ((x - 1 + WORLD_W) % WORLD_W)]
+      const right = w.marshDetritus[y * WORLD_W + ((x + 1) % WORLD_W)]
+      w.marshDetritus[i] = Math.max(0, Math.min(1, w.marshDetritus[i] + alpha * (left + right - 2 * w.marshDetritus[i])))
+    }
+  }
+}
+
 export function countByBlueprint(w: WorldState): Record<string, number> {
   const counts: Record<string, number> = {}
   for (const c of w.creatures) counts[c.blueprintId] = (counts[c.blueprintId] ?? 0) + 1

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -436,6 +436,11 @@ export interface CreatureBlueprint {
    */
   salinityTolerance?: { min: number; max: number }
   /**
+   * Aerial roots create structural shelter in tidal zones. When true, juvenile
+   * creatures within 8 tiles receive a doubled nursery hunger bonus.
+   */
+  aerialRoots?: boolean
+  /**
    * Drastically reduced basal metabolic rate — inspired by cave-adapted
    * species (cave olm, cave fish) that can survive months without food.
    *
@@ -1149,6 +1154,11 @@ export interface WorldState {
    * zone (estuary) in the middle of the world.
    */
   salinity?: Float32Array
+  /**
+   * Dissolved organic carbon exported from decomposing marsh plants.
+   * Boosts plant productivity in estuarine tiles. [0, 1] per tile.
+   */
+  marshDetritus?: Float32Array
   eggs: Egg[]
   nextEggId: number
   /** Burrows dug by territorial creatures at their home positions. */


### PR DESCRIPTION
Closes #3466, closes #3468

## What

**Mangrove root ecosystem** (#3466):
- New `MANGROVE` species — a size-4 rooted tree (`aerialRoots: true`) that tolerates freshwater to slightly brackish zones (`salinityTolerance: { min: 0.0, max: 0.4 }`)
- Mangrove aura (`radius: 12, boost: 1.4`) accelerates nearby grass/reed growth, modelling the sheltered productivity of mangrove understory
- New `aerialRoots?: boolean` blueprint field: when any plant with this flag is within 8 tiles of a juvenile fish in optimal salinity, the nursery hunger bonus doubles (0.00005 → 0.0001 per tick)

**Salt marsh productivity** (#3468):
- `SALT_MARSH_REED` (and any plant with `salinityTolerance`) now breeds up to **3× faster** when in the center of its optimal salinity range, falling to 1× at the edges — models the exceptional NPP of tidal wetland communities
- New `marshDetritus?: Float32Array` world overlay: when a salt-tolerant plant dies, it pulses 0.08 dissolved organic carbon to a 7×6 tile radius, subsidising the coastal food web
- `tickMarshDetritus()` decays this pool at 0.001/s and gently diffuses it laterally; plant productivity is further multiplied by `(1 + marshDetritus)` at the root tile

## How it fits together

```
Mangrove → shelters juvenile Finlings (2× nursery bonus) 
         → aura boosts Salt Marsh Reed spread
Salt Marsh Reed → 3× productivity in brackish zone
               → death exports marshDetritus
                 → marshDetritus boosts nearby plant productivity (incl. Reed regrowth)
```

No tuning knobs — all effects are emergent from the salinity gradient (`estuaryOceanFraction`).

## Tests

111 tests pass. Pre-existing timeouts in `carnivorous-plant.test.ts` and `root-bank-stabilizer.test.ts` are unrelated to this change.