### PR TITLE
feat(micro-land): Whittaker biome classification per horizontal region band (#3377)

### DIFF
--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -548,3 +548,9 @@ export const SPAWNER_DEFAULT_INTERVAL = 10
  * a small area while still letting the species spread.
  */
 export const SPAWNER_DEFAULT_MAX_LOCAL = 5
+
+/** Number of horizontal region bands for biome classification (Issue #3377). */
+export const NUM_BIOME_REGIONS = 8
+
+/** Height in rows of each biome region band. */
+export const BIOME_REGION_H = Math.ceil(WORLD_H / NUM_BIOME_REGIONS)  // 17

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -62,6 +62,7 @@ import {
   tickMoisture,
   tickSalinity,
   tileAt,
+  updateBiomeZones,
 } from './world'
 
 import type { Rng } from './prng'
@@ -830,6 +831,8 @@ export function tickCreatures(
           1 + TUNING.seasonAmplitude * Math.sin((2 * Math.PI * w.elapsed) / TUNING.seasonPeriod)
         )
       : 1
+
+  updateBiomeZones(w, tickCount, seasonFactor)
 
   const creatures = w.creatures
   const dead = new Set<number>()

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -14,6 +14,8 @@ import {
 import type { Biome } from '../config/biomes'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from '@/app/micro-land/domain/config/themes'
 import {
+  BIOME_REGION_H,
+  NUM_BIOME_REGIONS,
   PLANT_SEED_INTERVAL,
   SURFACE_SEEDING_BIAS,
   WIDTH_SCALE,
@@ -23,6 +25,8 @@ import {
 import { neutralTraits } from '@/app/micro-land/domain/traits'
 import { TUNING } from '@/app/micro-land/domain/tuning'
 import type {
+  BiomeZone,
+  BiomeZoneType,
   Creature,
   CreatureBlueprint,
   MaterialId,
@@ -1152,6 +1156,57 @@ export function countByBlueprint(w: WorldState): Record<string, number> {
   const counts: Record<string, number> = {}
   for (const c of w.creatures) counts[c.blueprintId] = (counts[c.blueprintId] ?? 0) + 1
   return counts
+}
+
+/**
+ * Compute Whittaker biome classification for each of the 8 horizontal region
+ * bands. Temperature is derived from the band's Y midpoint and seasonFactor;
+ * precipitation is the mean moisture across the band. Runs every 300 ticks.
+ * Issue #3377.
+ */
+export function updateBiomeZones(w: WorldState, tickCount: number, seasonFactor: number): void {
+  if (tickCount % 300 !== 0) return
+  w.biomeZones ??= []
+  for (let r = 0; r < NUM_BIOME_REGIONS; r++) {
+    const midY = r * BIOME_REGION_H + Math.floor(BIOME_REGION_H / 2)
+    const baseTemp = Math.max(0, 1 - midY / WORLD_H)
+    const temperature = Math.min(1, baseTemp * seasonFactor)
+
+    // Sample moisture across every 4th column of every row in the band
+    const rowStart = r * BIOME_REGION_H
+    const rowEnd = Math.min(rowStart + BIOME_REGION_H, WORLD_H)
+    let sum = 0, count = 0
+    for (let y = rowStart; y < rowEnd; y++) {
+      for (let x = 0; x < WORLD_W; x += 4) {
+        sum += w.moisture[y * WORLD_W + x] ?? 0
+        count++
+      }
+    }
+    const precipitation = count > 0 ? sum / count : 0
+
+    w.biomeZones[r] = { regionIndex: r, type: classifyBiome(temperature, precipitation), temperature, precipitation }
+  }
+}
+
+function classifyBiome(temp: number, precip: number): BiomeZoneType {
+  if (temp < 0.1) return 'ice-cap'
+  if (temp < 0.2) return 'tundra'
+  if (temp < 0.35) return precip >= 0.2 ? 'boreal' : 'desert'
+  if (temp < 0.75) return precip >= 0.3 ? 'temperate-forest' : 'temperate-grassland'
+  // temp >= 0.75 (tropical)
+  if (precip >= 0.5) return 'tropical-rainforest'
+  if (precip >= 0.2) return 'tropical-savanna'
+  return 'desert'
+}
+
+/**
+ * Return the biome type at a given Y tile coordinate, or null if biome zones
+ * have not been computed yet. O(1) lookup. Issue #3377.
+ */
+export function biomeZoneAt(w: WorldState, y: number): BiomeZoneType | null {
+  if (!w.biomeZones) return null
+  const r = Math.min(NUM_BIOME_REGIONS - 1, Math.floor(y / BIOME_REGION_H))
+  return w.biomeZones[r]?.type ?? null
 }
 
 export { AIR }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1302,6 +1302,33 @@ export interface WorldGeneratorEntry {
   nextSeed: number
 }
 
+/**
+ * Whittaker biome classification — one of eight climate zones.
+ * Assigned per horizontal region band (8 bands from sky to bedrock).
+ * Issue #3377.
+ */
+export type BiomeZoneType =
+  | 'tropical-rainforest'
+  | 'tropical-savanna'
+  | 'desert'
+  | 'temperate-grassland'
+  | 'temperate-forest'
+  | 'boreal'
+  | 'tundra'
+  | 'ice-cap'
+
+/** One classified biome band — a full-width horizontal slice of the world. */
+export interface BiomeZone {
+  /** Region index (0 = top/coldest, NUM_BIOME_REGIONS-1 = bottom/warmest). */
+  regionIndex: number
+  /** Classified biome type for this band. */
+  type: BiomeZoneType
+  /** Annual temperature proxy [0, 1]; higher = warmer. Derived from Y position × seasonFactor. */
+  temperature: number
+  /** Average moisture [0, 1] sampled across region tiles. */
+  precipitation: number
+}
+
 export interface WorldState {
   width: number
   height: number
@@ -1406,6 +1433,13 @@ export interface WorldState {
   nextSpawnerId: number
   /** Per-species background-seeding config. Plants default to enabled. */
   generators: WorldGeneratorEntry[]
+  /**
+   * Whittaker biome zones — one entry per horizontal region band.
+   * 8 bands by default (top = coldest/sky, bottom = warmest/deep). Updated
+   * by `updateBiomeZones` every 300 ticks. Undefined until first pass.
+   * Issue #3377.
+   */
+  biomeZones?: BiomeZone[]
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `BiomeZoneType` (8 Whittaker biomes) and `BiomeZone` to types.ts
- Adds `biomeZones?: BiomeZone[]` to `WorldState`
- Adds `NUM_BIOME_REGIONS = 8` and `BIOME_REGION_H = 17` constants
- `updateBiomeZones(w, tickCount, seasonFactor)` in world.ts: every 300 ticks, classifies each horizontal band from temperature (Y-axis gradient × seasonFactor) and precipitation (sampled from moisture overlay)
- `biomeZoneAt(w, y)` helper for O(1) lookup — prerequisite for #3378 biome gating
- Called from creature-sim.ts immediately after seasonFactor is computed

## Classification matrix
| Temp | Precip | Biome |
|---|---|---|
| < 0.1 | any | ice-cap |
| < 0.2 | any | tundra |
| < 0.35 | ≥ 0.2 | boreal |
| < 0.35 | < 0.2 | desert |
| < 0.75 | ≥ 0.3 | temperate-forest |
| < 0.75 | < 0.3 | temperate-grassland |
| ≥ 0.75 | ≥ 0.5 | tropical-rainforest |
| ≥ 0.75 | ≥ 0.2 | tropical-savanna |
| ≥ 0.75 | < 0.2 | desert |

## Closes
Closes #3377

## Test plan
- [ ] With default seasonAmplitude=0, biomes are static: top band = coldest, bottom = warmest
- [ ] With seasonAmplitude>0, biomes shift toward warmer/cooler seasonally
- [ ] `biomeZoneAt` returns null before first tick-300 update
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)