### PR TITLE
feat(micro-land): migration corridor overlay in Field Guide — routes, stopovers, and live count (#3327)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -81,6 +81,7 @@ export function FieldGuidePane() {
   const invasionFront = useMicroLand(s => s.invasionFront)
   const biomeZones = useMicroLand(s => s.biomeZones)
   const atmosphericCO2 = useMicroLand(s => s.atmosphericCO2)
+  const migrationStats = useMicroLand(s => s.migrationStats)
   const setTraitOverlay = useMicroLand(s => s.setTraitOverlay)
   const addBlueprint = useMicroLand(s => s.addBlueprint)
   const trailsEnabled = useMicroLand(s => s.trailsEnabled)
@@ -671,6 +672,55 @@ export function FieldGuidePane() {
                 <span style={{ color: 'var(--cc-text-muted)', fontSize: 10 }}>
                   {Math.round(zone.temperature * 100)}&deg;&nbsp;&nbsp;{Math.round(zone.precipitation * 100)}%
                 </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {Object.keys(migrationStats).length > 0 && (
+        <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+          <h3 className="pb-2" style={sectionHeading}>
+            Migration Routes
+          </h3>
+          <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
+            Seasonal travellers following ancient corridors across the world.
+          </p>
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {Object.entries(migrationStats).map(([bpId, stats]) => (
+              <li
+                key={bpId}
+                style={{
+                  padding: '4px 0',
+                  borderBottom: '1px solid var(--cc-panel-divider)',
+                  fontSize: 11,
+                  fontFamily: 'var(--cc-font-mono)',
+                  lineHeight: 1.7,
+                }}
+              >
+                <div style={{ color: 'var(--cc-text-default)', letterSpacing: 0.8, textTransform: 'uppercase', fontSize: 10 }}>
+                  {stats.name}
+                </div>
+                <div style={{ color: 'var(--cc-text-muted)' }}>
+                  {stats.migrating > 0
+                    ? `${stats.migrating} of ${stats.total} en route`
+                    : `${stats.total} resident`}
+                </div>
+                {stats.winteringX !== undefined && (
+                  <div style={{ color: 'var(--cc-text-muted)', opacity: 0.8 }}>
+                    {'← Winter grounds: tile '}{stats.winteringX}
+                  </div>
+                )}
+                {stats.summerX !== undefined && (
+                  <div style={{ color: 'var(--cc-text-muted)', opacity: 0.8 }}>
+                    {'→ Summer grounds: tile '}{stats.summerX}
+                  </div>
+                )}
+                {stats.stopoverHabitat.length > 0 && (
+                  <div style={{ color: 'var(--cc-text-muted)', opacity: 0.7 }}>
+                    {'Stopovers: '}{stats.stopoverHabitat.join(', ')}
+                  </div>
+                )}
               </li>
             ))}
           </ul>

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -798,6 +798,26 @@ export class GameInstance {
     // Atmospheric CO2 for Field Guide display. Issue #3381.
     useMicroLand.getState().setAtmosphericCO2(this.world.atmosphericCO2 ?? 0)
 
+    // Migration stats for Field Guide display. Issue #3327.
+    const migStats: Record<string, { name: string; total: number; migrating: number; winteringX: number | undefined; summerX: number | undefined; stopoverHabitat: string[] }> = {}
+    for (const c of this.world.creatures) {
+      const bp = this.world.blueprints[c.blueprintId]
+      if (!bp?.migratory) continue
+      if (!migStats[c.blueprintId]) {
+        migStats[c.blueprintId] = {
+          name: bp.name,
+          total: 0,
+          migrating: 0,
+          winteringX: bp.winteringX,
+          summerX: bp.summerX,
+          stopoverHabitat: bp.stopoverHabitat ?? [],
+        }
+      }
+      migStats[c.blueprintId].total++
+      if (c.migrating) migStats[c.blueprintId].migrating++
+    }
+    useMicroLand.getState().setMigrationStats(migStats)
+
     // Speed run win/loss detection
     const sr = useMicroLand.getState().speedRun
     if (sr.active && sr.result === 'none') {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -467,6 +467,26 @@ interface MicroLandState {
    */
   atmosphericCO2: number
   setAtmosphericCO2: (v: number) => void
+  /**
+   * Per-species migration stats for the Field Guide. Keyed by blueprintId;
+   * only populated for migratory species currently in the world. Issue #3327.
+   */
+  migrationStats: Record<string, {
+    name: string
+    total: number
+    migrating: number
+    winteringX: number | undefined
+    summerX: number | undefined
+    stopoverHabitat: string[]
+  }>
+  setMigrationStats: (stats: Record<string, {
+    name: string
+    total: number
+    migrating: number
+    winteringX: number | undefined
+    summerX: number | undefined
+    stopoverHabitat: string[]
+  }>) => void
   /** Set when the Field Guide circle is clicked — game instance centers + inspects. */
   locateCreatureRequest: { id: number; serial: number } | null
   requestLocateCreature: (id: number) => void
@@ -670,6 +690,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   invasionFront: {},
   biomeZones: [],
   atmosphericCO2: 0,
+  migrationStats: {},
   locateCreatureRequest: null,
   traitOverlay: null,
   compareId: null,
@@ -804,6 +825,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setInvasionFront: data => set({ invasionFront: data }),
   setBiomeZones: zones => set({ biomeZones: zones }),
   setAtmosphericCO2: v => set({ atmosphericCO2: v }),
+  setMigrationStats: stats => set({ migrationStats: stats }),
   requestLocateCreature: id =>
     set({ locateCreatureRequest: { id, serial: ++locateCreatureSerial } }),
   setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),


### PR DESCRIPTION
## Summary
- Adds `migrationStats` to store: per-species record with total, migrating count, winter/summer X, stopoverHabitat
- `pushStats()` in game-instance.ts filters migratory creatures and builds the stats map each tick
- Field Guide gains a "Migration Routes" section: species name, en-route vs resident count, winter/summer ground tiles, stopover habitats

## Closes
Closes #3327

## Test plan
- [ ] SUNHAWK appears in Migration Routes when present in the world
- [ ] En-route count updates as birds begin/end migration with season
- [ ] Winter/summer ground tiles match blueprint values
- [ ] Section hidden when no migratory species present
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)