### PR TITLE
feat(micro-land): holometabolous lifecycle — egg→larva→pupa→adult metamorphosis for Shimmer species (#3336)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -651,6 +651,11 @@ export function sanitizeBlueprint(
       ? (b.biocontrolTargets as unknown[]).filter((s): s is string => typeof s === 'string')
       : undefined,
     biocontrolAgent: b.biocontrolAgent !== undefined ? !!b.biocontrolAgent : undefined,
+    holometabolous: b.holometabolous !== undefined ? !!b.holometabolous : undefined,
+    larvaeBlueprint: typeof b.larvaeBlueprint === 'string' ? b.larvaeBlueprint : undefined,
+    metamorphosesInto: typeof b.metamorphosesInto === 'string' ? b.metamorphosesInto : undefined,
+    metamorphosisAge: typeof b.metamorphosisAge === 'number' && b.metamorphosisAge > 0 ? b.metamorphosisAge : undefined,
+    pupalDuration: typeof b.pupalDuration === 'number' && b.pupalDuration > 0 ? b.pupalDuration : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -1992,6 +1992,83 @@ const SHIMMER_LARVA = builtin('shimmer-larva', {
   glow: 0.1,
   canDrift: true,
   flowZonePreference: 'run',  // intermediate flow — grips substrate but stays in current
+  metamorphosesInto: 'shimmer-pupa',  // larva → pupa at 60 s. Issue #3336.
+  metamorphosisAge: 60,
+})
+
+// ---------------------------------------------------------------------------
+// Shimmer Pupa — still chrysalis stage. Issue #3336.
+// ---------------------------------------------------------------------------
+
+const SHIMMER_PUPA = builtin('shimmer-pupa', {
+  name: 'Shimmer Pupa',
+  blurb: 'A still chrysalis anchored to stone. Something perfect waits inside.',
+  size: 1,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { p: '#aaccbb', d: '#668877', g: '#cceeee' },
+    frames: [
+      ['.p.', 'pdp', '.p.'],
+      ['.p.', 'pgp', '.p.'],
+    ],
+    frameMs: 400,
+    faceMotion: false,
+  },
+  body: { mass: 0.8, bounce: 0, drag: 0.1, buoyancy: 0.9, immuneTo: [] },
+  move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+  diet: {
+    eats: [],
+    fears: ['fish', 'flier'],
+    hungerRate: 0,
+    starveSeconds: 300,
+    breedAt: 1,       // never breeds
+    lifespanSeconds: 300,
+  },
+  senses: { sight: 2 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#aaccbb', particleCount: 3 },
+  aura: null,
+  glow: 0.05,
+  pupalDuration: 20,              // 20 s countdown until adult emergence. Issue #3336.
+  metamorphosesInto: 'shimmer-fly',
+})
+
+// ---------------------------------------------------------------------------
+// Shimmer Fly — winged adult. Lays eggs that hatch as shimmer-larva. Issue #3336.
+// ---------------------------------------------------------------------------
+
+const SHIMMER_FLY = builtin('shimmer-fly', {
+  name: 'Shimmer Fly',
+  blurb: 'The winged adult lives just long enough to breed. Its iridescent wings catch every light.',
+  size: 1,
+  tags: ['meat', 'bug', 'flier'],
+  art: {
+    palette: { w: '#ccffee', b: '#44bbaa', g: '#eeffdd' },
+    frames: [
+      ['w.w', 'wbw', '.w.'],
+      ['.w.', 'wgw', 'w.w'],
+    ],
+    frameMs: 100,
+    faceMotion: true,
+  },
+  body: { mass: 0.1, bounce: 0.1, drag: 0.5, buoyancy: 1.5, immuneTo: [] },
+  move: { kind: 'fly', speed: 5, jump: 0, restlessness: 0.7 },
+  diet: {
+    eats: [],           // adults do not eat
+    fears: ['fish'],
+    hungerRate: 0,
+    starveSeconds: 120,
+    breedAt: 0.5,
+    lifespanSeconds: 40,  // short adult lifespan — breed and die
+  },
+  senses: { sight: 16 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#ccffee', particleCount: 6 },
+  aura: null,
+  glow: 0.2,
+  egglayer: true,
+  holometabolous: true,       // eggs hatch as shimmer-larva. Issue #3336.
+  larvaeBlueprint: 'shimmer-larva',
 })
 
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
@@ -2044,6 +2121,8 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   TREX,
   DRAGON,
   SHIMMER_LARVA,
+  SHIMMER_PUPA,
+  SHIMMER_FLY,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1394,6 +1394,42 @@ export function tickCreatures(
       c.vy = 0
     }
 
+    // --- metamorphosis: larva → pupa → adult. Issue #3336. -------------------
+    // Age-gated transition: when the larva (or any metamorphosing stage) exceeds
+    // its metamorphosisAge, it transforms into the next stage blueprint.
+    if (bp.metamorphosesInto && bp.metamorphosisAge !== undefined && c.ageSeconds >= bp.metamorphosisAge) {
+      const nextBp = w.blueprints[bp.metamorphosesInto]
+      if (nextBp) {
+        c.blueprintId = bp.metamorphosesInto
+        c.lifeStage = nextBp.pupalDuration !== undefined ? 'pupa' : 'adult'
+        c.pupalTimer = nextBp.pupalDuration
+        c.ageSeconds = 0  // reset age for the new stage
+        c.hunger = 0.5    // reset hunger at metamorphosis
+      }
+    }
+    // Pupa countdown: timer ticks down until adult emergence. Issue #3336.
+    // We read the current blueprintId because it may have just been updated above.
+    const currentBp = w.blueprints[c.blueprintId] ?? bp
+    if (c.lifeStage === 'pupa' && c.pupalTimer !== undefined) {
+      c.pupalTimer -= dt
+      if (c.pupalTimer <= 0) {
+        const adultBpId = currentBp.metamorphosesInto
+        const adultBp = adultBpId ? w.blueprints[adultBpId] : undefined
+        if (adultBp) {
+          c.blueprintId = adultBpId!
+          c.lifeStage = 'adult'
+          c.pupalTimer = undefined
+          c.ageSeconds = 0
+        }
+      }
+    }
+    // Pupae are immobile — skip movement and hunting this tick. Issue #3336.
+    if (c.lifeStage === 'pupa') {
+      c.vx = 0
+      c.vy = 0
+      continue
+    }
+
     // --- old age --------------------------------------------------------
     if (c.ageSeconds >= lifespanOf(c, bp) * TUNING.lifespanScale) {
       kill(w, c, bp, dead, events, 'aged')
@@ -2297,7 +2333,12 @@ export function tickCreatures(
   for (const egg of w.eggs) {
     egg.hatchIn -= dt
     if (egg.hatchIn <= 0) {
-      const ebp = w.blueprints[egg.blueprintId]
+      const parentBp = w.blueprints[egg.blueprintId]
+      // Holometabolous: eggs from this adult hatch as the larval form. Issue #3336.
+      const hatchBpId = parentBp?.holometabolous && parentBp.larvaeBlueprint
+        ? parentBp.larvaeBlueprint
+        : egg.blueprintId
+      const ebp = w.blueprints[hatchBpId]
       if (ebp && w.creatures.length < TUNING.maxCreatures) {
         const { w: ew, h: eh } = artSize(ebp)
         const hatchling = spawnCreature(w, ebp, egg.x - ew / 2, egg.y - eh / 2)
@@ -2305,6 +2346,10 @@ export function tickCreatures(
           hatchling.generation = egg.generation
           hatchling.traits = egg.traits
           hatchling.lifeLog = [{ elapsed: w.elapsed, text: `Born (gen ${egg.generation})` }]
+          // Mark life stage from hatch. Issue #3336.
+          if (parentBp?.holometabolous) {
+            hatchling.lifeStage = 'larva'
+          }
           events.push({ kind: 'born', blueprintId: ebp.id, x: egg.x, y: egg.y })
         }
       }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -765,6 +765,31 @@ export interface CreatureBlueprint {
    * naturally occurring species. Used for Field Guide tracking. Issue #3368.
    */
   biocontrolAgent?: boolean
+  /**
+   * This species transitions through complete metamorphosis: egg → larva → pupa → adult.
+   * Eggs hatch into `larvaeBlueprint` creatures instead of adults. Issue #3336.
+   */
+  holometabolous?: boolean
+  /**
+   * BlueprintId of the larval form. Eggs from this adult species hatch as this blueprint.
+   * Only meaningful when `holometabolous: true`. Issue #3336.
+   */
+  larvaeBlueprint?: string
+  /**
+   * This creature transforms into this blueprintId when it reaches `metamorphosisAge`.
+   * Used on larval and pupal blueprints to encode the lifecycle chain. Issue #3336.
+   */
+  metamorphosesInto?: string
+  /**
+   * Age in seconds at which metamorphosis is triggered. When `c.ageSeconds` exceeds
+   * this value, the creature switches to `metamorphosesInto` blueprint. Issue #3336.
+   */
+  metamorphosisAge?: number
+  /**
+   * Seconds this pupa stage lasts before adult emerges. Only relevant for pupal blueprints
+   * where the transition is time-gated, not age-gated. Issue #3336.
+   */
+  pupalDuration?: number
 }
 
 /**
@@ -1167,6 +1192,10 @@ export interface Creature {
   /** Seconds remaining of mycorrhizal-relayed chemical defense prime. Reduces
    * herbivory damage while active. Set when a network neighbor is attacked. Issue #3331. */
   defenseTimer?: number
+  /** Current metamorphic stage — set at hatch time or after each transition. Issue #3336. */
+  lifeStage?: 'larva' | 'pupa' | 'adult'
+  /** Countdown seconds until adult emergence. Only set on pupa-stage creatures. Issue #3336. */
+  pupalTimer?: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `holometabolous`, `larvaeBlueprint`, `metamorphosesInto`, `metamorphosisAge`, `pupalDuration` to `CreatureBlueprint`
- Adds `lifeStage` and `pupalTimer` to `Creature` instance
- Egg hatching: if parent blueprint is `holometabolous`, eggs hatch as `larvaeBlueprint` with `lifeStage='larva'`
- Metamorphosis tick: age-gated larva→pupa transition; timer-gated pupa→adult; pupae are immobile (vx/vy=0, skip movement/hunting)
- Shimmer lifecycle chain: SHIMMER_LARVA (60s aquatic) → SHIMMER_PUPA (20s stationary) → SHIMMER_FLY (40s flying adult, lays eggs)

## Closes
Closes #3336

## Test plan
- [ ] SHIMMER_FLY eggs hatch as SHIMMER_LARVA (not as adults)
- [ ] SHIMMER_LARVA after 60s transforms into SHIMMER_PUPA (immobile)
- [ ] SHIMMER_PUPA after 20s becomes SHIMMER_FLY adult
- [ ] Pupae do not move or hunt
- [ ] TypeScript passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)