### PR TITLE
feat(micro-land): bat guano food web — cave bats subsidise cave ecology

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -593,6 +593,7 @@ export function sanitizeBlueprint(
     bioturbator: b.bioturbator === true,
     rootBankStabilizer: b.rootBankStabilizer === true,
     polluter: b.polluter === true,
+    caveBat: b.caveBat !== undefined ? !!b.caveBat : undefined,
     carnivorousPlant: b.carnivorousPlant === true,
     trapType: b.trapType === 'snap' ? 'snap'
       : b.trapType === 'pitfall' ? 'pitfall'

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -1221,6 +1221,75 @@ const CRYSTAL_SNAIL = builtin('crystal-snail', {
 })
 
 // ---------------------------------------------------------------------------
+// The cave food web — bat guano subsidises fungi, fungi feed cave crickets,
+// cave crickets feed bats. The caveNutrient overlay carries the signal.
+// ---------------------------------------------------------------------------
+
+const CAVE_CRICKET = builtin('cave-cricket', {
+  name: 'Cave Cricket',
+  blurb: 'Feeds on fungus and bat droppings. Sees nothing; feels everything.',
+  size: 2,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { t: '#a08060', d: '#5a4030', l: '#c0a878' },
+    frames: [
+      ['t.t.t', 'ttttt', '.tdt.', 't...t'],
+      ['.t.t.', 'ttttt', '.tdt.', 't...t'],
+    ],
+    frameMs: 300,
+    faceMotion: true,
+  },
+  body: { mass: 0.8, bounce: 0.1, drag: 0.3, buoyancy: 0.4, immuneTo: [] },
+  move: { kind: 'crawl', speed: 2.5, jump: 4, restlessness: 0.3 },
+  diet: {
+    eats: ['fungus'],
+    fears: ['flier'],
+    hungerRate: 0.025,
+    starveSeconds: 40,
+    breedAt: 0.65,
+    lifespanSeconds: 160,
+  },
+  senses: { sight: 6 },
+  habitat: { needs: null, drowns: false },
+  death: { becomes: null, particleColor: '#a08060', particleCount: 3 },
+  aura: null,
+  glow: 0,
+})
+
+const BAT = builtin('bat', {
+  name: 'Bat',
+  blurb: 'Sleeps through the day, slips out at dusk to hunt. Its droppings feed the dark.',
+  size: 2,
+  tags: ['meat', 'flier'],
+  art: {
+    palette: { d: '#2a1a2e', g: '#6b3a6e', w: '#c0a0c8' },
+    frames: [
+      ['dggd', '.gg.', '.ww.'],
+      ['g..g', 'gggg', '.ww.'],
+    ],
+    frameMs: 120,
+    faceMotion: true,
+  },
+  body: { mass: 0.3, bounce: 0.1, drag: 0.5, buoyancy: 0.2, immuneTo: [] },
+  move: { kind: 'crawl', speed: 6, jump: 0, restlessness: 0.6 },
+  diet: {
+    eats: ['bug', 'flier'],
+    fears: [],
+    hungerRate: 0.04,
+    starveSeconds: 25,
+    breedAt: 0.7,
+    lifespanSeconds: 300,
+  },
+  senses: { sight: 14 },
+  habitat: { needs: null, drowns: false },
+  death: { becomes: null, particleColor: '#6b3a6e', particleCount: 4 },
+  aura: null,
+  glow: 0,
+  traitDefaults: { diurnal: -1 },  // nocturnal — hunts at dusk/night
+  caveBat: true,
+})
+
+// ---------------------------------------------------------------------------
 // The big ones
 //
 // Every one of these was authored by the model through the ordinary summon
@@ -1731,6 +1800,8 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   RIMECLAW,
   SUNHAWK,
   GLOOMWEAVER,
+  CAVE_CRICKET,
+  BAT,
   WISP,
   GRUMBLESTONE,
   TREX,

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1267,6 +1267,22 @@ export function tickCreatures(
       }
     }
 
+    // Cave bat guano: underground bats continuously deposit guano on floor tiles,
+    // subsidising the cave food web through the caveNutrient overlay.
+    // SPORECAP fungi grow faster on guano-enriched stone; cave crickets follow.
+    if (bp.caveBat && isUnderground(w, c)) {
+      const gx = Math.floor(c.x + bw / 2)
+      const gy = Math.floor(c.y + bh)  // floor tile directly below bat
+      w.caveNutrient ??= new Float32Array(WORLD_W * WORLD_H)
+      for (let dx = -2; dx <= 2; dx++) {
+        const tx = (gx + dx + WORLD_W) % WORLD_W
+        if (gy >= 0 && gy < WORLD_H) {
+          const idx = gy * WORLD_W + tx
+          w.caveNutrient[idx] = Math.min(1, (w.caveNutrient[idx] ?? 0) + 0.0002 * dt)
+        }
+      }
+    }
+
     // Industrial pollution: creatures with polluter flag deposit soot (ash) on
     // the tiles they walk through, darkening the substrate and creating selection
     // pressure for cryptic variants with ash-hue colouring (industrial melanism).

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -408,6 +408,11 @@ export interface CreatureBlueprint {
    */
   polluter?: boolean
   /**
+   * Cave bats roost on underground surfaces. While underground they slowly
+   * deposit guano onto floor tiles, boosting caveNutrient for cave plant growth.
+   */
+  caveBat?: boolean
+  /**
    * Plants that supplement nutrient-poor substrate by trapping and digesting prey.
    *
    * Inverts the fertility curve: carnivorous plants breed *faster* on low-fertility


### PR DESCRIPTION
Closes #3434

## What

Cave-dwelling bats roost underground during the day and deposit guano that feeds the cave food web. Two new species and one new blueprint field:

**`BAT`** — nocturnal crawler (`traitDefaults: { diurnal: -1 }`, `caveBat: true`):
- Hunts bugs and other fliers at night on the surface (no nocturnal penalty)
- Retreats underground at dawn (daytime surface penalty keeps them cave-bound)
- While underground, continuously deposits guano to floor tiles beneath them (`caveNutrient += 0.0002 * dt` per tick across a 5-tile strip)

**`CAVE_CRICKET`** — cave detritivore:
- Feeds on `'fungus'` (i.e. `SPORECAP`, which grows faster on guano-enriched cave stone)
- Flees `'flier'` tag creatures (bats)
- Bridges the gap between fungal mat and bat predation

**Food web:**
```
Bat guano → caveNutrient overlay → SPORECAP grows faster on enriched stone
→ Cave Cricket eats SPORECAP → Bat eats Cave Cricket
```

The `fertilityAt()` function already reads `caveNutrient` for stone tiles (`0.05 + nutrient * 1.5`), so SPORECAP and other cave plants respond to bat populations automatically — no new code needed there.

## New blueprint field

`caveBat?: boolean` — when true, the creature deposits guano while underground. Sanitized in `blueprint.ts`.

## Tests

All previously-passing tests continue to pass.