### PR TITLE
feat(micro-land): biome creep under warming — atmospheric CO2 from lava shifts biome zones (#3381)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -80,6 +80,7 @@ export function FieldGuidePane() {
   const traitOverlay = useMicroLand(s => s.traitOverlay)
   const invasionFront = useMicroLand(s => s.invasionFront)
   const biomeZones = useMicroLand(s => s.biomeZones)
+  const atmosphericCO2 = useMicroLand(s => s.atmosphericCO2)
   const setTraitOverlay = useMicroLand(s => s.setTraitOverlay)
   const addBlueprint = useMicroLand(s => s.addBlueprint)
   const trailsEnabled = useMicroLand(s => s.trailsEnabled)
@@ -645,6 +646,12 @@ export function FieldGuidePane() {
           <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
             Whittaker biome classification by world depth — temperature and moisture shape each band&rsquo;s ecology.
           </p>
+          {atmosphericCO2 > 0.05 && (
+            <p className="biome-co2-warning" style={{ fontSize: 11, color: 'var(--cc-gold)', marginBottom: 8 }}>
+              CO&#x2082;: {Math.round(atmosphericCO2 * 100)}% above baseline
+              {atmosphericCO2 > 0.5 ? ' — biomes shifting rapidly' : atmosphericCO2 > 0.2 ? ' — warming detected' : ''}
+            </p>
+          )}
           <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
             {biomeZones.map(zone => (
               <li

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -58,6 +58,7 @@ import {
   settleOnGround,
   solidAt,
   spawnCreature,
+  tickAtmosphericCO2,
   tickCaveNutrient,
   tickMarshDetritus,
   tickMoisture,
@@ -852,16 +853,16 @@ export function tickCreatures(
         )
       : 1
 
+  // Count living plants for CO2 absorption
+  const plantCount = w.creatures.filter(c => w.blueprints[c.blueprintId]?.move.kind === 'root').length
+  tickAtmosphericCO2(w, tickCount, plantCount)
   updateBiomeZones(w, tickCount, seasonFactor)
 
   const creatures = w.creatures
   const dead = new Set<number>()
 
   // Plants are capped as a share of the population so they can't carpet the map.
-  let plantCount = 0
-  for (const c of creatures) {
-    if (w.blueprints[c.blueprintId]?.move.kind === 'root') plantCount++
-  }
+  // plantCount was already computed above for CO2 absorption.
   // Tracked live rather than snapshotted: every eligible plant breeds in the
   // same tick, so a snapshot taken up here lets 150 plants become 300 before
   // the cap is ever re-read.

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -1170,7 +1170,8 @@ export function updateBiomeZones(w: WorldState, tickCount: number, seasonFactor:
   for (let r = 0; r < NUM_BIOME_REGIONS; r++) {
     const midY = r * BIOME_REGION_H + Math.floor(BIOME_REGION_H / 2)
     const baseTemp = Math.max(0, 1 - midY / WORLD_H)
-    const temperature = Math.min(1, baseTemp * seasonFactor)
+    const co2Warming = (w.atmosphericCO2 ?? 0) * 0.3  // up to +0.3 temperature units at max CO2
+    const temperature = Math.min(1, baseTemp * seasonFactor + co2Warming)
 
     // Sample moisture across every 4th column of every row in the band
     const rowStart = r * BIOME_REGION_H
@@ -1186,6 +1187,32 @@ export function updateBiomeZones(w: WorldState, tickCount: number, seasonFactor:
 
     w.biomeZones[r] = { regionIndex: r, type: classifyBiome(temperature, precipitation), temperature, precipitation }
   }
+}
+
+const LAVA_CO2_EMIT = 0.000002   // per lava tile per tick
+const PLANT_CO2_ABSORB = 0.00001  // per living plant creature per tick
+
+/**
+ * Accumulate atmospheric CO2 from lava tiles and deplete it via plant
+ * photosynthesis. CO2 remains in [0, 1]. Called every tick. Issue #3381.
+ */
+export function tickAtmosphericCO2(
+  w: WorldState,
+  tickCount: number,
+  livingPlantCount: number
+): void {
+  if (tickCount % 60 !== 0) return  // update once per second
+  w.atmosphericCO2 ??= 0
+  // Count lava tiles (lazy: sample every 8th tile for performance)
+  const lavaIdx = MATERIAL_INDEX.lava
+  let lavaTiles = 0
+  for (let i = 0; i < w.tiles.length; i += 8) {
+    if (w.tiles[i] === lavaIdx) lavaTiles++
+  }
+  // Emit from lava, absorb by plants
+  const emission = lavaTiles * LAVA_CO2_EMIT
+  const absorption = livingPlantCount * PLANT_CO2_ABSORB
+  w.atmosphericCO2 = Math.max(0, Math.min(1, w.atmosphericCO2 + emission - absorption))
 }
 
 function classifyBiome(temp: number, precip: number): BiomeZoneType {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1464,6 +1464,13 @@ export interface WorldState {
    * Issue #3377.
    */
   biomeZones?: BiomeZone[]
+  /**
+   * Atmospheric CO2 concentration offset [0, 1]. 0 = pre-industrial baseline,
+   * 1 = extreme warming. Emitted by lava tiles; absorbed by living plants.
+   * Raises temperature baseline in `updateBiomeZones`, shifting zones toward
+   * warmer classification. Issue #3381.
+   */
+  atmosphericCO2?: number
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -795,6 +795,9 @@ export class GameInstance {
       useMicroLand.getState().setBiomeZones(this.world.biomeZones)
     }
 
+    // Atmospheric CO2 for Field Guide display. Issue #3381.
+    useMicroLand.getState().setAtmosphericCO2(this.world.atmosphericCO2 ?? 0)
+
     // Speed run win/loss detection
     const sr = useMicroLand.getState().speedRun
     if (sr.active && sr.result === 'none') {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -461,6 +461,12 @@ interface MicroLandState {
    */
   biomeZones: import('./domain/types').BiomeZone[]
   setBiomeZones: (zones: import('./domain/types').BiomeZone[]) => void
+  /**
+   * Atmospheric CO2 concentration offset [0, 1]. Mirrored from WorldState on
+   * each stats tick. Used by the Field Guide to show the CO2 warning. Issue #3381.
+   */
+  atmosphericCO2: number
+  setAtmosphericCO2: (v: number) => void
   /** Set when the Field Guide circle is clicked — game instance centers + inspects. */
   locateCreatureRequest: { id: number; serial: number } | null
   requestLocateCreature: (id: number) => void
@@ -663,6 +669,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   populationItems: [],
   invasionFront: {},
   biomeZones: [],
+  atmosphericCO2: 0,
   locateCreatureRequest: null,
   traitOverlay: null,
   compareId: null,
@@ -796,6 +803,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setPopulationItems: items => set({ populationItems: items }),
   setInvasionFront: data => set({ invasionFront: data }),
   setBiomeZones: zones => set({ biomeZones: zones }),
+  setAtmosphericCO2: v => set({ atmosphericCO2: v }),
   requestLocateCreature: id =>
     set({ locateCreatureRequest: { id, serial: ++locateCreatureSerial } }),
   setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),


### PR DESCRIPTION
## Summary
- Adds `atmosphericCO2?: number` to WorldState [0, 1] — emitted by lava, absorbed by plants
- `tickAtmosphericCO2()` runs every 60 ticks: samples lava tile count, increments CO2 by `lavaTiles × 0.000002`, decrements by `plantCount × 0.00001`
- `updateBiomeZones` adds `co2Warming = CO2 × 0.3` to band temperature, shifting zones toward warmer classification as CO2 rises
- Species with `biomeRequirements` experience climate debt — their zone shrinks away from them under sustained volcanic activity
- Field Guide Climate Zones section shows CO2 % with escalating warnings at 20% and 50%

## Closes
Closes #3381

## Test plan
- [ ] With no lava tiles, CO2 stays near 0
- [ ] Sustained lava activity raises CO2 and bottom bands shift from tundra toward boreal/temperate
- [ ] Dense plant cover slows/reverses warming
- [ ] Species gated to cold biomes begin failing to breed as their zones warm
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)