### PR TITLE
feat(micro-land): invertebrate drift — stream larvae passively carried by current

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -625,6 +625,7 @@ export function sanitizeBlueprint(
     polarizedSkin: !!b.polarizedSkin,
     uvNectar: b.uvNectar !== undefined ? !!b.uvNectar : undefined,
     uvSensitive: b.uvSensitive !== undefined ? !!b.uvSensitive : undefined,
+    canDrift: b.canDrift !== undefined ? !!b.canDrift : undefined,
     canLearnFoodWashing: !!b.canLearnFoodWashing,
     elderWisdom: !!b.elderWisdom,
     phenology: b.phenology?.breedingGdd !== undefined

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -1897,6 +1897,42 @@ const UV_BEE = builtin('uv-bee', {
   uvSensitive: true,
 })
 
+// ---------------------------------------------------------------------------
+// Stream invertebrate — drifts passively in current, feeds fish. Issue #3373.
+// ---------------------------------------------------------------------------
+
+const SHIMMER_LARVA = builtin('shimmer-larva', {
+  name: 'Shimmer Larva',
+  blurb: 'A stream-dwelling larva that lets go at dusk and drifts. The trout are waiting.',
+  size: 1,
+  tags: ['meat', 'bug', 'aquatic'],
+  art: {
+    palette: { s: '#88ddcc', d: '#4499aa', g: '#ccffee' },
+    frames: [
+      ['sss', 'dsd', '.s.'],
+      ['.ss', 'sds', 'ss.'],
+    ],
+    frameMs: 200,
+    faceMotion: true,
+  },
+  body: { mass: 0.6, bounce: 0, drag: 0.5, buoyancy: 1.2, immuneTo: [] },
+  move: { kind: 'crawl', speed: 1.5, jump: 0, restlessness: 0.3 },
+  diet: {
+    eats: ['plant', 'fungus'],
+    fears: ['fish', 'flier'],
+    hungerRate: 0.02,
+    starveSeconds: 30,
+    breedAt: 0.75,
+    lifespanSeconds: 120,
+  },
+  senses: { sight: 8 },
+  habitat: { needs: ['water'], drowns: false },
+  death: { becomes: null, particleColor: '#88ddcc', particleCount: 3 },
+  aura: null,
+  glow: 0.1,
+  canDrift: true,
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -1945,6 +1981,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   GRUMBLESTONE,
   TREX,
   DRAGON,
+  SHIMMER_LARVA,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -784,6 +784,11 @@ export function tickCreatures(
     if (c.insightTimer && c.insightTimer > 0) c.insightTimer = Math.max(0, c.insightTimer - dt)
     if ((c as { symbiosisTimer?: number }).symbiosisTimer === undefined) c.symbiosisTimer = 0
     if (c.symbiosisTimer > 0) c.symbiosisTimer = Math.max(0, c.symbiosisTimer - dt)
+    // Drift state: exit drift when creature leaves water.
+    if (c.drifting) {
+      const driftTile = w.tiles[Math.floor(c.y) * WORLD_W + wrapCol(Math.floor(c.x))] ?? 0
+      if (!IS_LIQUID[driftTile]) c.drifting = false
+    }
     if ((c as { sick?: number }).sick === undefined) c.sick = 0
     if ((c as { carryingSeed?: unknown }).carryingSeed === undefined) {
       c.carryingSeed = null
@@ -1361,6 +1366,26 @@ export function tickCreatures(
         if (gy >= 0 && gy < WORLD_H) {
           const idx = gy * WORLD_W + tx
           w.caveNutrient[idx] = Math.min(1, (w.caveNutrient[idx] ?? 0) + 0.0002 * dt)
+        }
+      }
+    }
+
+    // Invertebrate drift: aquatic invertebrates with canDrift occasionally release
+    // from substrate and drift passively with current. Highest at dusk/dawn.
+    // Drifting creatures are easy prey for fish positioned upstream. Issue #3373.
+    if (bp.canDrift && bp.move.kind !== 'root' && !c.drifting) {
+      const driftTile = w.tiles[Math.floor(c.y) * WORLD_W + wrapCol(Math.floor(c.x))] ?? 0
+      if (IS_LIQUID[driftTile] && !IS_DEADLY[driftTile]) {
+        // Dawn/dusk periodicity: nightFactor ∈ [0.25, 0.75] → 3× base probability.
+        // Compute nightFactor inline (same formula as look() function).
+        const driftNightFactor = TUNING.dayLengthSeconds > 0
+          ? (1 - Math.cos((2 * Math.PI * w.elapsed) / TUNING.dayLengthSeconds)) / 2
+          : 0
+        const isDuskDawn = driftNightFactor > 0.25 && driftNightFactor < 0.75
+        const driftProb = (isDuskDawn ? 0.0006 : 0.0002) * dt
+        if (rng() < driftProb) {
+          c.drifting = true
+          c.drift = 1  // drift rightward (proxy for downstream)
         }
       }
     }
@@ -3137,6 +3162,10 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
         c.drift = leftScore > rightScore ? -1 : 1
       }
     }
+    // Drifting invertebrates are locked rightward and move slowly regardless of state.
+    if (c.drifting) {
+      c.drift = 1
+    }
     wantX = c.drift
     wantY = bp.move.kind === 'fly' || bp.move.kind === 'swim' ? (rng() - 0.5) * 0.6 : 0
     c.targetId = null
@@ -3190,6 +3219,7 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
       (c.sick > 0 ? 0.7 : 1) *
       (c.symbiosisTimer > 0 ? 1.15 : 1) *
       (c.insightTimer && c.insightTimer > 0 ? 0.05 : 1) *  // insight pause
+      (c.drifting ? 0.4 : 1) *  // drift — slower passive flow
       (1 - Math.max(0, (c.fatigue ?? 0) - 0.5))) /
       sizeOf(c)) *
     (1 - diurnalPenalty)

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -642,6 +642,11 @@ export interface CreatureBlueprint {
    * 3-tile contact range for non-UV pollinators.
    */
   uvSensitive?: boolean
+  /**
+   * Stream invertebrate that occasionally enters the water column and drifts
+   * passively with current. Delivers food to downstream fish. Issue #3373.
+   */
+  canDrift?: boolean
 }
 
 /**
@@ -1004,6 +1009,8 @@ export interface Creature {
   insightTimer?: number
   /** Total insight events this creature has had. */
   insightCount?: number
+  /** Currently in passive drift (stream invertebrate released into current). Issue #3373. */
+  drifting?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- New **SHIMMER_LARVA** species: a small aquatic invertebrate (size 1, crawl, aquatic, `drowns: false`) that lives in water and is eaten by fish
- `canDrift: true` blueprint flag; `drifting?: boolean` per-creature state
- At dusk/dawn (nightFactor ∈ [0.25, 0.75]) the trigger rate is 3× base — models documented crepuscular drift periodicity of real stream invertebrates
- Drifting creatures: locked rightward drift (downstream proxy), move at 0.4× speed — passive, easy prey for fish positioned facing upstream
- Drift exits automatically when the creature reaches a non-liquid tile

## Changed files
- `types.ts` — `canDrift` on blueprint; `drifting` on creature
- `blueprint.ts` — sanitize `canDrift`
- `creatures.ts` — SHIMMER_LARVA species + added to export array
- `creature-sim.ts` — drift exit check, drift trigger block, direction lock + speed multiplier in steer()

Closes #3373

## Test plan
- [ ] Observe SHIMMER_LARVA drifting rightward in water tiles at dawn/dusk
- [ ] Confirm drift stops when hitting solid substrate
- [ ] Observe fish eating drifting larvae
- [ ] Confirm non-aquatic species are unaffected
- [ ] Vercel CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)