### PR TITLE
feat(micro-land): insight problem solving for cognitively superior creatures

### DIFF
--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -386,6 +386,7 @@ const MANTIS_SHRIMP = builtin('mantis-shrimp', {
   glow: 0,
   polarizedVision: true,
   polarizedSkin: true,
+  brainSize: 0.75,  // real mantis shrimp are remarkably intelligent
 })
 
 const FINLING = builtin('finling', {
@@ -525,6 +526,7 @@ const STALKER = builtin('stalker', {
   phenology: { breedingGdd: 350 }, // breeds in late spring / early summer
   // Pack hunters communicate and coordinate well — high cultural transmission.
   socialLearningRate: 0.8,
+  brainSize: 0.8,  // apex social predator with complex cooperative strategies
 })
 
 const DRIFTER_JELLY = builtin('drifter-jelly', {
@@ -1354,6 +1356,7 @@ const CAVE_SALAMANDER = builtin('cave-salamander', {
   death: { becomes: null, particleColor: '#d4607a', particleCount: 4 },
   aura: null,
   glow: 0,
+  brainSize: 0.6,  // cave salamanders navigate complex 3-D environments by smell alone
 })
 
 const BAT = builtin('bat', {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -781,6 +781,7 @@ export function tickCreatures(
     }
     if ((c as { stunTimer?: number }).stunTimer === undefined) c.stunTimer = 0
     if (c.stunTimer > 0) c.stunTimer = Math.max(0, c.stunTimer - dt)
+    if (c.insightTimer && c.insightTimer > 0) c.insightTimer = Math.max(0, c.insightTimer - dt)
     if ((c as { symbiosisTimer?: number }).symbiosisTimer === undefined) c.symbiosisTimer = 0
     if (c.symbiosisTimer > 0) c.symbiosisTimer = Math.max(0, c.symbiosisTimer - dt)
     if ((c as { sick?: number }).sick === undefined) c.sick = 0
@@ -2522,6 +2523,22 @@ function look(
     c.huntPassCount = 0
   }
 
+  // Insight problem solving: cognitively superior creatures unlock novel solutions when stuck
+  const insightBrainSize = bp.brainSize ?? 0
+  if (
+    insightBrainSize >= 0.5 &&
+    bp.move.kind !== 'root' &&
+    (c.huntPassCount ?? 0) >= 4 &&
+    !c.insightTimer &&
+    Math.random() < insightBrainSize * 0.08
+  ) {
+    c.insightTimer = 2 + insightBrainSize * 3
+    c.insightCount = (c.insightCount ?? 0) + 1
+    c.huntPassCount = 0
+    c.huntBlockedId = null
+    logLife(c, w.elapsed, `Insight #${c.insightCount}: unlocked novel path to prey`)
+  }
+
   // Disease spread: an infected creature spreads to non-plant neighbours within 4 tiles.
   if (c.sick > 0 && bp.move.kind !== 'root') {
     const spreadReach = 4
@@ -3172,6 +3189,7 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
       (c.stunTimer > 0 ? 0.2 : 1) *
       (c.sick > 0 ? 0.7 : 1) *
       (c.symbiosisTimer > 0 ? 1.15 : 1) *
+      (c.insightTimer && c.insightTimer > 0 ? 0.05 : 1) *  // insight pause
       (1 - Math.max(0, (c.fatigue ?? 0) - 0.5))) /
       sizeOf(c)) *
     (1 - diurnalPenalty)

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1000,6 +1000,10 @@ export interface Creature {
    * Default undefined = 0 (no offset from species baseline).
    */
   phenoOffset?: number
+  /** Seconds remaining in an insight pause. While above zero the creature moves at 0.05× speed. */
+  insightTimer?: number
+  /** Total insight events this creature has had. */
+  insightCount?: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- Creatures with `brainSize >= 0.5` now have occasional insight events when stuck chasing prey
- During insight (2–5 seconds depending on brainSize), the creature moves at 0.05× speed — a visible thinking pause
- After the pause, `huntPassCount` and `huntBlockedId` are cleared so the creature tries a fresh approach
- Each insight is logged to the creature's Field Guide lifeLog as `"Insight #N: unlocked novel path to prey"`
- Added `brainSize` to three species: **mantis shrimp** (0.75), **stalker** (0.8), **cave salamander** (0.6)

## Changed files
- `types.ts` — added `insightTimer` and `insightCount` to `Creature` interface
- `creature-sim.ts` — timer decay, trigger logic in `look()`, speed multiplier
- `creatures.ts` — `brainSize` set on three cognitively capable species

Closes #3416

## Test plan
- [ ] Observe mantis shrimp or stalker briefly freeze while hunting — should resume after 2–5 seconds
- [ ] Check creature's Field Guide entry for "Insight #1" log line
- [ ] Confirm plants (roots) are excluded — insight only fires for mobile creatures
- [ ] Vercel CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)