### PR TITLE
feat(micro-land): mycorrhizal chemical signals + hub trees — network defense relay and mother-tree tracking (#3331, #3332)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -82,6 +82,7 @@ export function FieldGuidePane() {
   const biomeZones = useMicroLand(s => s.biomeZones)
   const atmosphericCO2 = useMicroLand(s => s.atmosphericCO2)
   const migrationStats = useMicroLand(s => s.migrationStats)
+  const networkDegree = useMicroLand(s => s.networkDegree)
   const setTraitOverlay = useMicroLand(s => s.setTraitOverlay)
   const addBlueprint = useMicroLand(s => s.addBlueprint)
   const trailsEnabled = useMicroLand(s => s.trailsEnabled)
@@ -726,6 +727,45 @@ export function FieldGuidePane() {
           </ul>
         </section>
       )}
+
+      {Object.keys(networkDegree).length > 0 && (() => {
+        const maxDegree = Math.max(...Object.values(networkDegree))
+        if (maxDegree < 2) return null  // not interesting until trees are well-connected
+        const hubEntries = Object.entries(networkDegree)
+          .filter(([, d]) => d >= Math.max(3, maxDegree * 0.6))
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 5)
+        if (hubEntries.length === 0) return null
+        return (
+          <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+            <h3 className="pb-2" style={sectionHeading}>Hub Trees</h3>
+            <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
+              Mother trees with the most fungal connections — keystone nodes of the Wood Wide Web.
+            </p>
+            {hubEntries.map(([id, degree]) => {
+              const creature = populationItems.find(p => String(p.id) === id)
+              return (
+                <div
+                  key={id}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    padding: '3px 0',
+                    fontSize: 11,
+                    fontFamily: 'var(--cc-font-mono)',
+                    borderBottom: '1px solid var(--cc-panel-divider)',
+                  }}
+                >
+                  <span style={{ color: 'var(--cc-text-default)' }}>
+                    {creature?.name ?? `Node ${id}`}
+                  </span>
+                  <span style={{ color: 'var(--cc-text-muted)' }}>{degree} links</span>
+                </div>
+              )
+            })}
+          </section>
+        )
+      })()}
 
       {Object.keys(foodWeb).length > 0 && (
         <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -976,6 +976,10 @@ export function tickCreatures(
     if ((c as { stunTimer?: number }).stunTimer === undefined) c.stunTimer = 0
     if (c.stunTimer > 0) c.stunTimer = Math.max(0, c.stunTimer - dt)
     if (c.insightTimer && c.insightTimer > 0) c.insightTimer = Math.max(0, c.insightTimer - dt)
+    // Chemical defense prime: tick down mycorrhizal-relayed signal. Issue #3331.
+    if (c.defenseTimer !== undefined && c.defenseTimer > 0) {
+      c.defenseTimer = Math.max(0, c.defenseTimer - dt)
+    }
     if ((c as { symbiosisTimer?: number }).symbiosisTimer === undefined) c.symbiosisTimer = 0
     if (c.symbiosisTimer > 0) c.symbiosisTimer = Math.max(0, c.symbiosisTimer - dt)
     // Drift state: exit drift when creature leaves water.
@@ -2700,6 +2704,11 @@ function look(
         return
       }
       if (touching) {
+        // Chemical defense: a plant that received a mycorrhizal warning signal is
+        // primed with volatile compounds — the grazer finds it unpalatable and
+        // moves on. The signal decays in 30 s so the defense is temporary.
+        // Issue #3331.
+        if (obp.move.kind === 'root' && other.defenseTimer && other.defenseTimer > 0) return
         // Eyespot deflection: false-eye markings redirect 40% of killing blows to
         // a non-vital region. The prey escapes with a burst of speed; the predator
         // lands a wing-tip bite and gains almost nothing from the missed kill.
@@ -2714,6 +2723,18 @@ function look(
           return
         }
         devour(w, other, obp, dead, events)
+        // Chemical signal relay: the eaten plant warns its mycorrhizal-network
+        // neighbors via volatile compounds, priming their chemical defenses for
+        // 30 s. Only plants (root locomotion) relay the signal. Issue #3331.
+        if (obp.move.kind === 'root' && w.mycorrhizalLinks) {
+          const links = w.mycorrhizalLinks[String(other.id)]
+          if (links) {
+            for (const neighborId of links) {
+              const neighbor = w.creatures.find(nc => nc.id === neighborId)
+              if (neighbor) neighbor.defenseTimer = Math.max(neighbor.defenseTimer ?? 0, 30)
+            }
+          }
+        }
         let fill = mealFill(c, bp, obp, sizeOf(other))
         // Food washing bonus: +5% energy if the creature has learned the behavior
         // and is near non-deadly liquid (water, not lava/acid).

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1151,6 +1151,9 @@ export interface Creature {
   /** Migratory fat reserve [0, 1]. Depletes during active migration; refills at stopover habitat. */
   migratoryFat?: number
   circadianPhase?: number  // internal clock phase [0, 1]; 0 = subjective dawn, 0.5 = subjective dusk
+  /** Seconds remaining of mycorrhizal-relayed chemical defense prime. Reduces
+   * herbivory damage while active. Set when a network neighbor is attacked. Issue #3331. */
+  defenseTimer?: number
 }
 
 /**

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -818,6 +818,15 @@ export class GameInstance {
     }
     useMicroLand.getState().setMigrationStats(migStats)
 
+    // Hub tree degree — count per-node connections in the mycorrhizal network. Issue #3332.
+    if (this.world.mycorrhizalLinks) {
+      const degree: Record<string, number> = {}
+      for (const [idStr, links] of Object.entries(this.world.mycorrhizalLinks)) {
+        degree[idStr] = links.length
+      }
+      useMicroLand.getState().setNetworkDegree(degree)
+    }
+
     // Speed run win/loss detection
     const sr = useMicroLand.getState().speedRun
     if (sr.active && sr.result === 'none') {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -438,6 +438,13 @@ interface MicroLandState {
    */
   shelf: ShelfState
 
+  /**
+   * Per-node connection count in the mycorrhizal network.
+   * Keyed by creature ID (as string). Only populated when mycorrhizalLinks exist.
+   * Used by the Field Guide to identify hub trees. Issue #3332.
+   */
+  networkDegree: Record<string, number>
+  setNetworkDegree: (d: Record<string, number>) => void
   /** Set when the field guide asks to find a species in the world. */
   locateRequest: { blueprintId: string; serial: number } | null
   /** Close the sidebar and emit a locate request for the game instance to handle. */
@@ -685,6 +692,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   historyLog: [],
   saveState: { kind: 'idle' },
   shelf: { worlds: [], activeId: null, busy: false, error: null },
+  networkDegree: {},
   locateRequest: null,
   populationItems: [],
   invasionFront: {},
@@ -821,6 +829,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setShelf: shelf => set({ shelf }),
   requestLocate: blueprintId =>
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, sidebar: null }),
+  setNetworkDegree: d => set({ networkDegree: d }),
   setPopulationItems: items => set({ populationItems: items }),
   setInvasionFront: data => set({ invasionFront: data }),
   setBiomeZones: zones => set({ biomeZones: zones }),


### PR DESCRIPTION
## Summary
- Adds `defenseTimer?: number` to `Creature` — active while chemical defense prime is in effect
- When a plant is eaten: signals all mycorrhizal network neighbors (sets `defenseTimer = 30s`); while timer > 0, plant blocks grazers from eating it
- Hub Trees section in Field Guide: shows top-5 most-connected network nodes with link count (creature name or node ID)
- `networkDegree: Record<string, number>` exposed via store; synced from `mycorrhizalLinks` in `pushStats()`

## Closes
Closes #3331, Closes #3332

## Test plan
- [ ] When one plant is eaten, its network neighbors become temporarily inedible
- [ ] defenseTimer decrements each frame and expires after 30s
- [ ] Hub Trees section appears in Field Guide when plants have ≥ 3 connections
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)