### PR TITLE
feat(micro-land): biome zone overlay in Field Guide — Whittaker classification by world region (#3380)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -79,6 +79,7 @@ export function FieldGuidePane() {
   const populationHistory = useMicroLand(s => s.populationHistory)
   const traitOverlay = useMicroLand(s => s.traitOverlay)
   const invasionFront = useMicroLand(s => s.invasionFront)
+  const biomeZones = useMicroLand(s => s.biomeZones)
   const setTraitOverlay = useMicroLand(s => s.setTraitOverlay)
   const addBlueprint = useMicroLand(s => s.addBlueprint)
   const trailsEnabled = useMicroLand(s => s.trailsEnabled)
@@ -130,6 +131,24 @@ export function FieldGuidePane() {
     } else {
       setCompareTarget(bpId)
     }
+  }
+
+  function biomeIcon(type: string): string {
+    const icons: Record<string, string> = {
+      'tropical-rainforest': '🌴',
+      'tropical-savanna': '🌿',
+      'desert': '🏜',
+      'temperate-grassland': '🌾',
+      'temperate-forest': '🌲',
+      'boreal': '🌲',
+      'tundra': '❄',
+      'ice-cap': '🧊',
+    }
+    return icons[type] ?? '🌍'
+  }
+
+  function biomeLabel(type: string): string {
+    return type.split('-').map((w: string) => w[0].toUpperCase() + w.slice(1)).join(' ')
   }
 
   return (
@@ -611,6 +630,39 @@ export function FieldGuidePane() {
                 <span>🦴 {ext.name}</span>
                 <span style={{ color: 'var(--cc-text-muted)', fontSize: 10 }}>
                   gen {ext.maxGeneration} · {Math.round(ext.livedFor / 60)} min
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {biomeZones.length > 0 && (
+        <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+          <h3 className="pb-2" style={sectionHeading}>
+            Climate Zones
+          </h3>
+          <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
+            Whittaker biome classification by world depth — temperature and moisture shape each band&rsquo;s ecology.
+          </p>
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {biomeZones.map(zone => (
+              <li
+                key={zone.regionIndex}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'baseline',
+                  padding: '3px 0',
+                  fontSize: 11,
+                  fontFamily: 'var(--cc-font-mono)',
+                }}
+              >
+                <span>
+                  {biomeIcon(zone.type)}{' '}{biomeLabel(zone.type)}
+                </span>
+                <span style={{ color: 'var(--cc-text-muted)', fontSize: 10 }}>
+                  {Math.round(zone.temperature * 100)}&deg;&nbsp;&nbsp;{Math.round(zone.precipitation * 100)}%
                 </span>
               </li>
             ))}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -790,6 +790,11 @@ export class GameInstance {
       useMicroLand.getState().setInvasionFront(frontData)
     }
 
+    // Biome zone data for Field Guide display.
+    if (this.world.biomeZones && this.world.biomeZones.length > 0) {
+      useMicroLand.getState().setBiomeZones(this.world.biomeZones)
+    }
+
     // Speed run win/loss detection
     const sr = useMicroLand.getState().speedRun
     if (sr.active && sr.result === 'none') {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -455,6 +455,12 @@ interface MicroLandState {
    */
   invasionFront: Record<string, { originX: number; frontX: number }>
   setInvasionFront: (data: Record<string, { originX: number; frontX: number }>) => void
+  /**
+   * Whittaker biome classification for each world region band.
+   * Synced from world.biomeZones by game-instance. Empty until first pass.
+   */
+  biomeZones: import('./domain/types').BiomeZone[]
+  setBiomeZones: (zones: import('./domain/types').BiomeZone[]) => void
   /** Set when the Field Guide circle is clicked — game instance centers + inspects. */
   locateCreatureRequest: { id: number; serial: number } | null
   requestLocateCreature: (id: number) => void
@@ -656,6 +662,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   locateRequest: null,
   populationItems: [],
   invasionFront: {},
+  biomeZones: [],
   locateCreatureRequest: null,
   traitOverlay: null,
   compareId: null,
@@ -788,6 +795,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, sidebar: null }),
   setPopulationItems: items => set({ populationItems: items }),
   setInvasionFront: data => set({ invasionFront: data }),
+  setBiomeZones: zones => set({ biomeZones: zones }),
   requestLocateCreature: id =>
     set({ locateCreatureRequest: { id, serial: ++locateCreatureSerial } }),
   setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),


### PR DESCRIPTION
## Summary
- Adds `biomeZones: BiomeZone[]` and `setBiomeZones` to the store
- Syncs `world.biomeZones` to store in `game-instance.ts` `pushStats()`
- Field Guide gains a "Climate Zones" section (rendered after Extinctions when data exists) showing all 8 region bands with emoji icon, biome name, temperature %, and precipitation %

## Closes
Closes #3380

## Test plan
- [ ] Field Guide shows Climate Zones section after first 300-tick classification pass
- [ ] All 8 bands listed with correct labels (Tropical Rainforest, Tundra, etc.)
- [ ] Temperature and precipitation values update as seasons change (with seasonAmplitude > 0)
- [ ] Section hidden when biomeZones not yet computed
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)