### PR TITLE
feat(micro-land): circadian clock, zeitgeber, and chronotype variation

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -791,6 +791,32 @@ export function tickCreatures(
     if (c.insightTimer && c.insightTimer > 0) c.insightTimer = Math.max(0, c.insightTimer - dt)
     if ((c as { symbiosisTimer?: number }).symbiosisTimer === undefined) c.symbiosisTimer = 0
     if (c.symbiosisTimer > 0) c.symbiosisTimer = Math.max(0, c.symbiosisTimer - dt)
+
+    // Circadian clock: advance internal phase at individual period (±10% of day length).
+    // Issue #3357, #3358, #3359.
+    if (TUNING.dayLengthSeconds > 0) {
+      if (c.circadianPhase === undefined) {
+        // First tick: initialize to a random phase (different individuals are out of sync)
+        c.circadianPhase = (c.id % 97) / 97  // deterministic spread using creature id
+      }
+      // Individual period variation: ±10% based on creature id (deterministic, not random)
+      const periodVariation = 1 + ((c.id % 17) - 8) / 80  // ±10%
+      const chronotypeOffset = (c.traits.chronotype ?? 0) * (2 / 24)  // ±2h expressed as fraction
+      c.circadianPhase = (c.circadianPhase + dt / (TUNING.dayLengthSeconds * periodVariation) + chronotypeOffset * dt / TUNING.dayLengthSeconds * 0.01) % 1
+      if (c.circadianPhase < 0) c.circadianPhase += 1
+
+      // Zeitgeber: dawn light resets circadian phase toward external time. Issue #3358.
+      // Underground creatures in deep cave (> 3 tiles) do not receive the signal.
+      const externalPhase = (w.elapsed % TUNING.dayLengthSeconds) / TUNING.dayLengthSeconds
+      const inDawnWindow = externalPhase < 0.1 || externalPhase > 0.95  // dawn/just-before-dawn
+      const isDeepCave = isUnderground(w, c) && cavityDepth(w, c) > 3
+      if (inDawnWindow && !isDeepCave) {
+        // Gentle pull toward external phase — not an instant reset, a gradual correction
+        const phaseError = ((c.circadianPhase - externalPhase + 1.5) % 1) - 0.5  // signed shortest-path error
+        c.circadianPhase = ((c.circadianPhase - phaseError * 0.003 * dt) + 1) % 1
+      }
+    }
+
     if ((c as { sick?: number }).sick === undefined) c.sick = 0
     if ((c as { carryingSeed?: unknown }).carryingSeed === undefined) {
       c.carryingSeed = null

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -83,6 +83,7 @@ export const NEUTRAL_TRAITS: Traits = Object.freeze({
   diurnal: 0,
   immunity: 0.2,
   reproductionCooldown: 1,
+  chronotype: 0,
 })
 
 /** A fresh set for a creature that wasn't born here. Always a copy — it's mutable state. */
@@ -130,8 +131,8 @@ function wrapHue(h: number): number {
 export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const drift = TUNING.traitDrift
   const hueDrift = drift * HUE_DRIFT_SCALE
-  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity' | 'reproductionCooldown') =>
-    b ? (a[key] + b[key]) / 2 : a[key]
+  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity' | 'reproductionCooldown' | 'chronotype') =>
+    b ? ((a[key] ?? 0) + (b[key] ?? 0)) / 2 : (a[key] ?? 0)
 
   return {
     speed: clamp(mix('speed') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
@@ -148,6 +149,7 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
     diurnal: clamp(mix('diurnal') + nudge(rng, drift), -1, 1),
     immunity: clamp(mix('immunity') + nudge(rng, drift), 0, 1),
     reproductionCooldown: clamp(mix('reproductionCooldown') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
+    chronotype: clamp(mix('chronotype') + nudge(rng, drift), -1, 1),
   }
 }
 
@@ -283,6 +285,8 @@ export function traitPhrases(t: Traits): string[] {
   else if ((t.immunity ?? 0.2) <= 0.05) phrases.push('susceptible')
   if ((t.reproductionCooldown ?? 1) <= 1 - NOTABLE) phrases.push('breeds quickly')
   else if ((t.reproductionCooldown ?? 1) >= 1 + NOTABLE) phrases.push('breeds slowly')
+  if ((t.chronotype ?? 0) <= -0.4) phrases.push('early riser')
+  else if ((t.chronotype ?? 0) >= 0.4) phrases.push('night owl')
   return phrases
 }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -793,6 +793,7 @@ export interface Traits {
    * Neutral at 1. Range [TRAIT_MIN, TRAIT_MAX].
    */
   reproductionCooldown: number
+  chronotype?: number  // phase offset trait: negative = early bird, positive = late owl, range [-1, 1]
 }
 
 /** One living thing in the world. */
@@ -1027,6 +1028,7 @@ export interface Creature {
   insightCount?: number
   /** X tile position where this creature was born (for anadromous migration). */
   natalX?: number  // X tile position where this creature was born (for anadromous migration)
+  circadianPhase?: number  // internal clock phase [0, 1]; 0 = subjective dawn, 0.5 = subjective dusk
 }
 
 /**


### PR DESCRIPTION
## Summary
- **#3357 — Internal circadian clock**: `circadianPhase?: number` [0,1] on each creature. Advances each tick at the creature's individual period (±10% of `dayLengthSeconds`, deterministic from `c.id % 17`). Phase is initialized at first tick from `c.id % 97` so individuals are naturally out of sync.
- **#3358 — Light zeitgeber**: During the dawn window (`externalPhase < 0.1` or `> 0.95`), surface creatures get a gentle phase-correction pull toward external time (0.3% per second). Deep-cave creatures (>3 solid tiles overhead) receive no light signal and free-run.
- **#3359 — Chronotype variation**: `chronotype?: number` trait added to `Traits`, range [-1, 1]. Heritable via `inherit()`. Gradually biases phase accumulation: early birds (negative) lead external time; night owls (positive) lag. Field Guide phrases: `'early riser'` / `'night owl'` at ±0.4 threshold.

## Changed files
- `types.ts` — `circadianPhase` on creature; `chronotype` on Traits
- `traits.ts` — `chronotype: 0` in `NEUTRAL_TRAITS`; added to `inherit()` blend; `traitPhrases()` descriptions
- `creature-sim.ts` — circadian advance + zeitgeber block in timer section

Closes #3357, #3358, #3359

## Test plan
- [ ] Confirm `circadianPhase` is set on creatures after first tick
- [ ] Confirm phase drifts in deep-cave creatures while surface creatures stay synchronized
- [ ] Confirm Field Guide shows "early riser" / "night owl" on creatures with extreme chronotype
- [ ] Vercel CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)