### PR TITLE
feat(micro-land): invasion front propagation — track spread and display in Field Guide (#3366)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -78,6 +78,7 @@ export function FieldGuidePane() {
   const milestones = useMicroLand(s => s.milestones)
   const populationHistory = useMicroLand(s => s.populationHistory)
   const traitOverlay = useMicroLand(s => s.traitOverlay)
+  const invasionFront = useMicroLand(s => s.invasionFront)
   const setTraitOverlay = useMicroLand(s => s.setTraitOverlay)
   const addBlueprint = useMicroLand(s => s.addBlueprint)
   const trailsEnabled = useMicroLand(s => s.trailsEnabled)
@@ -1000,6 +1001,28 @@ function GuideEntry({
                           {' '}· {preyOverlap}% prey overlap
                         </span>
                       )}
+                    </>
+                  )
+                })()}
+              </>
+            )}
+            {bp.invasive && invasionFront[bp.id] && (
+              <>
+                <br />
+                {(() => {
+                  const { originX, frontX } = invasionFront[bp.id]
+                  const spread = Math.abs(frontX - originX)
+                  const pct = Math.round((spread / 672) * 100)
+                  return (
+                    <>
+                      <strong style={{ fontWeight: 600 }}>Invasion origin:</strong>{' '}
+                      tile {originX}
+                      <br />
+                      <strong style={{ fontWeight: 600 }}>Current front:</strong>{' '}
+                      tile {frontX} · spread {spread} tiles{' '}
+                      <span style={{ color: pct >= 50 ? '#ef4444' : pct >= 25 ? '#f97316' : 'var(--cc-text-muted)' }}>
+                        ({pct}% of world)
+                      </span>
                     </>
                   )
                 })()}

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -772,6 +772,25 @@ export function tickCreatures(
     speciesCount[c.blueprintId] = (speciesCount[c.blueprintId] ?? 0) + 1
   }
 
+  // Invasion front tracking: for each invasive species, record origin and
+  // track the historical maximum X spread. Runs every 60 ticks (once per
+  // second). Issue #3366.
+  if (tickCount % 60 === 0) {
+    w.invasionOriginX ??= {}
+    w.invasionFrontX ??= {}
+    for (const c of w.creatures) {
+      const cbp = w.blueprints[c.blueprintId]
+      if (!cbp?.invasive) continue
+      const cx = Math.floor(c.x)
+      if (w.invasionOriginX[c.blueprintId] === undefined) {
+        w.invasionOriginX[c.blueprintId] = cx
+      }
+      if (w.invasionFrontX[c.blueprintId] === undefined || cx > w.invasionFrontX[c.blueprintId]) {
+        w.invasionFrontX[c.blueprintId] = cx
+      }
+    }
+  }
+
   // Helpers — bees, worms, anything with an aura. Gathered once per tick
   // because the breeding check below asks "is one of these near me", and there
   // are normally none at all.

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1269,6 +1269,18 @@ export interface WorldState {
    * Boosts plant productivity in estuarine tiles. [0, 1] per tile.
    */
   marshDetritus?: Float32Array
+  /**
+   * X tile position where each invasive species was first observed in this
+   * world. Keyed by blueprintId. Populated lazily when the first individual
+   * of an invasive species is seen. Issue #3366.
+   */
+  invasionOriginX?: Record<string, number>
+  /**
+   * Maximum X tile position ever reached by each invasive species, ratcheting
+   * up monotonically. Keyed by blueprintId. Tracks the historical invasion
+   * front. Issue #3366.
+   */
+  invasionFrontX?: Record<string, number>
   eggs: Egg[]
   nextEggId: number
   /**

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -761,6 +761,22 @@ export class GameInstance {
       .sort((a, b) => b.ageSeconds - a.ageSeconds)
     useMicroLand.getState().setPopulationItems(thumbs)
 
+    // Invasion front data for Field Guide display.
+    if (this.world.invasionOriginX || this.world.invasionFrontX) {
+      const frontData: Record<string, { originX: number; frontX: number }> = {}
+      const origins = this.world.invasionOriginX ?? {}
+      const fronts = this.world.invasionFrontX ?? {}
+      for (const id of [...Object.keys(origins), ...Object.keys(fronts)]) {
+        if (origins[id] !== undefined) {
+          frontData[id] = {
+            originX: origins[id],
+            frontX: fronts[id] ?? origins[id],
+          }
+        }
+      }
+      useMicroLand.getState().setInvasionFront(frontData)
+    }
+
     // Speed run win/loss detection
     const sr = useMicroLand.getState().speedRun
     if (sr.active && sr.result === 'none') {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -449,6 +449,12 @@ interface MicroLandState {
    */
   populationItems: CreatureThumb[]
   setPopulationItems: (items: CreatureThumb[]) => void
+  /**
+   * Invasion front data for display in the Field Guide.
+   * Keyed by blueprintId; only populated for invasive species.
+   */
+  invasionFront: Record<string, { originX: number; frontX: number }>
+  setInvasionFront: (data: Record<string, { originX: number; frontX: number }>) => void
   /** Set when the Field Guide circle is clicked — game instance centers + inspects. */
   locateCreatureRequest: { id: number; serial: number } | null
   requestLocateCreature: (id: number) => void
@@ -648,6 +654,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   shelf: { worlds: [], activeId: null, busy: false, error: null },
   locateRequest: null,
   populationItems: [],
+  invasionFront: {},
   locateCreatureRequest: null,
   traitOverlay: null,
   compareId: null,
@@ -778,6 +785,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   requestLocate: blueprintId =>
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, sidebar: null }),
   setPopulationItems: items => set({ populationItems: items }),
+  setInvasionFront: data => set({ invasionFront: data }),
   requestLocateCreature: id =>
     set({ locateCreatureRequest: { id, serial: ++locateCreatureSerial } }),
   setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),


### PR DESCRIPTION
## Summary

- Adds `invasionOriginX` and `invasionFrontX` per-species records to `WorldState`, updated every 60 ticks for `bp.invasive === true` species
- Exposes invasion data via `invasionFront` in the Zustand store, populated from `pushStats()` in `game-instance.ts`
- Field Guide species card now shows invasion origin tile, current front tile, spread distance, and world coverage % (color-coded orange at 25%, red at 50%) for invasive species with active tracking data

Closes #3366

## Test plan
- [ ] Vercel build passes
- [ ] Place an invasive species; Field Guide shows invasion origin and front after ~1 second
- [ ] As species spreads, front tile increases monotonically; coverage % rises

🤖 Generated with [Claude Code](https://claude.com/claude-code)