### PR TITLE
feat(micro-land): photoperiodism and clock disruption penalties

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -626,6 +626,10 @@ export function sanitizeBlueprint(
     uvNectar: b.uvNectar !== undefined ? !!b.uvNectar : undefined,
     uvSensitive: b.uvSensitive !== undefined ? !!b.uvSensitive : undefined,
     anadromous: b.anadromous !== undefined ? !!b.anadromous : undefined,
+    breedingPhotoperiod: b.breedingPhotoperiod === 'long' || b.breedingPhotoperiod === 'short'
+      ? b.breedingPhotoperiod
+      : undefined,
+    dormancyPhotoperiod: b.dormancyPhotoperiod !== undefined ? !!b.dormancyPhotoperiod : undefined,
     canLearnFoodWashing: !!b.canLearnFoodWashing,
     canInnovateTechniques: b.canInnovateTechniques !== undefined ? !!b.canInnovateTechniques : undefined,
     elderWisdom: !!b.elderWisdom,

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -817,6 +817,23 @@ export function tickCreatures(
       }
     }
 
+    // Clock disruption: creatures badly out of phase with local time suffer
+    // jet-lag equivalent penalties — mild hunger increase. Issue #3361.
+    if (
+      TUNING.dayLengthSeconds > 0 &&
+      c.circadianPhase !== undefined &&
+      !isUnderground(w, c)
+    ) {
+      const extPhase = (w.elapsed % TUNING.dayLengthSeconds) / TUNING.dayLengthSeconds
+      const rawErr = Math.abs(c.circadianPhase - extPhase)
+      const phaseErr = Math.min(rawErr, 1 - rawErr)  // shortest-path error [0, 0.5]
+      const jetlagThreshold = 4 / 24  // 4 hours in a 24-hour equivalent cycle
+      if (phaseErr > jetlagThreshold) {
+        const severity = (phaseErr - jetlagThreshold) / (0.5 - jetlagThreshold)  // 0→1
+        c.hunger = Math.min(1, c.hunger + severity * 0.00005 * dt)  // mild metabolic disruption
+      }
+    }
+
     if ((c as { sick?: number }).sick === undefined) c.sick = 0
     if ((c as { carryingSeed?: unknown }).carryingSeed === undefined) {
       c.carryingSeed = null
@@ -929,6 +946,12 @@ export function tickCreatures(
         const springRelief = moisture * heatStress  // high moisture = full relief
         c.hunger = Math.min(1, c.hunger + Math.max(0, heatStress - springRelief))
       }
+    }
+    // Winter dormancy: creatures with dormancyPhotoperiod slow metabolism
+    // in deep winter (seasonFactor < 0.7). Issue #3360.
+    if (bp.dormancyPhotoperiod && TUNING.seasonAmplitude > 0 && seasonFactor < 0.7) {
+      const dormancyDepth = Math.max(0, 0.7 - seasonFactor) / 0.7  // 0→1 as season goes from 0.7→0
+      c.hunger = Math.max(0, c.hunger - dormancyDepth * 0.0003 * dt)
     }
     if (c.hunger >= 1) {
       c.starving += dt
@@ -1595,8 +1618,14 @@ export function tickCreatures(
     // accumulated warmth (0–1000) has reached their seasonal window. When
     // seasons are disabled (seasonAmplitude=0), worldGdd returns 1000, so the
     // gate is permanently open and existing behaviour is unchanged.
-    const inBreedingSeason = !bp.phenology?.breedingGdd ||
+    // Photoperiod gate: long-day breeders require seasonFactor >= 1 (summer);
+    // short-day breeders require seasonFactor <= 1 (winter/autumn). Issue #3360.
+    const photoperiodOk = !bp.breedingPhotoperiod || TUNING.seasonAmplitude === 0 ||
+      (bp.breedingPhotoperiod === 'long' ? seasonFactor >= 1.0 : seasonFactor <= 1.0)
+    const inBreedingSeason = photoperiodOk && (
+      !bp.phenology?.breedingGdd ||
       worldGdd(w.elapsed) >= bp.phenology.breedingGdd + (c.phenoOffset ?? 0)
+    )
     if (
       inBreedingSeason &&
       readyToBreed(c, bp) &&

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -655,6 +655,19 @@ export interface CreatureBlueprint {
    * nutrients into the headwater ecosystem. Issue #3374.
    */
   anadromous?: boolean  // records natal X at birth; adult drives toward it to spawn and die
+  /**
+   * Photoperiod breeding gate. Issue #3360.
+   * 'long' = only breeds when seasonFactor >= 1 (long days, summer).
+   * 'short' = only breeds when seasonFactor <= 1 (short days, winter/autumn).
+   * undefined = no photoperiod restriction.
+   */
+  breedingPhotoperiod?: 'long' | 'short'
+  /**
+   * When true and deep winter (seasonFactor < 0.7), metabolic rate is reduced —
+   * the creature burns hunger more slowly. Models hibernation / torpor in species
+   * that slow down in response to short photoperiods. Issue #3360.
+   */
+  dormancyPhotoperiod?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

### #3360 — Photoperiodism
- `breedingPhotoperiod?: 'long' | 'short'` on blueprint: long-day breeders only reproduce when `seasonFactor ≥ 1.0` (summer); short-day breeders when `≤ 1.0` (winter/autumn)
- `dormancyPhotoperiod?: boolean`: when `seasonFactor < 0.7` (deep winter), hunger is reduced by up to `0.0003/s` × `dormancyDepth` — modelling hibernation/metabolic suppression
- Both effects are completely inert when `seasonAmplitude = 0` (default)

### #3361 — Clock disruption
- Each tick measures shortest-path phase error between `c.circadianPhase` and external time
- When phase error exceeds 4/24 (4 equivalent hours out of sync), a severity-scaled hunger penalty applies (up to `0.00005/s`)
- Underground creatures are exempt — they already free-run without a zeitgeber signal
- Requires `dayLengthSeconds > 0` to activate

## Changed files
- `types.ts` — `breedingPhotoperiod` and `dormancyPhotoperiod` on blueprint
- `blueprint.ts` — sanitize both fields
- `creature-sim.ts` — photoperiod breeding gate; dormancy hunger reduction; clock disruption block

Closes #3360, #3361

## Test plan
- [ ] Set `seasonAmplitude > 0`; assign `breedingPhotoperiod: 'long'` to a species; confirm they only breed in summer
- [ ] Assign `dormancyPhotoperiod: true`; confirm hunger rises slower in deep winter
- [ ] Enable day/night cycle; confirm clock disruption hunger penalty appears when creatures are briefly shifted
- [ ] Vercel CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)