### PR TITLE
feat(micro-land): mycorrhizal fungal network — hyphae spread between plant roots; obligate species require partner (#3329, #3333)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -645,6 +645,8 @@ export function sanitizeBlueprint(
           ['tropical-rainforest','tropical-savanna','desert','temperate-grassland','temperate-forest','boreal','tundra','ice-cap'].includes(z as string)
         )
       : undefined,
+    mycorrhizalPartner: b.mycorrhizalPartner !== undefined ? !!b.mycorrhizalPartner : undefined,
+    obligateMycorrhizal: b.obligateMycorrhizal !== undefined ? !!b.obligateMycorrhizal : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -64,6 +64,7 @@ const SUNLEAF = builtin('sunleaf', {
   fireGerminator: true,  // pioneer plant: fire-scarified seeds germinate in ash-cleared ground
   lightGapGerminator: true,  // gap-dependent pioneer: seeds sprout when canopy opens above them. Issue #3351.
   seedLongevity: 2400,  // fire-adapted pioneer: seeds persist for multiple seasons awaiting open ground
+  mycorrhizalPartner: true,  // forms associations with soil fungi, becoming a node in the Wood Wide Web. Issue #3329.
 })
 
 const BRAMBLE = builtin('bramble', {
@@ -96,6 +97,7 @@ const BRAMBLE = builtin('bramble', {
   aura: null,
   glow: 0,
   lightGapGerminator: true,  // gap-loving shrub: colonises treefall gaps. Issue #3351.
+  mycorrhizalPartner: true,  // forms associations with soil fungi, becoming a node in the Wood Wide Web. Issue #3329.
 })
 
 const KELP = builtin('kelp', {
@@ -1885,6 +1887,8 @@ const MANGROVE = builtin('mangrove', {
   salinityTolerance: { min: 0.0, max: 0.4 },
   seedLongevity: 1800,  // persistent seed bank: long-lived tree seeds outlast multiple seasons
   biomeRequirements: ['tropical-rainforest', 'tropical-savanna'],  // coastal tropics only. Issue #3378.
+  mycorrhizalPartner: true,  // forms associations with soil fungi, becoming a node in the Wood Wide Web. Issue #3329.
+  obligateMycorrhizal: true,  // requires fungal colonization to establish — cannot germinate or survive without a network partner. Issue #3333.
 })
 
 const UV_BEE = builtin('uv-bee', {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -52,6 +52,7 @@ import {
   boxHitsSolid,
   boxLiquidFraction,
   boxViscosity,
+  hasMycorrhizalPartnerNearby,
   inBounds,
   isInEcotone,
   liquidAt,
@@ -64,6 +65,7 @@ import {
   tickCaveNutrient,
   tickMarshDetritus,
   tickMoisture,
+  tickMycorrhizalNetwork,
   tickSalinity,
   tileAt,
   updateBiomeZones,
@@ -808,6 +810,12 @@ function tickSeedBank(
       if (!zones.some(z => bp.biomeRequirements!.includes(z))) { surviving.push(seed); continue }
     }
 
+    // Obligate mycorrhizal seeds cannot germinate without nearby fungal partners. Issue #3333.
+    if (bp.obligateMycorrhizal && !hasMycorrhizalPartnerNearby(w, seed.x, seed.y)) {
+      surviving.push(seed)  // wait for network establishment
+      continue
+    }
+
     // Try to germinate via the same reproduce path the pollinator uses.
     const { w: bw, h: bh } = artSize(bp)
     const wasExtinct = (speciesCount[seed.blueprintId] ?? 0) === 0
@@ -862,6 +870,7 @@ export function tickCreatures(
   // Count living plants for CO2 absorption
   const plantCount = w.creatures.filter(c => w.blueprints[c.blueprintId]?.move.kind === 'root').length
   tickAtmosphericCO2(w, tickCount, plantCount)
+  tickMycorrhizalNetwork(w, tickCount, rng)
   updateBiomeZones(w, tickCount, seasonFactor)
 
   const creatures = w.creatures
@@ -1196,6 +1205,12 @@ export function tickCreatures(
       const zone = biomeZoneAt(w, Math.floor(c.y))
       if (zone && !bp.biomeRequirements.includes(zone)) {
         c.hunger = Math.min(1, c.hunger + 0.00003 * dt)
+      }
+    }
+    // Obligate mycorrhizal: plants cannot survive without fungal partners. Issue #3333.
+    if (bp.obligateMycorrhizal && bp.move.kind === 'root') {
+      if (!hasMycorrhizalPartnerNearby(w, c.x, c.y)) {
+        c.hunger = Math.min(1, c.hunger + 0.0001 * dt)  // starvation without fungal support
       }
     }
     if (c.hunger >= 1) {

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -1215,6 +1215,69 @@ export function tickAtmosphericCO2(
   w.atmosphericCO2 = Math.max(0, Math.min(1, w.atmosphericCO2 + emission - absorption))
 }
 
+const HYPHAE_RANGE = 20  // tiles — max fungal link distance
+const COLONIZATION_CHANCE = 0.05  // probability per tick-60 cycle of forming a new link
+
+/**
+ * Spread mycorrhizal fungal hyphae between nearby compatible plants, building
+ * the network graph in `w.mycorrhizalLinks`. Prunes dead links each cycle.
+ * Runs every 60 ticks. Issue #3329.
+ */
+export function tickMycorrhizalNetwork(w: WorldState, tickCount: number, rng: Rng): void {
+  if (tickCount % 60 !== 0) return
+
+  // Collect all living mycorrhizal-partner plants
+  const mycoPlants = w.creatures.filter(c => w.blueprints[c.blueprintId]?.mycorrhizalPartner)
+  if (mycoPlants.length === 0) return
+
+  w.mycorrhizalLinks ??= {}
+
+  // Prune links where one end is dead
+  const livingIds = new Set(w.creatures.map(c => c.id))
+  for (const [idStr, neighbors] of Object.entries(w.mycorrhizalLinks)) {
+    if (!livingIds.has(Number(idStr))) {
+      delete w.mycorrhizalLinks[idStr]
+      continue
+    }
+    w.mycorrhizalLinks[idStr] = neighbors.filter(n => livingIds.has(n))
+    if (w.mycorrhizalLinks[idStr].length === 0) delete w.mycorrhizalLinks[idStr]
+  }
+
+  // Attempt new connections between nearby plants
+  for (let i = 0; i < mycoPlants.length; i++) {
+    const a = mycoPlants[i]
+    for (let j = i + 1; j < mycoPlants.length; j++) {
+      const b = mycoPlants[j]
+      const dist = Math.hypot(a.x - b.x, a.y - b.y)
+      if (dist > HYPHAE_RANGE) continue
+      // Check if already connected
+      const aLinks = w.mycorrhizalLinks[String(a.id)]
+      if (aLinks?.includes(b.id)) continue
+      // Probabilistic colonization
+      if (rng() > COLONIZATION_CHANCE) continue
+      // Add bidirectional link
+      w.mycorrhizalLinks[String(a.id)] ??= []
+      w.mycorrhizalLinks[String(b.id)] ??= []
+      w.mycorrhizalLinks[String(a.id)].push(b.id)
+      w.mycorrhizalLinks[String(b.id)].push(a.id)
+    }
+  }
+}
+
+/**
+ * True if there is at least one mycorrhizal-partner plant within HYPHAE_RANGE
+ * tiles of the given position. Used to gate obligate species. Issue #3333.
+ */
+export function hasMycorrhizalPartnerNearby(w: WorldState, x: number, y: number): boolean {
+  if (!w.mycorrhizalLinks) return false
+  const linkedIds = new Set(Object.keys(w.mycorrhizalLinks).map(Number))
+  for (const c of w.creatures) {
+    if (!linkedIds.has(c.id)) continue
+    if (Math.hypot(c.x - x, c.y - y) <= HYPHAE_RANGE) return true
+  }
+  return false
+}
+
 function classifyBiome(temp: number, precip: number): BiomeZoneType {
   if (temp < 0.1) return 'ice-cap'
   if (temp < 0.2) return 'tundra'

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -740,6 +740,18 @@ export interface CreatureBlueprint {
    * Leave undefined to allow establishment anywhere. Issue #3378.
    */
   biomeRequirements?: BiomeZoneType[]
+  /**
+   * This species can form symbiotic associations with soil fungi, becoming a
+   * node in the mycorrhizal network. Connected plants share nutrients and
+   * chemical signals. Issue #3329.
+   */
+  mycorrhizalPartner?: boolean
+  /**
+   * This species REQUIRES fungal colonization to establish or survive beyond
+   * the seedling stage. Without a mycorrhizal partner within HYPHAE_RANGE
+   * tiles, seedlings die and adults face a starvation penalty. Issue #3333.
+   */
+  obligateMycorrhizal?: boolean
 }
 
 /**
@@ -1471,6 +1483,12 @@ export interface WorldState {
    * warmer classification. Issue #3381.
    */
   atmosphericCO2?: number
+  /**
+   * Mycorrhizal network graph: maps creature ID (as string) to array of
+   * connected creature IDs. Entries are pruned when a creature dies. Undefined
+   * until first mycorrhizal plant establishes. Issue #3329.
+   */
+  mycorrhizalLinks?: Record<string, number[]>
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `mycorrhizalPartner` and `obligateMycorrhizal` to CreatureBlueprint
- Adds `mycorrhizalLinks?: Record<string, number[]>` graph to WorldState
- `tickMycorrhizalNetwork()` in world.ts runs every 60 ticks: prunes dead links and probabilistically (5%) connects mycorrhizal plants within 20 tiles
- `hasMycorrhizalPartnerNearby(w, x, y)` O(n) lookup for gating
- Obligate species (MANGROVE) face +0.0001/tick starvation when not networked, and seeds refuse to germinate without nearby network
- SUNLEAF, BRAMBLE, MANGROVE gain `mycorrhizalPartner: true`

## Closes
Closes #3329, Closes #3333

## Test plan
- [ ] Two nearby SUNLEAF plants connect over time; distant ones don't
- [ ] Dead plant links are pruned each cycle
- [ ] MANGROVE seedlings refuse to germinate in an isolated area; succeed near other mycorrhizal plants
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)