### PR TITLE
feat(micro-land): light-gap germination — canopy-gap seeds sprout when overhead cover opens (#3351)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -639,6 +639,7 @@ export function sanitizeBlueprint(
     migratory: b.migratory !== undefined ? !!b.migratory : undefined,
     magnetoreceptive: b.magnetoreceptive !== undefined ? !!b.magnetoreceptive : undefined,
     fireGerminator: b.fireGerminator !== undefined ? !!b.fireGerminator : undefined,
+    lightGapGerminator: b.lightGapGerminator !== undefined ? !!b.lightGapGerminator : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -62,6 +62,7 @@ const SUNLEAF = builtin('sunleaf', {
   glow: 0,
   uvNectar: true,
   fireGerminator: true,  // pioneer plant: fire-scarified seeds germinate in ash-cleared ground
+  lightGapGerminator: true,  // gap-dependent pioneer: seeds sprout when canopy opens above them. Issue #3351.
   seedLongevity: 2400,  // fire-adapted pioneer: seeds persist for multiple seasons awaiting open ground
 })
 
@@ -94,6 +95,7 @@ const BRAMBLE = builtin('bramble', {
   death: { becomes: null, particleColor: '#57b04a', particleCount: 5 },
   aura: null,
   glow: 0,
+  lightGapGerminator: true,  // gap-loving shrub: colonises treefall gaps. Issue #3351.
 })
 
 const KELP = builtin('kelp', {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -737,6 +737,26 @@ function tickSeedBank(
       continue  // don't fall through to normal germination
     }
 
+    // Light-gap germinator: germinates eagerly when canopy opens above the seed.
+    if (bp.lightGapGerminator && w.lightGrid) {
+      const lightLevel = w.lightGrid[seed.y * WORLD_W + seed.x]
+      if (lightLevel < 0.4) { surviving.push(seed); continue }  // still shaded — wait
+      // Light gap detected: attempt immediate germination
+      if (plantsRef.value >= TUNING.maxPlants) { surviving.push(seed); continue }
+      if ((speciesCount[seed.blueprintId] ?? 0) >= TUNING.plantSpeciesCap) { surviving.push(seed); continue }
+      const { w: bw, h: bh } = artSize(bp)
+      const wasExtinct = (speciesCount[seed.blueprintId] ?? 0) === 0
+      const germinated = reproduce(w, bp, seed.x + 0.5, seed.y, bw, bh, rng)
+      if (germinated) {
+        plantsRef.value++
+        speciesCount[seed.blueprintId] = (speciesCount[seed.blueprintId] ?? 0) + 1
+        if (wasExtinct) events.push({ kind: 'diversity-rescue', blueprintId: seed.blueprintId, x: seed.x, y: seed.y } as SimEvent)
+      } else {
+        surviving.push(seed)
+      }
+      continue
+    }
+
     const halfLife = bp.seedLongevity ?? HALF_LIFE
     const viability = Math.pow(0.5, seed.age / halfLife)
     if (rng() > viability) continue  // seed died

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -967,6 +967,7 @@ export function tickMoisture(w: WorldState, tickCount: number, dt: number, rng: 
     }
   }
   updateFlowZones(w, tickCount)
+  tickLight(w, tickCount)
 }
 
 /**
@@ -1012,6 +1013,27 @@ export function updateFlowZones(w: WorldState, tickCount: number): void {
       const gradient = Math.abs(fL - fR)
       const zone = gradient >= 3 ? 3 : gradient >= 1 ? 2 : 1
       w.flowZone[y * WORLD_W + wrapCol(x)] = zone
+    }
+  }
+}
+
+/**
+ * Compute the per-tile light level by column-sweep from the top of the world.
+ *
+ * Starts at full sunlight (1.0) at row 0 and attenuates by 0.25 for each solid
+ * tile encountered, reaching near-zero under thick overhangs or cave ceilings.
+ * Air and liquid tiles are transparent. Runs every 30 ticks (same cadence as
+ * tickMoisture). Used by the light-gap germination trigger. Issue #3351.
+ */
+export function tickLight(w: WorldState, tickCount: number): void {
+  if (tickCount % 30 !== 0) return
+  w.lightGrid ??= new Float32Array(WORLD_W * WORLD_H)
+  for (let x = 0; x < WORLD_W; x++) {
+    let light = 1.0
+    for (let y = 0; y < WORLD_H; y++) {
+      const tileIdx = w.tiles[y * WORLD_W + wrapCol(x)]
+      if (IS_SOLID[tileIdx] === 1) light *= 0.25
+      w.lightGrid[y * WORLD_W + x] = light
     }
   }
 }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -719,6 +719,13 @@ export interface CreatureBlueprint {
    */
   fireGerminator?: boolean
   /**
+   * Seeds of this species germinate preferentially in light gaps — openings in the
+   * canopy created by treefall or disturbance. When `lightGrid` at the seed's tile
+   * exceeds 0.4, the seed attempts immediate germination. Models gap-dependent
+   * pioneers like SUNLEAF and BRAMBLE. Issue #3351.
+   */
+  lightGapGerminator?: boolean
+  /**
    * Viability half-life of dormant seeds in seconds. Seeds decay exponentially:
    * viability = 0.5^(age / seedLongevity). Short-lived (transient bank, ~150 s)
    * seeds must germinate within one season or die. Long-lived (persistent bank,
@@ -1350,6 +1357,12 @@ export interface WorldState {
    * Only set on water tiles; all other tiles remain 0. Updated every 60 ticks.
    */
   flowZone?: Uint8Array
+  /**
+   * Per-tile light level [0, 1]. 1 = full sky exposure, 0 = complete shade.
+   * Computed by column-sweep from top to bottom: each solid tile attenuates by 0.25.
+   * Updated every 30 ticks. Used for light-gap germination triggers. Issue #3351.
+   */
+  lightGrid?: Float32Array
   eggs: Egg[]
   nextEggId: number
   /**


### PR DESCRIPTION
## Summary
- Adds `lightGrid: Float32Array` to `WorldState`: per-tile light level [0–1] computed by column sweep from sky; each solid tile attenuates by 0.25
- Adds `tickLight()` to `world.ts`, running every 30 ticks, called alongside `updateFlowZones`
- Adds `lightGapGerminator` flag to `CreatureBlueprint`
- In `tickSeedBank`: light-gap species check `lightGrid` at their tile; if > 0.4 (open canopy) they attempt immediate germination; otherwise remain dormant
- SUNLEAF and BRAMBLE gain `lightGapGerminator: true` — pioneer plants that rush into gaps when a tree falls

## Closes
Closes #3351

## Test plan
- [ ] Place SUNLEAF seeds under solid tiles; confirm they stay dormant
- [ ] Clear tiles above; confirm seeds germinate within 1-2 tickSeedBank cycles (~2–4 s)
- [ ] Species without `lightGapGerminator` are unaffected by light changes
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)