### PR TITLE
feat(micro-land): per-species seed longevity variation — configurable viability half-life (#3354)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -632,6 +632,7 @@ export function sanitizeBlueprint(
       : undefined,
     dormancyPhotoperiod: b.dormancyPhotoperiod !== undefined ? !!b.dormancyPhotoperiod : undefined,
     requiresStratification: b.requiresStratification !== undefined ? !!b.requiresStratification : undefined,
+    seedLongevity: typeof b.seedLongevity === 'number' && b.seedLongevity > 0 ? b.seedLongevity : undefined,
     flowZonePreference: b.flowZonePreference === 'riffle' || b.flowZonePreference === 'run' || b.flowZonePreference === 'pool'
       ? b.flowZonePreference
       : undefined,

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -61,6 +61,7 @@ const SUNLEAF = builtin('sunleaf', {
   aura: null,
   glow: 0,
   uvNectar: true,
+  seedLongevity: 2400,  // fire-adapted pioneer: seeds persist for multiple seasons awaiting open ground
 })
 
 const BRAMBLE = builtin('bramble', {
@@ -154,6 +155,7 @@ const SPORECAP = builtin('sporecap', {
   death: { becomes: null, particleColor: '#b9a6ff', particleCount: 6 },
   aura: null,
   glow: 0.55,
+  seedLongevity: 1800,  // persistent spore bank: fungal spores outlast multiple population crashes
 })
 
 const SNAP_TRAP = builtin('snap-trap', {
@@ -192,6 +194,7 @@ const SNAP_TRAP = builtin('snap-trap', {
   death: { becomes: null, particleColor: '#2a6b2a', particleCount: 6 },
   aura: null,
   glow: 0,
+  seedLongevity: 150,  // transient seed bank: must germinate within a season or die
 })
 
 const PITCHER_PLANT = builtin('pitcher-plant', {
@@ -223,6 +226,7 @@ const PITCHER_PLANT = builtin('pitcher-plant', {
   death: { becomes: null, particleColor: '#3a7a2a', particleCount: 6 },
   aura: null,
   glow: 0,
+  seedLongevity: 150,  // transient seed bank: must germinate within a season or die
 })
 
 const SUNDEW = builtin('sundew', {
@@ -254,6 +258,7 @@ const SUNDEW = builtin('sundew', {
   death: { becomes: null, particleColor: '#2d5a1f', particleCount: 6 },
   aura: null,
   glow: 0,
+  seedLongevity: 150,  // transient seed bank: must germinate within a season or die
 })
 
 // ---------------------------------------------------------------------------
@@ -985,6 +990,7 @@ const GLOWVINE = builtin('glowvine', {
   aura: null,
   glow: 0.62,
   uvNectar: true,
+  seedLongevity: 1800,  // persistent spore bank: cave-adapted, seeds survive extended dark periods
 })
 
 const PALECRAWLER = builtin('palecrawler', {
@@ -1839,6 +1845,7 @@ const SALT_MARSH_REED = builtin('salt-marsh-reed', {
   aura: null,
   glow: 0,
   salinityTolerance: { min: 0.2, max: 0.7 },  // thrives in brackish mixing zone
+  seedLongevity: 150,  // transient seed bank: annual grass, seeds must germinate within one season
 })
 
 const MANGROVE = builtin('mangrove', {
@@ -1871,6 +1878,7 @@ const MANGROVE = builtin('mangrove', {
   glow: 0,
   aerialRoots: true,
   salinityTolerance: { min: 0.0, max: 0.4 },
+  seedLongevity: 1800,  // persistent seed bank: long-lived tree seeds outlast multiple seasons
 })
 
 const UV_BEE = builtin('uv-bee', {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -702,12 +702,14 @@ function tickSeedBank(
   const surviving: SeedEntry[] = []
   for (const seed of w.seedBank) {
     seed.age += 60 * dt  // approximate: called every 60 ticks
-    const viability = Math.pow(0.5, seed.age / HALF_LIFE)
-    if (rng() > viability) continue  // seed died
 
     // Try germination
     const bp = w.blueprints[seed.blueprintId]
     if (!bp || bp.move.kind !== 'root') { surviving.push(seed); continue }
+
+    const halfLife = bp.seedLongevity ?? HALF_LIFE
+    const viability = Math.pow(0.5, seed.age / halfLife)
+    if (rng() > viability) continue  // seed died
 
     // Cold stratification: accumulate cold hours; gate germination until threshold met.
     if (bp.requiresStratification && isCold) {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -710,6 +710,14 @@ export interface CreatureBlueprint {
    * tree seeds that need winter to break dormancy. Issue #3352.
    */
   requiresStratification?: boolean
+  /**
+   * Viability half-life of dormant seeds in seconds. Seeds decay exponentially:
+   * viability = 0.5^(age / seedLongevity). Short-lived (transient bank, ~150 s)
+   * seeds must germinate within one season or die. Long-lived (persistent bank,
+   * ~1800 s) seeds can outlast multiple extinctions. Defaults to 600 s if unset.
+   * Issue #3354.
+   */
+  seedLongevity?: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `seedLongevity` to `CreatureBlueprint`: species-specific viability half-life in seconds
- Moves blueprint lookup before viability check in `tickSeedBank` so per-species longevity is accessible
- Viability formula uses `bp.seedLongevity ?? HALF_LIFE` (600 s default unchanged)
- Short-lived (transient bank, 150 s): SNAP_TRAP, PITCHER_PLANT, SUNDEW, SALT_MARSH_REED — must germinate within one season or die
- Long-lived (persistent bank, 1800 s): SPORECAP, GLOWVINE, MANGROVE — outlast population crashes
- SUNLEAF (fire-adapted pioneer) gets 2400 s — seeds wait across multiple seasons for the next lava event

## Closes
Closes #3354

## Test plan
- [ ] Short-longevity seeds disappear from seed bank within ~150 s without germinating
- [ ] Long-longevity seeds persist through multiple seasons in the bank
- [ ] Species without `seedLongevity` still use the 600 s HALF_LIFE default
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)