### PR TITLE
feat(micro-land): seasonal flood pulse — spring moisture surge and nutrient deposition

### DIFF
--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -908,6 +908,26 @@ export function tickMoisture(w: WorldState, tickCount: number, dt: number, rng: 
   w.moisture ??= new Float32Array(WORLD_W * WORLD_H)
   const timePassed = 30 / 60 // seconds per update window
   const waterIdx = MATERIAL_INDEX.water
+
+  // Spring flood pulse: rising-phase sine (spring) amplifies moisture near water
+  // and deposits floodwater nutrients in floodplain tiles. Issue #3372.
+  let springFloodMult = 1
+  let nutrientDeposit = 0
+  if (TUNING.seasonAmplitude > 0) {
+    const sPhase = (2 * Math.PI * w.elapsed) / TUNING.seasonPeriod
+    const sinP = Math.sin(sPhase)
+    const cosP = Math.cos(sPhase)
+    // Spring = sin > 0 && cos > 0: the rising quarter heading toward summer peak.
+    if (sinP > 0 && cosP > 0) {
+      springFloodMult = 1 + TUNING.seasonAmplitude * sinP * 4
+      nutrientDeposit = TUNING.seasonAmplitude * sinP * 0.0001 * timePassed
+    }
+  }
+
+  if (nutrientDeposit > 0) {
+    w.caveNutrient ??= new Float32Array(WORLD_W * WORLD_H)
+  }
+
   for (let y = 0; y < WORLD_H; y++) {
     for (let x = 0; x < WORLD_W; x++) {
       const i = y * WORLD_W + x
@@ -922,7 +942,11 @@ export function tickMoisture(w: WorldState, tickCount: number, dt: number, rng: 
         (y > 0 && w.tiles[i - WORLD_W] === waterIdx) ||
         (y < WORLD_H - 1 && w.tiles[i + WORLD_W] === waterIdx)
       if (hasWater) {
-        w.moisture[i] = Math.min(1, w.moisture[i] + 0.01 * timePassed)
+        w.moisture[i] = Math.min(1, w.moisture[i] + 0.01 * timePassed * springFloodMult)
+        // Spring floodwater deposits nutrients in floodplain tiles
+        if (nutrientDeposit > 0 && w.caveNutrient) {
+          w.caveNutrient[i] = Math.min(1, (w.caveNutrient[i] ?? 0) + nutrientDeposit)
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- During spring (the rising quarter of the seasonal sine — `sin > 0 && cos > 0`), water-adjacent tiles receive amplified moisture: up to `1 + seasonAmplitude × 4` times the normal gain
- The same spring window deposits dissolved nutrients (`caveNutrient`) in those floodplain tiles, modelling the nutrient-rich sediment load of snowmelt floodwater
- Effect scales smoothly with `sinP × seasonAmplitude` — strongest at mid-spring, zero in summer/autumn/winter
- Completely inert when `seasonAmplitude = 0` (default) — no change to non-seasonal worlds

## Changed files
- `world.ts` — `tickMoisture`: spring flood multiplier computed from seasonal phase; applied to water-adjacent moisture gain; nutrient deposit added

Closes #3372

## Test plan
- [ ] Enable seasons (`seasonAmplitude > 0`) and observe elevated moisture in water-adjacent tiles during spring
- [ ] Confirm `caveNutrient` rises near water tiles during spring
- [ ] Confirm no change when `seasonAmplitude = 0`
- [ ] Vercel CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)