### PR TITLE
feat(micro-land): anadromous fish migration — spawn-and-die lifecycle with nutrient return

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -625,6 +625,7 @@ export function sanitizeBlueprint(
     polarizedSkin: !!b.polarizedSkin,
     uvNectar: b.uvNectar !== undefined ? !!b.uvNectar : undefined,
     uvSensitive: b.uvSensitive !== undefined ? !!b.uvSensitive : undefined,
+    anadromous: b.anadromous !== undefined ? !!b.anadromous : undefined,
     canLearnFoodWashing: !!b.canLearnFoodWashing,
     canInnovateTechniques: b.canInnovateTechniques !== undefined ? !!b.canInnovateTechniques : undefined,
     elderWisdom: !!b.elderWisdom,

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -453,6 +453,7 @@ const SPRING_TROUT = builtin('spring-trout', {
   glow: 0,
   heatSensitive: true,
   phenology: { breedingGdd: 200 },  // spring spawner — breeds early, before summer heat
+  anadromous: true,  // migrates back to natal headwater to spawn
 })
 
 const EMBER_GRUB = builtin('ember-grub', {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1674,6 +1674,8 @@ export function tickCreatures(
               child.phenoOffset = Math.max(-200, Math.min(200, mutated))
             }
             child.lifeLog = [{ elapsed: w.elapsed, text: `Born (gen ${child.generation})` }]
+            // Record birth position for anadromous migration homing.
+            if (bp.anadromous) child.natalX = Math.floor(child.x)
             c.children++
             if (c.children === 1) logLife(c, w.elapsed, 'First offspring')
             else if (c.children % 10 === 0) logLife(c, w.elapsed, `${c.children} offspring`)
@@ -1829,6 +1831,23 @@ export function tickCreatures(
                 else if (mate.children % 10 === 0)
                   logLife(mate, w.elapsed, `${mate.children} offspring`)
                 payForChild(w, mate, bp, bw, bh, helpers)
+              }
+              // Anadromous spawning: the act of reproduction is fatal — spent fish die
+              // and deposit marine-derived nutrients (nitrogen, phosphorus) into the
+              // headwater ecosystem. Issue #3374.
+              if (bp.anadromous) {
+                c.hunger = 1  // exhausted — will starve next tick
+                const spawnX = Math.floor(c.x + bw / 2), spawnY = Math.floor(c.y + bh / 2)
+                w.caveNutrient ??= new Float32Array(WORLD_W * WORLD_H)
+                for (let ndy = -3; ndy <= 3; ndy++) {
+                  for (let ndx = -3; ndx <= 3; ndx++) {
+                    const ntx = wrapCol(spawnX + ndx), nty = spawnY + ndy
+                    if (nty >= 0 && nty < WORLD_H) {
+                      w.caveNutrient[nty * WORLD_W + ntx] = Math.min(1, (w.caveNutrient[nty * WORLD_W + ntx] ?? 0) + 0.15)
+                    }
+                  }
+                }
+                logLife(c, w.elapsed, 'Spawned and spent — returning nutrients to the headwater')
               }
             }
             events.push({ kind: 'born', blueprintId: bp.id, x: child.x, y: child.y })
@@ -3232,6 +3251,13 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
       }
       if (leftScore !== rightScore) {
         c.drift = leftScore > rightScore ? -1 : 1
+      }
+    }
+    // Anadromous migration: adult fish drive toward natal spawn site when mature.
+    if (bp.anadromous && c.natalX !== undefined && c.ageSeconds > (bp.diet.lifespanSeconds ?? 240) * 0.4) {
+      const toNatal = deltaX(c.x, c.natalX)
+      if (Math.abs(toNatal) > 5) {
+        c.drift = toNatal > 0 ? 1 : -1
       }
     }
     wantX = c.drift

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -649,6 +649,12 @@ export interface CreatureBlueprint {
    * 3-tile contact range for non-UV pollinators.
    */
   uvSensitive?: boolean
+  /**
+   * Records natal X position at birth; as adults, these fish migrate back toward
+   * that position to spawn. Spawning is fatal — the fish dies and deposits marine
+   * nutrients into the headwater ecosystem. Issue #3374.
+   */
+  anadromous?: boolean  // records natal X at birth; adult drives toward it to spawn and die
 }
 
 /**
@@ -1019,6 +1025,8 @@ export interface Creature {
   insightTimer?: number
   /** Total insight events this creature has had. */
   insightCount?: number
+  /** X tile position where this creature was born (for anadromous migration). */
+  natalX?: number  // X tile position where this creature was born (for anadromous migration)
 }
 
 /**


### PR DESCRIPTION
## Summary
- `anadromous: true` flag added to `SPRING_TROUT` (and type/blueprint infrastructure)
- At birth, anadromous fish record `natalX = Math.floor(child.x)` — their spawn site
- After 40% of lifespan, adults override their wander drift to home toward `natalX` — the upstream migration
- On successful spawning: `c.hunger = 1` (the fish is spent and starves next tick); a 7×7 caveNutrient patch (+0.15 each tile) is deposited around the spawn site — marine-derived nitrogen and phosphorus returning to the headwater
- Event logged to Field Guide: `"Spawned and spent — returning nutrients to the headwater"`

## Changed files
- `types.ts` — `anadromous` on blueprint; `natalX` on creature
- `blueprint.ts` — sanitize `anadromous`
- `creatures.ts` — `anadromous: true` on SPRING_TROUT
- `creature-sim.ts` — natal X recording at birth; spawning exhaustion + nutrient deposit; migration drive in steer()

Closes #3374

## Test plan
- [ ] Observe SPRING_TROUT recording a `natalX` in their state
- [ ] Observe adult SPRING_TROUT drifting toward their `natalX` instead of wandering
- [ ] Observe `caveNutrient` spike near spawn sites after trout breed
- [ ] Confirm trout die after spawning (hunger = 1)
- [ ] Check Field Guide for "Spawned and spent" log entry
- [ ] Vercel CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)