### PR TITLE
feat(micro-land): cold stratification — temperate seeds wait for winter before germinating (#3352)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -631,6 +631,7 @@ export function sanitizeBlueprint(
       ? b.breedingPhotoperiod
       : undefined,
     dormancyPhotoperiod: b.dormancyPhotoperiod !== undefined ? !!b.dormancyPhotoperiod : undefined,
+    requiresStratification: b.requiresStratification !== undefined ? !!b.requiresStratification : undefined,
     flowZonePreference: b.flowZonePreference === 'riffle' || b.flowZonePreference === 'run' || b.flowZonePreference === 'pool'
       ? b.flowZonePreference
       : undefined,

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -692,6 +692,13 @@ function tickSeedBank(
 
   const HALF_LIFE = 600  // seconds to 50 % viability
 
+  // Compute current seasonal phase for cold stratification checks.
+  const seasonFactor = TUNING.seasonAmplitude > 0
+    ? Math.max(0.05, 1 + TUNING.seasonAmplitude * Math.sin((2 * Math.PI * w.elapsed) / TUNING.seasonPeriod))
+    : 1
+  const isCold = seasonFactor < 0.9
+  const STRATIFICATION_THRESHOLD = 120  // seconds of cold needed to break dormancy
+
   const surviving: SeedEntry[] = []
   for (const seed of w.seedBank) {
     seed.age += 60 * dt  // approximate: called every 60 ticks
@@ -701,6 +708,16 @@ function tickSeedBank(
     // Try germination
     const bp = w.blueprints[seed.blueprintId]
     if (!bp || bp.move.kind !== 'root') { surviving.push(seed); continue }
+
+    // Cold stratification: accumulate cold hours; gate germination until threshold met.
+    if (bp.requiresStratification && isCold) {
+      seed.coldHours = (seed.coldHours ?? 0) + 60 * dt
+    }
+    if (bp.requiresStratification && (seed.coldHours ?? 0) < STRATIFICATION_THRESHOLD) {
+      surviving.push(seed)  // not yet stratified — wait
+      continue
+    }
+
     if (plantsRef.value >= TUNING.maxPlants) { surviving.push(seed); continue }
     if ((speciesCount[seed.blueprintId] ?? 0) >= TUNING.plantSpeciesCap) { surviving.push(seed); continue }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -680,6 +680,13 @@ export interface CreatureBlueprint {
    * 'riffle' = fast oxygenated water, 'run' = intermediate, 'pool' = slow silted.
    */
   flowZonePreference?: 'riffle' | 'run' | 'pool'
+  /**
+   * Seeds of this species require cold stratification before they can germinate.
+   * Dispersed seeds accumulate cold exposure (when seasonFactor < 0.9); only after
+   * 120 seconds of cold do they become capable of germinating. Models temperate
+   * tree seeds that need winter to break dormancy. Issue #3352.
+   */
+  requiresStratification?: boolean
 }
 
 /**
@@ -1144,6 +1151,8 @@ export interface SeedEntry {
   y: number
   /** Seconds since this seed entered the seed bank. */
   age: number
+  /** Accumulated seconds of cold exposure (seasonFactor < 0.9) for stratification. */
+  coldHours?: number
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `requiresStratification?: boolean` to `CreatureBlueprint` and `coldHours?: number` to `SeedEntry`
- In `tickSeedBank`: when `seasonFactor < 0.9` (cold season), stratification-requiring seeds accumulate cold hours at `60 * dt` per call
- Germination is gated on `coldHours >= 120` (120 sim-seconds ≈ 40% of a 300s year = roughly half a winter)
- Seeds dispersed in autumn correctly wait through winter and germinate in spring; a brief autumn warm spell does not prematurely trigger germination

Closes #3352

## Test plan
- [ ] Vercel build passes
- [ ] Seeds with `requiresStratification: true` don't germinate until winter has accumulated cold hours
- [ ] Seeds without the flag germinate normally regardless of season

🤖 Generated with [Claude Code](https://claude.com/claude-code)