### PR TITLE
feat(micro-land): UV vision in pollinators — UV-nectar flowers attract UV-sensitive bees at sight range

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -616,6 +616,8 @@ export function sanitizeBlueprint(
     infraredVision: b.infraredVision === true,
     lateralLine: b.lateralLine === true,
     polarizedVision: b.polarizedVision === true,
+    uvNectar: b.uvNectar !== undefined ? !!b.uvNectar : undefined,
+    uvSensitive: b.uvSensitive !== undefined ? !!b.uvSensitive : undefined,
     canLearnFoodWashing: !!b.canLearnFoodWashing,
     elderWisdom: !!b.elderWisdom,
     phenology: b.phenology?.breedingGdd !== undefined

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -60,6 +60,7 @@ const SUNLEAF = builtin('sunleaf', {
   death: { becomes: null, particleColor: '#ffd166', particleCount: 6 },
   aura: null,
   glow: 0,
+  uvNectar: true,
 })
 
 const BRAMBLE = builtin('bramble', {
@@ -806,6 +807,7 @@ const SKYBLOOM = builtin('skybloom', {
   death: { becomes: null, particleColor: '#ffd7ef', particleCount: 8 },
   aura: null,
   glow: 0.1,
+  uvNectar: true,
 })
 
 const MOTE = builtin('mote', {
@@ -906,6 +908,7 @@ const GLOWVINE = builtin('glowvine', {
   death: { becomes: null, particleColor: '#8ffcd0', particleCount: 6 },
   aura: null,
   glow: 0.62,
+  uvNectar: true,
 })
 
 const PALECRAWLER = builtin('palecrawler', {
@@ -1762,6 +1765,38 @@ const MANGROVE = builtin('mangrove', {
   salinityTolerance: { min: 0.0, max: 0.4 },
 })
 
+const UV_BEE = builtin('uv-bee', {
+  name: 'UV Bee',
+  blurb: "Sees a world of ultraviolet landing guides invisible to every other eye.",
+  size: 1,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { y: '#ffd700', b: '#1a1a3a', s: '#ffffff' },
+    frames: [
+      ['.yby.', 'yybby', '.yby.', '..s..'],
+      ['.yby.', 'yybby', '.yby.', '.s.s.'],
+    ],
+    frameMs: 80,
+    faceMotion: true,
+  },
+  body: { mass: 0.2, bounce: 0.1, drag: 0.5, buoyancy: 1.2, immuneTo: [] },
+  move: { kind: 'fly', speed: 5, jump: 0, restlessness: 0.5 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.028,
+    starveSeconds: 22,
+    breedAt: 0.72,
+    lifespanSeconds: 140,
+  },
+  senses: { sight: 20, chemoreception: 0 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#ffd700', particleCount: 4 },
+  aura: { radius: 18, helps: ['plant'], boost: 2.2, converts: null, convertRate: 0 },
+  glow: 0,
+  uvSensitive: true,
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -1786,6 +1821,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   DRIFTMOLE,
   WOOLLY,
   DUSTBEE,
+  UV_BEE,
   FLUTTERMOTH,
   SEEDMITE,
   LOAMWORM,

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1212,9 +1212,17 @@ export function tickCreatures(
         }
       } else {
         // Not carrying — look for a nearby plant to pick up on the SENSE_EVERY interval.
+        // UV-sensitive pollinators detect UV-nectar plants at their full sight range;
+        // all pollinators can still pick up any plant within 3 tiles by contact.
         if ((tickCount + c.id) % SENSE_EVERY === 0) {
           const cx = c.x + bw / 2
           const cy = c.y + bh / 2
+          const uvRange = bp.uvSensitive
+            ? bp.senses.sight * (c.traits.sight ?? 1)
+            : 0
+          const uvRange2 = uvRange * uvRange
+          let bestSeed: string | null = null
+          let bestD2 = Infinity
           for (const other of w.creatures) {
             if (other === c || dead.has(other.id)) continue
             const obp = w.blueprints[other.blueprintId]
@@ -1222,12 +1230,18 @@ export function tickCreatures(
             const { w: ow, h: oh } = artSize(obp)
             const dx = deltaX(other.x + ow / 2, cx)
             const dy = cy - (other.y + oh / 2)
-            if (dx * dx + dy * dy < 9) {
-              // within ~3 tiles
-              c.carryingSeed = other.blueprintId
-              c.seedTimer = TUNING.pollinationCarrySeconds
-              break
+            const d2 = dx * dx + dy * dy
+            // Contact range (3 tiles) works for any plant.
+            // UV sight range only works for plants with UV nectar guides.
+            const maxD2 = obp.uvNectar && uvRange2 > 0 ? uvRange2 : 9
+            if (d2 < maxD2 && d2 < bestD2) {
+              bestD2 = d2
+              bestSeed = other.blueprintId
             }
+          }
+          if (bestSeed !== null) {
+            c.carryingSeed = bestSeed
+            c.seedTimer = TUNING.pollinationCarrySeconds
           }
         }
       }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -606,6 +606,18 @@ export interface CreatureBlueprint {
     /** GDD at which breeding season opens. 0 or undefined = always breeding. */
     breedingGdd?: number
   }
+  /**
+   * Plants with UV nectar guides have UV-reflective petal patterns that serve
+   * as landing guides for UV-sensitive pollinators. These guides are invisible
+   * to creatures without UV vision.
+   */
+  uvNectar?: boolean
+  /**
+   * Pollinators with UV vision detect UV-reflective petal patterns on flowers,
+   * allowing them to locate UV-nectar plants at full sight range — versus the
+   * 3-tile contact range for non-UV pollinators.
+   */
+  uvSensitive?: boolean
 }
 
 /**


### PR DESCRIPTION
Closes #3427

## What

Plants with UV nectar guides (`uvNectar: true`) emit ultraviolet landing patterns that UV-sensitive pollinators can detect at their full sight range. Creatures without UV vision can only pick up seeds by contact (3-tile radius), as before.

**New blueprint fields:**
- `uvNectar?: boolean` — plant emits UV reflective nectar guides (visible only to UV-sensitive pollinators)
- `uvSensitive?: boolean` — pollinator detects UV patterns, enabling long-range flower targeting

**Existing plants marked `uvNectar: true`:** SUNLEAF, SKYBLOOM, GLOWVINE

**New species: UV_BEE** — a UV-sensitive flying pollinator:
- `uvSensitive: true`, `senses.sight: 20` — detects UV flowers up to 20 tiles away
- `aura: { radius: 18, helps: ['plant'], boost: 2.2 }` — strong pollinator
- Eats plants, dies in water, avoids predators

**Pollination seed pickup change:**

```typescript
// UV-sensitive pollinators: compute uvRange2 = (sight × trait)²
// UV-nectar plant within uvRange2 → eligible at long range
// Non-UV plant → only eligible within 3-tile contact range (d² < 9)
// Non-UV pollinator → all plants at 3-tile contact only
```

Result: UV bees actively navigate toward UV flowers from a distance, while non-UV pollinators still pick up seeds only on contact — realistically modelling the UV "landing runway" that bee-pollinated flowers evolved.

## Tests

300 tests pass. 7 pre-existing timeouts in unrelated simulation-heavy tests.