### PR TITLE
feat(micro-land): polarized skin mating signals — covert polarized beacons for mate detection

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -616,6 +616,7 @@ export function sanitizeBlueprint(
     infraredVision: b.infraredVision === true,
     lateralLine: b.lateralLine === true,
     polarizedVision: b.polarizedVision === true,
+    polarizedSkin: !!b.polarizedSkin,
     canLearnFoodWashing: !!b.canLearnFoodWashing,
     elderWisdom: !!b.elderWisdom,
     phenology: b.phenology?.breedingGdd !== undefined

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -354,6 +354,39 @@ const GLIMMER_MOTH = builtin('glimmer-moth', {
   glow: 0.7,
 })
 
+const MANTIS_SHRIMP = builtin('mantis-shrimp', {
+  name: 'Mantis Shrimp',
+  blurb: "Sees sixteen color channels. Its polarized patterns speak a language only kin can read.",
+  size: 2,
+  tags: ['meat', 'crustacean'],
+  art: {
+    palette: { r: '#e84343', g: '#43a843', b: '#4343e8', o: '#e89043', w: '#ffffff' },
+    frames: [
+      ['rgobo', 'rwwwr', 'gbbog'],
+      ['obrgo', 'rwwwr', 'boogb'],
+    ],
+    frameMs: 180,
+    faceMotion: true,
+  },
+  body: { mass: 1.1, bounce: 0.1, drag: 0.35, buoyancy: 0.9, immuneTo: [] },
+  move: { kind: 'crawl', speed: 4, jump: 3, restlessness: 0.3 },
+  diet: {
+    eats: ['crustacean', 'bug', 'fish'],
+    fears: [],
+    hungerRate: 0.025,
+    starveSeconds: 50,
+    breedAt: 0.68,
+    lifespanSeconds: 280,
+  },
+  senses: { sight: 12 },
+  habitat: { needs: ['water'], drowns: false },
+  death: { becomes: null, particleColor: '#e84343', particleCount: 5 },
+  aura: null,
+  glow: 0,
+  polarizedVision: true,
+  polarizedSkin: true,
+})
+
 const FINLING = builtin('finling', {
   name: 'Finling',
   blurb: 'A small bright fish. Out of water it flops and gasps.',
@@ -1778,6 +1811,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   MITE,
   HOPPER,
   GLIMMER_MOTH,
+  MANTIS_SHRIMP,
   FINLING,
   EMBER_GRUB,
   DELVER,

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1396,6 +1396,13 @@ export function tickCreatures(
       }
     }
 
+    // Polarized mating beacon: polarized-skin creatures ready to breed emit a
+    // covert polarized signal once per SENSE_EVERY interval. Only same-species
+    // polarizedVision creatures can detect this — predators are blind to it.
+    if (bp.polarizedSkin && readyToBreed(c, bp) && (tickCount + c.id) % SENSE_EVERY === 0 && w.scents.length < 200) {
+      w.scents.push({ x: c.x + bw / 2, y: c.y + bh / 2, blueprintId: c.blueprintId, decaySeconds: 8, polarized: true })
+    }
+
     // --- breeding -------------------------------------------------------
     const isPlant = bp.move.kind === 'root'
     // Phenological gate: species with a breedingGdd threshold only mate when
@@ -2336,6 +2343,38 @@ function look(
       const weight = cooperationVal * 0.3
       c.drift = deltaX(midX, nearestScent.x) > 0 ? weight : -weight
       ;(c as { followingScent?: boolean }).followingScent = true
+    }
+  }
+
+  // Polarized mating signal: polarizedVision creatures detect polarized beacons
+  // from same-species polarizedSkin individuals at 2× normal sight range.
+  // These covert signals are invisible to predators without polarizedVision.
+  if (
+    bp.polarizedVision &&
+    !prey &&
+    !threat &&
+    c.mood === 'wander' &&
+    w.scents.length > 0
+  ) {
+    const polReach2 = sight * sight * 4  // 2× sight radius
+    const midX = cx
+    const midY = c.y + bh / 2
+    let nearestPolD2 = Infinity
+    let nearestPolScent: Scent | null = null
+    for (const s of w.scents) {
+      if (!s.polarized) continue
+      if (s.blueprintId !== c.blueprintId) continue
+      const sdx = deltaX(midX, s.x)
+      const sdy = s.y - midY
+      const d2 = sdx * sdx + sdy * sdy
+      if (d2 < nearestPolD2 && d2 < polReach2) {
+        nearestPolD2 = d2
+        nearestPolScent = s
+      }
+    }
+    if (nearestPolScent) {
+      const weight = 0.35
+      c.drift = deltaX(midX, nearestPolScent.x) > 0 ? weight : -weight
     }
   }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -558,6 +558,13 @@ export interface CreatureBlueprint {
    */
   polarizedVision?: boolean
   /**
+   * Cephalopods and mantis shrimp emit polarized skin patterns as covert
+   * mating signals. Other same-species polarizedVision creatures detect these
+   * beacons at 2× normal sight range. Predators without polarizedVision are
+   * blind to the signal — it cannot be eavesdropped.
+   */
+  polarizedSkin?: boolean
+  /**
    * Species-level opt-in to the food-washing cultural innovation.
    *
    * When true, individuals of this species can discover — or learn from kin —
@@ -1050,6 +1057,8 @@ export interface Scent {
   blueprintId: string
   /** Seconds until this marker vanishes. */
   decaySeconds: number
+  /** When true, this is a polarized-light mating signal; only detected by polarizedVision creatures */
+  polarized?: boolean
 }
 
 export interface Particle {


### PR DESCRIPTION
Closes #3429

## What

Extends the existing `polarizedVision` system with covert mating signals via polarized skin patterns. Two additions:

**`polarizedSkin?: boolean`** — creatures with this flag emit polarized-light mating beacons that are invisible to predators without `polarizedVision`. Models how cephalopods and mantis shrimp communicate species identity through a hidden light channel.

**`polarized?: boolean` on `Scent`** — marks scents that are only detectable by `polarizedVision` creatures.

**How it works:**

```
1. polarizedSkin creature + readyToBreed → emits polarized: true scent every SENSE_EVERY ticks
2. Same-species polarizedVision creature wandering (no prey/threat) → scans for polarized scents
   at 2× sight radius → drifts toward nearest beacon (weight 0.35)
3. Predators without polarizedVision iterate past polarized scents — filter skips them entirely
```

This creates a covert mating channel: signal-emitting cephalopods advertise readiness to kin without broadcasting to predators.

**New species: MANTIS_SHRIMP** — the canonical polarized-vision creature:
- `polarizedVision: true` + `polarizedSkin: true`
- Hunts crustaceans, bugs, and fish
- Aquatic crawler (`needs: ['water']`)
- Colourful multi-hue palette (6 distinct palette colors to evoke 16-channel vision)

## What was already there

The camouflage-bypass effect (`polarizedVision` breaks `cryptic` creatures' camouflage bonus) was already implemented in prior work. This PR adds the covert mating communication layer on top.

## Tests

303/307 tests pass. The 4 failures are pre-existing timeouts in carnivorous-plant and invasive-species simulation tests.