### PR TITLE
feat(micro-land): seed bank diversity rescue — extinct species re-establish from dormant seeds (#3355)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -450,8 +450,12 @@ export interface SimEvent {
    * `eaten` is from the victim's side (this species lost one); `ate` is from the
    * hunter's side and carries who it caught. Both fire for a single kill — the
    * UI wants the hunter's framing, the extinction check wants the victim's.
+   *
+   * `diversity-rescue` fires when a species germinates from the seed bank after
+   * going locally extinct (speciesCount was 0 at the moment of germination). The
+   * field guide removes the species from the extinctions list on receiving this.
    */
-  kind: 'born' | 'eaten' | 'ate' | 'starved' | 'drowned' | 'burned' | 'aged' | 'diseased' | 'sick'
+  kind: 'born' | 'eaten' | 'ate' | 'starved' | 'drowned' | 'burned' | 'aged' | 'diseased' | 'sick' | 'diversity-rescue'
   blueprintId: string
   /** Only set on `ate`: the blueprint id of what was caught. */
   victimId?: string
@@ -685,7 +689,8 @@ function tickSeedBank(
   tickCount: number,
   speciesCount: Record<string, number>,
   plantsRef: { value: number },
-  rng: Rng
+  rng: Rng,
+  events: SimEvent[]
 ): void {
   if (!w.seedBank || w.seedBank.length === 0) return
   if (tickCount % 60 !== 0) return  // run once per second
@@ -730,10 +735,12 @@ function tickSeedBank(
       if (plantsRef.value >= TUNING.maxPlants) { surviving.push(seed); continue }
       if ((speciesCount[seed.blueprintId] ?? 0) >= TUNING.plantSpeciesCap) { surviving.push(seed); continue }
       const { w: bw, h: bh } = artSize(bp)
+      const wasExtinct = (speciesCount[seed.blueprintId] ?? 0) === 0
       const germinated = reproduce(w, bp, seed.x + 0.5, seed.y, bw, bh, rng)
       if (germinated) {
         plantsRef.value++
         speciesCount[seed.blueprintId] = (speciesCount[seed.blueprintId] ?? 0) + 1
+        if (wasExtinct) events.push({ kind: 'diversity-rescue', blueprintId: seed.blueprintId, x: seed.x, y: seed.y })
       } else {
         surviving.push(seed)  // wait for better ground conditions
       }
@@ -754,11 +761,13 @@ function tickSeedBank(
 
     // Try to germinate via the same reproduce path the pollinator uses.
     const { w: bw, h: bh } = artSize(bp)
+    const wasExtinct = (speciesCount[seed.blueprintId] ?? 0) === 0
     const germinated = reproduce(w, bp, seed.x + 0.5, seed.y, bw, bh, rng)
     if (germinated) {
       plantsRef.value++
       speciesCount[seed.blueprintId] = (speciesCount[seed.blueprintId] ?? 0) + 1
       // Don't push seed — it germinated successfully
+      if (wasExtinct) events.push({ kind: 'diversity-rescue', blueprintId: seed.blueprintId, x: seed.x, y: seed.y })
     } else {
       surviving.push(seed)
     }
@@ -2319,7 +2328,7 @@ export function tickCreatures(
       if (w.blueprints[c.blueprintId]?.move.kind === 'root') sbPlantsAlive++
     }
     const plantsRef = { value: sbPlantsAlive }
-    tickSeedBank(w, dt, tickCount, sbSpeciesCount, plantsRef, rng)
+    tickSeedBank(w, dt, tickCount, sbSpeciesCount, plantsRef, rng, events)
   }
 }
 

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -562,6 +562,19 @@ export class GameInstance {
       if (isSoundEnabled()) playExtinction()
     }
 
+    // Seed bank diversity rescue: a species that went locally extinct has
+    // germinated from dormant seeds still in the soil. Remove it from the
+    // field guide's memorial list and let the player know.
+    for (const event of events) {
+      if (event.kind !== 'diversity-rescue') continue
+      const bp = this.world.blueprints[event.blueprintId]
+      if (!bp) continue
+      useMicroLand.getState().removeExtinction(event.blueprintId)
+      // Re-add to knownSpecies so a second extinction will be noticed again.
+      this.knownSpecies.add(event.blueprintId)
+      notify(`A ${bp.name} has re-emerged from dormant seeds in the soil.`)
+    }
+
     // Accumulate lifetime stats.
     let totalBorn = 0, totalDeaths = 0, totalEats = 0
     let longestLived = worldStats.longestLived

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -512,6 +512,7 @@ interface MicroLandState {
   clearGeneratorConfigRequest: () => void
   setStats: (population: PopulationEntry[], total: number, elapsed: number) => void
   addExtinction: (record: ExtinctionRecord) => void
+  removeExtinction: (blueprintId: string) => void
   clearExtinctions: () => void
   updateWorldStats: (patch: Partial<WorldStats>) => void
   resetWorldStats: () => void
@@ -706,6 +707,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
       }
     }),
   addExtinction: record => set(s => ({ extinctions: [...s.extinctions, record] })),
+  removeExtinction: blueprintId => set(s => ({ extinctions: s.extinctions.filter(e => e.blueprintId !== blueprintId) })),
   clearExtinctions: () => set({ extinctions: [] }),
   updateWorldStats: patch => set(s => ({ worldStats: { ...s.worldStats, ...patch } })),
   resetWorldStats: () => set({ worldStats: { ...EMPTY_STATS } }),


### PR DESCRIPTION
## Summary
- Adds `'diversity-rescue'` to `SimEvent.kind` union
- Threads `events` parameter into `tickSeedBank` so germination events can be emitted
- When a seed germinates and the species had 0 living individuals (locally extinct), a `diversity-rescue` event fires
- `game-instance.ts` handles the event: calls `removeExtinction()` on the store and shows a notice: "A {name} has re-emerged from dormant seeds in the soil."
- Adds `removeExtinction` action to store to remove a blueprintId from the extinctions list

## Closes
Closes #3355

## Test plan
- [ ] Kill all individuals of a plant species that had seeds in the bank; observe notice "re-emerged from dormant seeds" appear
- [ ] Extinct species disappears from extinctions panel, then reappears only if it goes extinct again
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)