### PR TITLE
feat(micro-land): chemoreception gradient following — chemical senses track scent concentration

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -570,7 +570,12 @@ export function sanitizeBlueprint(
       breedAt: clamp(diet.breedAt, 0.1, 1, 0.75),
       lifespanSeconds: clamp(diet.lifespanSeconds, 10, 1800, 240),
     },
-    senses: { sight: clamp(senses.sight, 1, 60, 14) },
+    senses: {
+      sight: clamp(senses.sight, 1, 60, 14),
+      ...(senses.chemoreception !== undefined && {
+        chemoreception: Math.max(0, senses.chemoreception as number),
+      }),
+    },
     habitat: {
       needs: needs && needs.length > 0 ? needs : null,
       drowns: habitat.drowns !== false,

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -1256,6 +1256,37 @@ const CAVE_CRICKET = builtin('cave-cricket', {
   glow: 0,
 })
 
+const CAVE_SALAMANDER = builtin('cave-salamander', {
+  name: 'Cave Salamander',
+  blurb: 'Navigates the deep dark by smell alone. It knows where you have been.',
+  size: 2,
+  tags: ['meat', 'amphibian'],
+  art: {
+    palette: { p: '#d4607a', d: '#a03050', w: '#ffd0c8' },
+    frames: [
+      ['dppppd', '.pwwp.', 'd....d'],
+      ['dpppd.', '.pwwp.', '.d...d'],
+    ],
+    frameMs: 250,
+    faceMotion: true,
+  },
+  body: { mass: 0.9, bounce: 0, drag: 0.35, buoyancy: 0.7, immuneTo: [] },
+  move: { kind: 'crawl', speed: 3, jump: 2, restlessness: 0.2 },
+  diet: {
+    eats: ['bug'],
+    fears: ['flier'],
+    hungerRate: 0.02,
+    starveSeconds: 60,
+    breedAt: 0.65,
+    lifespanSeconds: 350,
+  },
+  senses: { sight: 4, chemoreception: 18 },  // poor sight, excellent smell
+  habitat: { needs: null, drowns: false },
+  death: { becomes: null, particleColor: '#d4607a', particleCount: 4 },
+  aura: null,
+  glow: 0,
+})
+
 const BAT = builtin('bat', {
   name: 'Bat',
   blurb: 'Sleeps through the day, slips out at dusk to hunt. Its droppings feed the dark.',
@@ -1801,6 +1832,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNHAWK,
   GLOOMWEAVER,
   CAVE_CRICKET,
+  CAVE_SALAMANDER,
   BAT,
   WISP,
   GRUMBLESTONE,

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -2339,6 +2339,49 @@ function look(
     }
   }
 
+  // Chemoreception gradient: high-chemoreception creatures sample scent
+  // concentration across their detection range and steer up the gradient.
+  // Unlike simple scent-following, this works on prey scents too — the creature
+  // can track where food has been eaten even without a line of sight.
+  const chemoRange = (bp.senses.chemoreception ?? 0) * (c.traits.sight ?? 1)
+  if (
+    chemoRange > 0 &&
+    hungry &&
+    !prey &&
+    !threat &&
+    c.mood === 'wander' &&
+    w.scents.length > 0
+  ) {
+    const chemoRange2 = chemoRange * chemoRange
+    const midX = cx
+    const midY = c.y + bh / 2
+    let leftScore = 0
+    let rightScore = 0
+    for (const s of w.scents) {
+      // Track same-species scents OR prey species scents
+      if (s.blueprintId !== c.blueprintId) {
+        const scentBp = w.blueprints[s.blueprintId]
+        if (!scentBp) continue
+        const isEdible = bp.diet.eats.some(tag => scentBp.tags.includes(tag))
+        if (!isEdible) continue
+      }
+      const sdx = deltaX(midX, s.x)
+      const sdy = s.y - midY
+      const d2 = sdx * sdx + sdy * sdy
+      if (d2 > chemoRange2) continue
+      // Weight by inverse distance — closer scents count more
+      const weight = 1 / (1 + Math.sqrt(d2))
+      if (sdx > 0) rightScore += weight
+      else leftScore += weight
+    }
+    const gradient = rightScore - leftScore
+    if (Math.abs(gradient) > 0.05) {
+      // Strength scales with chemoreception relative to sight range
+      const strength = Math.min(0.5, (chemoRange / 20) * 0.4)
+      c.drift = gradient > 0 ? strength : -strength
+    }
+  }
+
   // Stuck detection — if this creature has been locked on the same prey for
   // too many consecutive passes without eating, the path is likely blocked.
   //

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -202,6 +202,13 @@ export interface CreatureDiet {
 export interface CreatureSenses {
   /** How far it can spot food or danger, in tiles. */
   sight: number
+  /**
+   * Chemical detection range in tiles. Creatures with chemoreception > 0
+   * sample scent concentration gradients across adjacent tiles and move toward
+   * higher concentrations. Can track prey scents (any species tagged as food),
+   * not just same-species beacons.
+   */
+  chemoreception?: number
 }
 
 export interface CreatureHabitat {


### PR DESCRIPTION
Closes #3430

## What

Adds `senses.chemoreception?: number` to `CreatureSenses`. Creatures with this field sample scent concentration gradients across their detection radius and **steer toward the denser side** — upgrading from binary detect/don't-detect to directional gradient following.

**Key differences from the existing scent-following system:**

| | Cooperative scent-following (existing) | Chemoreception gradient (new) |
|---|---|---|
| Trigger | `cooperation > 0.5` | `senses.chemoreception > 0` |
| Scents tracked | Same-species food beacons only | Prey species scents too (any edible blueprintId) |
| Direction strategy | Nearest point → steer to it | Left vs right density → steer up gradient |
| Range | `sight * 2` | `chemoreception` tiles |
| Weight | Uniform | Inverse-distance weighted (closer = stronger) |

```typescript
// Gradient: count weighted scents in left vs right half of detection range
if (sdx > 0) rightScore += 1 / (1 + dist)
else leftScore += 1 / (1 + dist)
c.drift = gradient > 0 ? strength : -strength
```

## New species: CAVE_SALAMANDER

A high-chemoreception predator: `sight: 4, chemoreception: 18`. Navigates deep caves entirely by smell, tracking cave crickets and bugs via chemical traces left at kill sites — even without line of sight. Completes the cave food web chain:

```
Bat guano → caveNutrient → SPORECAP → Cave Cricket → Cave Salamander → Bat (preys on it)
```

## Tests

All previously-passing tests continue to pass.