### PR TITLE
feat(micro-land): mycorrhizal network stats in Field Guide — Wood Wide Web connectivity overview (#3334)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -83,6 +83,7 @@ export function FieldGuidePane() {
   const atmosphericCO2 = useMicroLand(s => s.atmosphericCO2)
   const migrationStats = useMicroLand(s => s.migrationStats)
   const networkDegree = useMicroLand(s => s.networkDegree)
+  const networkStats = useMicroLand(s => s.networkStats)
   const setTraitOverlay = useMicroLand(s => s.setTraitOverlay)
   const addBlueprint = useMicroLand(s => s.addBlueprint)
   const trailsEnabled = useMicroLand(s => s.trailsEnabled)
@@ -766,6 +767,23 @@ export function FieldGuidePane() {
           </section>
         )
       })()}
+
+      {networkStats && (
+        <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+          <h3 className="pb-2" style={sectionHeading}>Wood Wide Web</h3>
+          <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
+            The invisible fungal network threading between plant roots.
+          </p>
+          <div style={{ fontSize: 11, fontFamily: 'var(--cc-font-mono)', lineHeight: 1.8 }}>
+            <div style={{ color: 'var(--cc-text-default)' }}>
+              {networkStats.connected} plants networked · {networkStats.isolated} isolated
+            </div>
+            <div style={{ color: 'var(--cc-text-muted)' }}>
+              {networkStats.clusterCount} cluster{networkStats.clusterCount !== 1 ? 's' : ''} · {networkStats.totalLinks} fungal links
+            </div>
+          </div>
+        </section>
+      )}
 
       {Object.keys(foodWeb).length > 0 && (
         <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -827,6 +827,40 @@ export class GameInstance {
       useMicroLand.getState().setNetworkDegree(degree)
     }
 
+    // Mycorrhizal network statistics for the Wood Wide Web Field Guide section. Issue #3334.
+    const mycoPlants = this.world.creatures.filter(c =>
+      this.world.blueprints[c.blueprintId]?.mycorrhizalPartner
+    )
+    if (mycoPlants.length > 0 && this.world.mycorrhizalLinks) {
+      const links = this.world.mycorrhizalLinks
+      const connected = new Set(Object.keys(links).map(Number))
+
+      // Union-Find for cluster count
+      const parent: Record<number, number> = {}
+      const find = (x: number): number => {
+        parent[x] ??= x
+        if (parent[x] !== x) parent[x] = find(parent[x])
+        return parent[x]
+      }
+      const union = (a: number, b: number) => { parent[find(a)] = find(b) }
+
+      for (const [idStr, neighbors] of Object.entries(links)) {
+        for (const n of neighbors) union(Number(idStr), n)
+      }
+      const roots = new Set(Object.keys(links).map(id => find(Number(id))))
+
+      const totalLinks = Object.values(links).reduce((s, l) => s + l.length, 0) / 2
+
+      useMicroLand.getState().setNetworkStats({
+        connected: connected.size,
+        isolated: mycoPlants.filter(c => !connected.has(c.id)).length,
+        clusterCount: roots.size,
+        totalLinks: Math.round(totalLinks),
+      })
+    } else {
+      useMicroLand.getState().setNetworkStats(null)
+    }
+
     // Speed run win/loss detection
     const sr = useMicroLand.getState().speedRun
     if (sr.active && sr.result === 'none') {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -499,6 +499,19 @@ interface MicroLandState {
   requestLocateCreature: (id: number) => void
 
   /**
+   * Mycorrhizal network connectivity statistics for the Wood Wide Web section
+   * of the Field Guide. Null when no mycorrhizal-partner plants are present.
+   * Issue #3334.
+   */
+  networkStats: {
+    connected: number
+    isolated: number
+    clusterCount: number
+    totalLinks: number
+  } | null
+  setNetworkStats: (stats: { connected: number; isolated: number; clusterCount: number; totalLinks: number } | null) => void
+
+  /**
    * When set, the renderer draws each creature with a color overlay based on
    * this trait's value — blue for weak, red for strong. Null means no overlay.
    */
@@ -693,6 +706,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   saveState: { kind: 'idle' },
   shelf: { worlds: [], activeId: null, busy: false, error: null },
   networkDegree: {},
+  networkStats: null,
   locateRequest: null,
   populationItems: [],
   invasionFront: {},
@@ -830,6 +844,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   requestLocate: blueprintId =>
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, sidebar: null }),
   setNetworkDegree: d => set({ networkDegree: d }),
+  setNetworkStats: stats => set({ networkStats: stats }),
   setPopulationItems: items => set({ populationItems: items }),
   setInvasionFront: data => set({ invasionFront: data }),
   setBiomeZones: zones => set({ biomeZones: zones }),


### PR DESCRIPTION
## Summary
- Adds `networkStats` to store: connected plants, isolated plants, cluster count, total links
- `game-instance.ts` computes Union-Find over `mycorrhizalLinks` each tick to count connected components
- Field Guide gains "Wood Wide Web" section showing network stats when any mycorrhizal plants exist

## Closes
Closes #3334

## Test plan
- [ ] Stats update as plants form connections over time
- [ ] Cluster count reflects actual connected components (2 isolated clusters → 2)
- [ ] Section hidden when no mycorrhizal-partner species are present
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)