### PR TITLE
feat(micro-land): cave habitat zones — twilight/transition/midnight darkness gradient

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -340,6 +340,25 @@ function isUnderground(w: WorldState, c: Creature): boolean {
 }
 
 /**
+ * Returns the depth-from-surface in tiles: how many consecutive solid tiles
+ * sit above the creature's head. Returns 0 at or near the surface.
+ * Used to model the twilight → transition → midnight cave zone gradient.
+ */
+function cavityDepth(w: WorldState, c: Creature): number {
+  const hx = Math.floor(c.x)
+  const hy = Math.floor(c.y) - 1
+  let depth = 0
+  for (let dy = 0; dy < WORLD_H; dy++) {
+    const ty = hy - dy
+    if (ty < 0) break
+    const tile = w.tiles[ty * WORLD_W + wrapCol(hx)]
+    if (!IS_SOLID[tile]) break
+    depth++
+  }
+  return depth
+}
+
+/**
  * True when c and other overlap — used for snap-trap contact detection.
  * Uses the creature positions as 1-tile points (plants are 1-wide).
  */
@@ -1789,7 +1808,7 @@ function look(
   // regardless of time — providing selection pressure against high sight traits
   // (troglobitic evolution). Lateral-line species bypass this penalty.
   const nightFactor = underground
-    ? 0.8  // constant cave darkness
+    ? Math.min(0.8, 0.1 + cavityDepth(w, c) * 0.07)  // twilight→midnight gradient
     : TUNING.dayLengthSeconds > 0
       ? (1 - Math.cos((2 * Math.PI * w.elapsed) / TUNING.dayLengthSeconds)) / 2
       : 0
@@ -2971,7 +2990,7 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
   const diurnal = (c.traits as { diurnal?: number }).diurnal ?? 0
   const underground = isUnderground(w, c)
   const nightFactor = underground
-    ? 0.8  // constant cave darkness
+    ? Math.min(0.8, 0.1 + cavityDepth(w, c) * 0.07)  // twilight→midnight gradient
     : TUNING.dayLengthSeconds > 0
       ? (1 - Math.cos((2 * Math.PI * w.elapsed) / TUNING.dayLengthSeconds)) / 2
       : 0


### PR DESCRIPTION
Closes #3432

## What

Cave depth now creates a light gradient rather than a flat constant darkness. A new `cavityDepth(w, c)` helper counts consecutive solid tiles above a creature's head, and the underground `nightFactor` scales with depth:

| Zone | Depth | nightFactor |
|---|---|---|
| Twilight | 3–5 tiles | 0.31–0.45 |
| Transition | 5–10 tiles | 0.45–0.80 |
| Midnight | 10+ tiles | 0.80 (capped) |

**Formula**: `min(0.8, 0.1 + depth * 0.07)` — linear ramp from 0.17 at depth 1 to 0.80 at depth 10.

## Ecological effects

- Surface species with `diurnal > 0` can forage in twilight zones without the full 0.8 darkness penalty — realistic mixed-zone ecology
- Only true midnight-zone creatures (depth 10+) face maximum selection for cave adaptation (lateral-line, low sight)
- Troglobitic evolution pressure becomes depth-dependent: populations in deeper caves evolve cave traits faster

## How it fits the existing system

`isUnderground()` (3+ tiles above) remains the entry gate — the gradient only activates once underground. Both `nightFactor` blocks (hunger and movement) use the same formula, applied consistently.

## Tests

All previously-passing tests continue to pass.