### PR TITLE
feat(micro-land): microclimate pockets — frost hollows and sun-traps modify local plant seasons

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -359,6 +359,39 @@ function cavityDepth(w: WorldState, c: Creature): number {
 }
 
 /**
+ * Y-coordinate of the first solid tile scanning down from the top at column x.
+ * Higher return value = lower terrain elevation. Returns WORLD_H for open-sky columns.
+ */
+function surfaceHeightAt(w: WorldState, x: number): number {
+  const col = wrapCol(Math.floor(x))
+  for (let y = 0; y < WORLD_H; y++) {
+    if (IS_SOLID[w.tiles[y * WORLD_W + col]]) return y
+  }
+  return WORLD_H
+}
+
+/**
+ * Local terrain temperature modifier based on terrain relief.
+ *
+ * Frost hollow (valley floor, surrounded by higher terrain): cold air drains
+ * downhill and pools, amplifying winter cold. Returns negative value.
+ * Sun-trap (elevated knoll or ridge): less frost shadow, warms faster.
+ * Returns positive value. Flat terrain returns 0.
+ *
+ * Only meaningful when `TUNING.seasonAmplitude > 0`.
+ */
+function microclimateMod(w: WorldState, x: number): number {
+  const here = surfaceHeightAt(w, x)
+  const left = surfaceHeightAt(w, x - 8)
+  const right = surfaceHeightAt(w, x + 8)
+  const avg = (left + right) / 2
+  const diff = here - avg  // positive = depression, negative = elevated
+  if (diff > 2) return -Math.min(0.4, diff / 20)   // frost hollow
+  if (diff < -2) return Math.min(0.25, -diff / 20)  // sun-trap
+  return 0
+}
+
+/**
  * True when c and other overlap — used for snap-trap contact detection.
  * Uses the creature positions as 1-tile points (plants are 1-wide).
  */
@@ -1652,11 +1685,17 @@ export function tickCreatures(
                 const det = w.marshDetritus[footY * WORLD_W + footX] ?? 0
                 salinityBoost *= 1 + det  // up to 2× additional from detrital export
               }
+              // Microclimate pocket: frost hollows amplify winter cold (lower season factor),
+              // sun-traps moderate it. Effect is proportional — strongest in winter when
+              // seasonFactor is already low. Only applies when seasons are enabled.
+              const localSeasonFactor = TUNING.seasonAmplitude > 0
+                ? Math.max(0.01, seasonFactor * (1 + microclimateMod(w, footX)))
+                : seasonFactor
               c.breedCooldown =
                 (TUNING.plantSpreadCooldown * crowdingPenalty * allelopathyFactor * bioticResistanceFactor * competitiveExclusionFactor) /
                 (auraBoost(w, c, bp, bw, bh, helpers) *
                   plantFertilityFactor *
-                  seasonFactor *
+                  localSeasonFactor *
                   salinityBoost)
             } else {
               // Both of them paid to be here, so both of them pay for it. Charging


### PR DESCRIPTION
Closes #3382

## What

Local terrain relief now creates microclimate pockets that modify plant growing seasons. Two new helper functions + one local variable in the plant breeding block — no new blueprint fields or world state.

**`surfaceHeightAt(w, x)`** — finds the y-coordinate of the first solid tile scanning down from the sky at column `x`. Higher y = lower terrain elevation.

**`microclimateMod(w, x)`** — compares surface height at `x` vs 8 tiles left and right:
- **Frost hollow** (valley floor, depression): cold air drains downhill → returns up to -0.4 → amplifies winter cold
- **Sun-trap** (elevated knoll or ridge): less frost shadow → returns up to +0.25 → moderates winter cold
- Flat terrain: returns 0

**In plant breeding**: `localSeasonFactor = seasonFactor * (1 + microclimateMod)` replaces the global `seasonFactor`. Only active when `TUNING.seasonAmplitude > 0`.

## Ecological effects

| Terrain | Winter (seasonFactor ≈ 0.1) | Summer (seasonFactor ≈ 1.8) |
|---|---|---|
| Frost hollow | ~0.06 (much slower growth) | ~1.26 (still warm) |
| Sun-trap | ~0.12 (less cold) | ~2.0 (warmer peak) |
| Flat | 0.1 (baseline) | 1.8 (baseline) |

Plants in frost hollows face strong selection for cold-tolerance (wide seasonFactor tolerance). Plants on sun-traps establish faster in winter. Valley floors can develop distinct plant communities from adjacent hillsides — the biological diversity hotspot effect the issue describes.

## Tests

All previously-passing tests continue to pass.