### PR TITLE
feat(micro-land): thermal plume — heat-sensitive fish find refuge in spring-fed cold water

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -607,6 +607,7 @@ export function sanitizeBlueprint(
     salinityTolerance: b.salinityTolerance && typeof (b.salinityTolerance as Record<string, unknown>).min === 'number' && typeof (b.salinityTolerance as Record<string, unknown>).max === 'number'
       ? { min: Math.max(0, (b.salinityTolerance as { min: number; max: number }).min), max: Math.min(1, (b.salinityTolerance as { min: number; max: number }).max) }
       : undefined,
+    heatSensitive: b.heatSensitive !== undefined ? !!b.heatSensitive : undefined,
     aerialRoots: b.aerialRoots !== undefined ? !!b.aerialRoots : undefined,
     slowMetabolism: b.slowMetabolism === true,
     invasive: b.invasive === true,

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -421,6 +421,39 @@ const FINLING = builtin('finling', {
   salinityTolerance: { min: 0.3, max: 1.0 },  // euryhaline — tolerates brackish to marine
 })
 
+const SPRING_TROUT = builtin('spring-trout', {
+  name: 'Spring Trout',
+  blurb: 'Thrives only where groundwater keeps the river cold. Vanishes in summer heat.',
+  size: 2,
+  tags: ['meat', 'fish'],
+  art: {
+    palette: { b: '#4a7ab5', s: '#8ab8d8', r: '#c84040', w: '#f0f0f0' },
+    frames: [
+      ['bbsbb', 'bwwrb', 'bbsbb'],
+      ['bbsbb', 'bwwrb', '.bbsb'],
+    ],
+    frameMs: 200,
+    faceMotion: true,
+  },
+  body: { mass: 0.6, bounce: 0.1, drag: 0.4, buoyancy: 1.0, immuneTo: [] },
+  move: { kind: 'swim', speed: 6, jump: 0, restlessness: 0.4 },
+  diet: {
+    eats: ['bug', 'crustacean'],
+    fears: [],
+    hungerRate: 0.025,
+    starveSeconds: 35,
+    breedAt: 0.70,
+    lifespanSeconds: 260,
+  },
+  senses: { sight: 16 },
+  habitat: { needs: ['water'], drowns: false },
+  death: { becomes: null, particleColor: '#4a7ab5', particleCount: 5 },
+  aura: null,
+  glow: 0,
+  heatSensitive: true,
+  phenology: { breedingGdd: 200 },  // spring spawner — breeds early, before summer heat
+})
+
 const EMBER_GRUB = builtin('ember-grub', {
   name: 'Ember Grub',
   blurb: 'Crawls over anything, even lava. Nothing burns it.',
@@ -1879,6 +1912,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   GLIMMER_MOTH,
   MANTIS_SHRIMP,
   FINLING,
+  SPRING_TROUT,
   EMBER_GRUB,
   DELVER,
   MOTE,

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -848,6 +848,21 @@ export function tickCreatures(
         }
       }
     }
+    // Thermal stress: heat-sensitive species suffer in warm summer water.
+    // Spring-fed tiles (high moisture from groundwater percolation) act as
+    // cool refugia — local moisture proportionally relieves the heat penalty.
+    // No effect when seasons are disabled (seasonAmplitude = 0).
+    if (bp.heatSensitive && TUNING.seasonAmplitude > 0 && seasonFactor > 1.0) {
+      const thx = Math.floor(c.x)
+      const thy = Math.floor(c.y)
+      if (thx >= 0 && thx < WORLD_W && thy >= 0 && thy < WORLD_H) {
+        const moisture = w.moisture ? (w.moisture[thy * WORLD_W + thx] ?? 0) : 0
+        // Stress proportional to how hot the season is; relief proportional to spring-water moisture
+        const heatStress = (seasonFactor - 1.0) * 0.0002 * dt
+        const springRelief = moisture * heatStress  // high moisture = full relief
+        c.hunger = Math.min(1, c.hunger + Math.max(0, heatStress - springRelief))
+      }
+    }
     if (c.hunger >= 1) {
       c.starving += dt
       if (c.starving >= bp.diet.starveSeconds) {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -448,6 +448,16 @@ export interface CreatureBlueprint {
    */
   salinityTolerance?: { min: number; max: number }
   /**
+   * Heat-sensitive species (cold-water fish, trout analogues) suffer increased
+   * hunger during warm seasons. Groundwater-fed tiles (high moisture from
+   * groundwater percolation) act as thermal refugia — the stress is
+   * proportionally relieved by local moisture.
+   *
+   * Models how spring seeps provide critical cold-water refuge for trout and
+   * salmon in warming climates.
+   */
+  heatSensitive?: boolean
+  /**
    * Aerial roots create structural shelter in tidal zones. When true, juvenile
    * creatures within 8 tiles receive a doubled nursery hunger bonus.
    */


### PR DESCRIPTION
Closes #3375

## What

Cold-water fish suffer thermal stress in warm summers but find relief in groundwater-fed (high moisture) tiles — modelling how spring seeps serve as critical cool refugia for trout and salmon.

**New blueprint field `heatSensitive?: boolean`:**
- When `seasonFactor > 1.0` (summer) and seasons are enabled, `heatSensitive` creatures pay extra hunger: `(seasonFactor - 1.0) * 0.0002 * dt`
- Local `moisture` (from `w.moisture` overlay) acts as a spring-water proxy — it's set by the existing `tickMoisture()` from groundwater percolation and rainfall. High moisture = spring-fed tile = thermally buffered
- Relief = `moisture * heatStress`, so fully spring-fed tiles (moisture = 1.0) cancel the penalty entirely

**New species: SPRING_TROUT**
- `heatSensitive: true` + `phenology: { breedingGdd: 200 }` (spring spawner, breeds before summer heat builds)
- Hunts bugs and crustaceans; aquatic swimmer
- Needs [`water`] habitat — dies if stranded

## Ecology

```
Summer heat → heat stress on SPRING_TROUT
High-moisture tiles (spring-fed, riparian zones) → relief = stress × moisture
Result: trout aggregate near springs and well-watered reaches naturally
```

Pairs with the microclimate pockets system (frost hollows, sun-traps) to create thermally heterogeneous landscapes where cold-sensitive species track the coolest refugia.

## Tests

All previously-passing tests continue to pass.