### PR TITLE
feat(micro-land): biocontrol introduction — specialist predators preferentially suppress invasive prey (#3368)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -647,6 +647,10 @@ export function sanitizeBlueprint(
       : undefined,
     mycorrhizalPartner: b.mycorrhizalPartner !== undefined ? !!b.mycorrhizalPartner : undefined,
     obligateMycorrhizal: b.obligateMycorrhizal !== undefined ? !!b.obligateMycorrhizal : undefined,
+    biocontrolTargets: Array.isArray(b.biocontrolTargets)
+      ? (b.biocontrolTargets as unknown[]).filter((s): s is string => typeof s === 'string')
+      : undefined,
+    biocontrolAgent: b.biocontrolAgent !== undefined ? !!b.biocontrolAgent : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -1028,6 +1028,40 @@ const PALECRAWLER = builtin('palecrawler', {
   death: { becomes: null, particleColor: '#ded3c4', particleCount: 6 },
   aura: null,
   glow: 0,
+  invasive: true,  // escaped from a cave research lab — spreads aggressively with no natural enemies. Issue #3368.
+})
+
+const PARASITOID_WASP = builtin('parasitoid-wasp', {
+  name: 'Parasitoid Wasp',
+  blurb: 'Introduced to suppress the Palecrawler — but its preferences are not always precise.',
+  size: 1,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { y: '#f5c518', b: '#1a1a1a', r: '#cc3300', w: '#ffffcc' },
+    frames: [
+      ['.yby.', 'ybbby', '.wrw.', '..b..'],
+      ['.yby.', 'ybwby', '.wrw.', '..b..'],
+    ],
+    frameMs: 120,
+    faceMotion: true,
+  },
+  body: { mass: 0.08, bounce: 0.1, drag: 0.55, buoyancy: 1.5, immuneTo: [] },
+  move: { kind: 'fly', speed: 5.5, jump: 0, restlessness: 0.5, hop: 0 },
+  diet: {
+    eats: ['bug'],
+    fears: [],
+    hungerRate: 0.035,
+    starveSeconds: 22,
+    breedAt: 0.72,
+    lifespanSeconds: 150,
+  },
+  senses: { sight: 18 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#f5c518', particleCount: 5 },
+  aura: null,
+  glow: 0,
+  biocontrolAgent: true,
+  biocontrolTargets: ['palecrawler'],  // specialist predator released to suppress the invasive Palecrawler. Issue #3368.
 })
 
 const GLOOMWEAVER = builtin('gloomweaver', {
@@ -1983,6 +2017,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   DELVER,
   MOTE,
   PALECRAWLER,
+  PARASITOID_WASP,
   DRIFTMOLE,
   WOOLLY,
   DUSTBEE,

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -2741,6 +2741,16 @@ function look(
         if (c.learnedFoodWashing && isNearWater(w, c)) {
           fill *= 1.05
         }
+        // Biocontrol targeting: specialist agents are more effective against their
+        // target species (2× fill — co-evolved hunting efficiency) and less effective
+        // against non-targets (0.7× fill — off-target effort). Issue #3368.
+        if (bp.biocontrolTargets && bp.biocontrolTargets.length > 0) {
+          if (bp.biocontrolTargets.includes(obp.id)) {
+            fill *= 2
+          } else {
+            fill *= 0.7
+          }
+        }
         c.hunger = Math.max(0, c.hunger - fill)
         c.starving = 0
         c.huntBlockedId = null
@@ -2881,8 +2891,13 @@ function look(
       const disrupted =
         obp.disruptivePattern === true && d2 > DISRUPTION_NEAR_TILES * DISRUPTION_NEAR_TILES
       const finalEfs2 = disrupted ? efs2 * DISRUPTION_FAR_FACTOR * DISRUPTION_FAR_FACTOR : efs2
-      if (d2 <= finalEfs2 && d2 < preyDist) {
-        preyDist = d2
+      // Biocontrol preference: specialist agents prioritize their target species.
+      // Halve the effective distance for biocontrol targets so they always win
+      // target selection over non-targets at similar range. Issue #3368.
+      const biocontrolPriorityD2 =
+        bp.biocontrolTargets && bp.biocontrolTargets.includes(obp.id) ? d2 * 0.25 : d2
+      if (d2 <= finalEfs2 && biocontrolPriorityD2 < preyDist) {
+        preyDist = biocontrolPriorityD2
         prey = other
         preyDir = dx >= 0 ? 1 : -1
         preyCx = other.x + ow / 2

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -752,6 +752,19 @@ export interface CreatureBlueprint {
    * tiles, seedlings die and adults face a starvation penalty. Issue #3333.
    */
   obligateMycorrhizal?: boolean
+  /**
+   * This species preferentially hunts creatures whose blueprintId appears in
+   * this list. When a `biocontrolTarget` creature is within attack range, the
+   * agent prioritizes it over other prey (2× attack bonus vs. target, 0.5×
+   * vs. non-target). Models specialist biocontrol agents introduced to suppress
+   * invasive species. Issue #3368.
+   */
+  biocontrolTargets?: string[]
+  /**
+   * True if this species is itself a biocontrol introduction rather than a
+   * naturally occurring species. Used for Field Guide tracking. Issue #3368.
+   */
+  biocontrolAgent?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `biocontrolTargets?: string[]` and `biocontrolAgent?: boolean` to `CreatureBlueprint`
- Biocontrol agents get 2× effective priority range when selecting invasive targets (appear 2× closer in scoring)
- Biocontrol agents get 2× meal efficiency vs. targets (co-evolved predation), 0.7× vs. non-targets (off-target ecological cost)
- PALECRAWLER gains `invasive: true` (escaped lab species with no natural enemies)
- New PARASITOID_WASP species: `biocontrolAgent: true`, `biocontrolTargets: ['palecrawler']` — the introduced suppressant

## Closes
Closes #3368

## Test plan
- [ ] PARASITOID_WASP preferentially hunts PALECRAWLERs when both are present
- [ ] Wasp is less efficient hunting non-PALECRAWLER prey (0.7× fill)
- [ ] Invasion front tracking already shows PALECRAWLER spread (from #3366)
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)