### PR TITLE
feat(micro-land): river flow velocity zones — pool/run/riffle from gradient (#3370)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -627,6 +627,9 @@ export function sanitizeBlueprint(
     uvSensitive: b.uvSensitive !== undefined ? !!b.uvSensitive : undefined,
     canDrift: b.canDrift !== undefined ? !!b.canDrift : undefined,
     anadromous: b.anadromous !== undefined ? !!b.anadromous : undefined,
+    flowZonePreference: b.flowZonePreference === 'riffle' || b.flowZonePreference === 'run' || b.flowZonePreference === 'pool'
+      ? b.flowZonePreference
+      : undefined,
     canLearnFoodWashing: !!b.canLearnFoodWashing,
     canInnovateTechniques: b.canInnovateTechniques !== undefined ? !!b.canInnovateTechniques : undefined,
     elderWisdom: !!b.elderWisdom,

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -454,6 +454,7 @@ const SPRING_TROUT = builtin('spring-trout', {
   heatSensitive: true,
   phenology: { breedingGdd: 200 },  // spring spawner — breeds early, before summer heat
   anadromous: true,  // migrates back to natal headwater to spawn
+  flowZonePreference: 'riffle',  // fast oxygenated headwater — its native habitat
 })
 
 const EMBER_GRUB = builtin('ember-grub', {
@@ -1933,6 +1934,7 @@ const SHIMMER_LARVA = builtin('shimmer-larva', {
   aura: null,
   glow: 0.1,
   canDrift: true,
+  flowZonePreference: 'run',  // intermediate flow — grips substrate but stays in current
 })
 
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -935,6 +935,25 @@ export function tickCreatures(
         c.hunger = Math.min(1, c.hunger + Math.max(0, heatStress - springRelief))
       }
     }
+    // Flow zone preference: aquatic creatures thrive in their matched zone.
+    // Preferred zone → slight hunger relief; wrong zone → mild hunger increase.
+    // Zones are 1=pool, 2=run, 3=riffle; 0 means non-water tile. Issue #3370.
+    if (bp.flowZonePreference && w.flowZone) {
+      const fzx = Math.floor(c.x)
+      const fzy = Math.floor(c.y)
+      if (fzx >= 0 && fzx < WORLD_W && fzy >= 0 && fzy < WORLD_H) {
+        const zone = w.flowZone[fzy * WORLD_W + fzx]
+        if (zone > 0) {
+          const preferred =
+            bp.flowZonePreference === 'riffle' ? 3 : bp.flowZonePreference === 'run' ? 2 : 1
+          if (zone === preferred) {
+            c.hunger = Math.max(0, c.hunger - 0.00005 * dt)
+          } else {
+            c.hunger = Math.min(1, c.hunger + 0.00008 * dt)
+          }
+        }
+      }
+    }
     if (c.hunger >= 1) {
       c.starving += dt
       if (c.starving >= bp.diet.starveSeconds) {

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -966,6 +966,54 @@ export function tickMoisture(w: WorldState, tickCount: number, dt: number, rng: 
       }
     }
   }
+  updateFlowZones(w, tickCount)
+}
+
+/**
+ * Classify each water tile as pool (1), run (2), or riffle (3) based on the
+ * local height gradient of the solid-floor beneath neighbour columns.
+ *
+ * For a water tile at (x, y), scan down in columns x-1 and x+1 to find the
+ * first solid-tile Y in each. The absolute difference gives the gradient:
+ * >= 3 tiles = riffle (steep), >= 1 = run, 0 = pool (flat). Runs every 60
+ * ticks (~1 Hz). The overlay stays undefined in worlds with no water.
+ * Issue #3370.
+ */
+export function updateFlowZones(w: WorldState, tickCount: number): void {
+  if (tickCount % 60 !== 0) return
+
+  // Early exit if no water tiles exist.
+  let hasWater = false
+  for (let i = 0; i < WORLD_W * WORLD_H; i++) {
+    if (IS_LIQUID[w.tiles[i]] === 1) { hasWater = true; break }
+  }
+  if (!hasWater) return
+
+  w.flowZone ??= new Uint8Array(WORLD_W * WORLD_H)
+  w.flowZone.fill(0)
+
+  for (let y = 0; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) {
+      if (IS_LIQUID[w.tiles[y * WORLD_W + wrapCol(x)]] !== 1) continue
+
+      // Find Y of first solid tile at or below y in a given column.
+      let fL = WORLD_H
+      const xL = wrapCol(x - 1)
+      for (let fy = y; fy < WORLD_H; fy++) {
+        if (IS_SOLID[w.tiles[fy * WORLD_W + xL]] === 1) { fL = fy; break }
+      }
+
+      let fR = WORLD_H
+      const xR = wrapCol(x + 1)
+      for (let fy = y; fy < WORLD_H; fy++) {
+        if (IS_SOLID[w.tiles[fy * WORLD_W + xR]] === 1) { fR = fy; break }
+      }
+
+      const gradient = Math.abs(fL - fR)
+      const zone = gradient >= 3 ? 3 : gradient >= 1 ? 2 : 1
+      w.flowZone[y * WORLD_W + wrapCol(x)] = zone
+    }
+  }
 }
 
 /**

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -660,6 +660,13 @@ export interface CreatureBlueprint {
    * nutrients into the headwater ecosystem. Issue #3374.
    */
   anadromous?: boolean
+  /**
+   * Preferred flow-velocity zone for aquatic creatures. Creatures in their
+   * preferred zone get a slight hunger relief; in a mismatched zone, a mild
+   * penalty. Only meaningful for aquatic species. Issue #3370.
+   * 'riffle' = fast oxygenated water, 'run' = intermediate, 'pool' = slow silted.
+   */
+  flowZonePreference?: 'riffle' | 'run' | 'pool'
 }
 
 /**
@@ -1238,6 +1245,12 @@ export interface WorldState {
    * Boosts plant productivity in estuarine tiles. [0, 1] per tile.
    */
   marshDetritus?: Float32Array
+  /**
+   * Per-tile flow velocity zone for river/stream tiles.
+   * 0 = non-water or uncomputed, 1 = pool (slow), 2 = run (intermediate), 3 = riffle (fast).
+   * Only set on water tiles; all other tiles remain 0. Updated every 60 ticks.
+   */
+  flowZone?: Uint8Array
   eggs: Egg[]
   nextEggId: number
   /** Burrows dug by territorial creatures at their home positions. */


### PR DESCRIPTION
## Summary

- Adds `updateFlowZones()` in `world.ts`: every 60 ticks, each water tile is classified as pool (1), run (2), or riffle (3) by comparing the floor depth beneath its left and right neighbor columns — steep gradient = riffle, flat = pool
- Adds `flowZone?: Uint8Array` overlay to `WorldState`
- Adds `flowZonePreference?: 'riffle' | 'run' | 'pool'` to `CreatureBlueprint`; aquatic creatures in their preferred zone get a small hunger relief, mismatched zone a mild penalty
- SPRING_TROUT gets `flowZonePreference: 'riffle'`; SHIMMER_LARVA gets `flowZonePreference: 'run'`
- Sanitization wired in `blueprint.ts`

Closes #3370

## Test plan
- [ ] Vercel build passes (typecheck)
- [ ] SPRING_TROUT and SHIMMER_LARVA survival unaffected in flat-water worlds
- [ ] In a sloped water channel (staircase terrain), SPRING_TROUT congregate toward high-gradient tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)