### PR TITLE
feat(micro-land): hemimetabolous lifecycle — nymph instars, moulting, shed-skin tiles (#3340, #3341)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -659,6 +659,11 @@ export function sanitizeBlueprint(
     larvalTrophicLevel: ['plant','meat','scavenger'].includes(b.larvalTrophicLevel as string) ? b.larvalTrophicLevel as 'plant'|'meat'|'scavenger' : undefined,
     adultTrophicLevel: ['plant','meat','nectar','none'].includes(b.adultTrophicLevel as string) ? b.adultTrophicLevel as 'plant'|'meat'|'nectar'|'none' : undefined,
     pupalVulnerability: typeof b.pupalVulnerability === 'number' ? Math.max(0, Math.min(1, b.pupalVulnerability)) : undefined,
+    hemimetabolous: typeof b.hemimetabolous === 'boolean' ? b.hemimetabolous : undefined,
+    nymphBlueprint: typeof b.nymphBlueprint === 'string' ? b.nymphBlueprint : undefined,
+    instarCount: typeof b.instarCount === 'number' ? Math.max(1, Math.floor(b.instarCount)) : undefined,
+    instarDuration: typeof b.instarDuration === 'number' ? Math.max(1, b.instarDuration) : undefined,
+    moultVulnerability: typeof b.moultVulnerability === 'number' ? Math.max(0, b.moultVulnerability) : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -2073,6 +2073,154 @@ const SHIMMER_FLY = builtin('shimmer-fly', {
   adultTrophicLevel: 'none',  // adult Shimmer Flies do not eat — breed and die. Issue #3337.
 })
 
+// ---------------------------------------------------------------------------
+// Meadow Locust Nymph — crawling juvenile that eats plants. Issue #3340, #3341.
+// ---------------------------------------------------------------------------
+
+const MEADOW_LOCUST_NYMPH = builtin('meadow-locust-nymph', {
+  name: 'Locust Nymph',
+  blurb: 'A small wingless hopper that munches leaves. It sheds its skin three times before growing wings.',
+  size: 1,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { w: '#88bb44', b: '#556622', g: '#aaddaa' },
+    frames: [['wbw', 'bgb', 'wbw']],
+    frameMs: 200,
+    faceMotion: true,
+  },
+  body: { mass: 0.8, bounce: 0.1, drag: 0.4, buoyancy: 0.9, immuneTo: [] },
+  move: { kind: 'walk', speed: 2.5, jump: 4, hop: 0.3, restlessness: 0.3 },
+  diet: {
+    eats: ['plant'],
+    fears: ['bug', 'flier'],
+    hungerRate: 0.03,
+    starveSeconds: 30,
+    breedAt: 1,          // nymphs do not breed — adults do
+    lifespanSeconds: 120,
+  },
+  senses: { sight: 8 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#88bb44', particleCount: 4 },
+  aura: null,
+  glow: 0,
+  metamorphosesInto: 'meadow-locust',
+  instarCount: 3,
+  instarDuration: 30,
+  moultVulnerability: 1.2,
+})
+
+// ---------------------------------------------------------------------------
+// Meadow Locust — flying adult that lays eggs. Issue #3340.
+// ---------------------------------------------------------------------------
+
+const MEADOW_LOCUST = builtin('meadow-locust', {
+  name: 'Meadow Locust',
+  blurb: 'A winged grass-hopper that strips plants bare. Its eggs hatch straight into tiny nymphs.',
+  size: 1,
+  tags: ['meat', 'bug', 'flier'],
+  art: {
+    palette: { w: '#88bb44', b: '#556622', g: '#ccff88' },
+    frames: [
+      ['gwg', 'wbw', 'gwg'],
+      ['.w.', 'gbg', '.w.'],
+    ],
+    frameMs: 120,
+    faceMotion: true,
+  },
+  body: { mass: 0.3, bounce: 0.2, drag: 0.5, buoyancy: 1.2, immuneTo: [] },
+  move: { kind: 'fly', speed: 5, jump: 0, hop: 0, restlessness: 0.5 },
+  diet: {
+    eats: ['plant'],
+    fears: ['flier'],
+    hungerRate: 0.03,
+    starveSeconds: 30,
+    breedAt: 0.6,
+    lifespanSeconds: 60,
+  },
+  senses: { sight: 14 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#88bb44', particleCount: 6 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  hemimetabolous: true,
+  nymphBlueprint: 'meadow-locust-nymph',
+})
+
+// ---------------------------------------------------------------------------
+// Dragonfly Nymph — aquatic predator with 5 instars. Issue #3340, #3341.
+// ---------------------------------------------------------------------------
+
+const DRAGONFLY_NYMPH = builtin('dragonfly-nymph', {
+  name: 'Dragonfly Nymph',
+  blurb: 'A fierce underwater hunter that clings to weeds. It moults five times before crawling out to fly.',
+  size: 1,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { w: '#665533', b: '#443322', g: '#998866' },
+    frames: [['gbg', 'wbw', 'gbg']],
+    frameMs: 200,
+    faceMotion: true,
+  },
+  body: { mass: 1.0, bounce: 0, drag: 0.4, buoyancy: 1.0, immuneTo: [] },
+  move: { kind: 'crawl', speed: 2, jump: 0, hop: 0, restlessness: 0.2 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.025,
+    starveSeconds: 60,
+    breedAt: 1,          // nymphs do not breed
+    lifespanSeconds: 180,
+  },
+  senses: { sight: 6 },
+  habitat: { needs: ['water'], drowns: false },
+  death: { becomes: null, particleColor: '#665533', particleCount: 4 },
+  aura: null,
+  glow: 0,
+  metamorphosesInto: 'dragonfly',
+  instarCount: 5,
+  instarDuration: 25,
+  moultVulnerability: 0.8,
+})
+
+// ---------------------------------------------------------------------------
+// Dragonfly — aerial predator that lays eggs in water. Issue #3340.
+// ---------------------------------------------------------------------------
+
+const DRAGONFLY = builtin('dragonfly', {
+  name: 'Dragonfly',
+  blurb: 'A dazzling aerial predator that hunts smaller bugs. It lays its eggs in still water.',
+  size: 1,
+  tags: ['meat', 'bug', 'flier'],
+  art: {
+    palette: { w: '#44aacc', b: '#226688', g: '#88ddff' },
+    frames: [
+      ['gwg', 'wbw', 'gwg'],
+      ['.g.', 'wbw', '.g.'],
+    ],
+    frameMs: 80,
+    faceMotion: true,
+  },
+  body: { mass: 0.2, bounce: 0.1, drag: 0.5, buoyancy: 1.3, immuneTo: [] },
+  move: { kind: 'fly', speed: 7, jump: 0, hop: 0, restlessness: 0.6 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.03,
+    starveSeconds: 30,
+    breedAt: 0.6,
+    lifespanSeconds: 40,
+  },
+  senses: { sight: 18 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#44aacc', particleCount: 6 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  hemimetabolous: true,
+  nymphBlueprint: 'dragonfly-nymph',
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -2125,6 +2273,10 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SHIMMER_LARVA,
   SHIMMER_PUPA,
   SHIMMER_FLY,
+  MEADOW_LOCUST_NYMPH,
+  MEADOW_LOCUST,
+  DRAGONFLY_NYMPH,
+  DRAGONFLY,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/config/materials.ts
+++ b/src/app/micro-land/domain/config/materials.ts
@@ -79,6 +79,7 @@ export const BASE_MATERIAL_IDS = [
   'cloud',
   'sap',
   'acid',
+  'shed-skin',
 ] as const satisfies readonly BaseMaterialId[]
 
 const BASE_MATERIALS: Record<BaseMaterialId, Material> = {
@@ -174,6 +175,11 @@ const BASE_MATERIALS: Record<BaseMaterialId, Material> = {
     corrosive: true,
     glow: 0.4,
     acidProof: true,
+  }),
+  'shed-skin': material('shed-skin', 'Shed Skin', '#d4c9a0', {
+    grain: 0.18,
+    solid: true,
+    fertile: true,
   }),
 }
 

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1435,6 +1435,53 @@ export function tickCreatures(
       continue
     }
 
+    // --- hemimetabolous instar progression + moulting. Issues #3340, #3341. ---
+    if (c.lifeStage === 'nymph') {
+      const currentNymphBp = w.blueprints[c.blueprintId] ?? bp
+      if (c.moultingTimer !== undefined) {
+        // Currently moulting — count down, stay immobile
+        c.moultingTimer -= dt
+        c.vx = 0
+        c.vy = 0
+        if (c.moultingTimer <= 0) {
+          c.moultingTimer = undefined
+          c.instar = (c.instar ?? 1) + 1
+          const instCount = currentNymphBp.instarCount ?? 3
+          if ((c.instar ?? 1) >= instCount) {
+            // Final moult → adult
+            const adultBpId = currentNymphBp.metamorphosesInto
+            const adultBp = adultBpId ? w.blueprints[adultBpId] : undefined
+            if (adultBp) {
+              c.blueprintId = adultBpId!
+              c.lifeStage = 'adult'
+              c.instar = undefined
+              c.ageSeconds = 0
+            }
+          }
+        }
+        continue  // immobile during moult, skip rest of tick
+      } else {
+        // Check if it's time to moult to the next instar
+        const instCount = currentNymphBp.instarCount ?? 3
+        const instDur = currentNymphBp.instarDuration ?? 30
+        const currentInstar = c.instar ?? 1
+        if (currentInstar < instCount && c.ageSeconds >= instDur * currentInstar) {
+          // Place shed-skin tile at creature position. Issue #3341.
+          const tx = Math.round(c.x)
+          const ty = Math.round(c.y)
+          const tileIdx = ty * w.width + tx
+          if (tileIdx >= 0 && tileIdx < w.tiles.length && w.tiles[tileIdx] === MATERIAL_INDEX['air']) {
+            w.tiles[tileIdx] = MATERIAL_INDEX['shed-skin']
+          }
+          // Start moult pause
+          c.moultingTimer = 2
+          c.vx = 0
+          c.vy = 0
+          continue
+        }
+      }
+    }
+
     // --- old age --------------------------------------------------------
     if (c.ageSeconds >= lifespanOf(c, bp) * TUNING.lifespanScale) {
       kill(w, c, bp, dead, events, 'aged')
@@ -2340,9 +2387,12 @@ export function tickCreatures(
     if (egg.hatchIn <= 0) {
       const parentBp = w.blueprints[egg.blueprintId]
       // Holometabolous: eggs from this adult hatch as the larval form. Issue #3336.
+      // Hemimetabolous: eggs from this adult hatch as nymph instar 1. Issue #3340.
       const hatchBpId = parentBp?.holometabolous && parentBp.larvaeBlueprint
         ? parentBp.larvaeBlueprint
-        : egg.blueprintId
+        : parentBp?.hemimetabolous && parentBp.nymphBlueprint
+          ? parentBp.nymphBlueprint
+          : egg.blueprintId
       const ebp = w.blueprints[hatchBpId]
       if (ebp && w.creatures.length < TUNING.maxCreatures) {
         const { w: ew, h: eh } = artSize(ebp)
@@ -2354,6 +2404,11 @@ export function tickCreatures(
           // Mark life stage from hatch. Issue #3336.
           if (parentBp?.holometabolous) {
             hatchling.lifeStage = 'larva'
+          }
+          // Hemimetabolous: hatch as nymph at instar 1. Issue #3340.
+          if (parentBp?.hemimetabolous) {
+            hatchling.lifeStage = 'nymph'
+            hatchling.instar = 1
           }
           events.push({ kind: 'born', blueprintId: ebp.id, x: egg.x, y: egg.y })
         }
@@ -2844,6 +2899,10 @@ function look(
         // fill, making pupae more targeted by opportunistic hunters. Issue #3338.
         if (other.lifeStage === 'pupa' && obp.pupalVulnerability) {
           fill *= 1 + obp.pupalVulnerability
+        }
+        // Moult vulnerability: moulting nymphs are soft-shelled and easy prey. Issue #3341.
+        if (other.lifeStage === 'nymph' && other.moultingTimer !== undefined && obp.moultVulnerability) {
+          fill *= 1 + obp.moultVulnerability
         }
         c.hunger = Math.max(0, c.hunger - fill)
         c.starving = 0

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -46,6 +46,7 @@ export type BaseMaterialId =
   | 'cloud'
   | 'sap'
   | 'acid'
+  | 'shed-skin'
 
 /** The colors a tintable material can be painted in. */
 export type TintId =
@@ -812,6 +813,30 @@ export interface CreatureBlueprint {
    * Issue #3338.
    */
   pupalVulnerability?: number
+  /**
+   * This species undergoes incomplete metamorphosis: egg → nymph (instars) → adult.
+   * Eggs from this adult hatch as the nymph form (`nymphBlueprint`). Issue #3340.
+   */
+  hemimetabolous?: boolean
+  /**
+   * BlueprintId of the nymph form. Eggs from this adult hatch as this blueprint.
+   * Only meaningful when `hemimetabolous: true`. Issue #3340.
+   */
+  nymphBlueprint?: string
+  /**
+   * Number of moults before the nymph becomes an adult. Default 3. Issue #3341.
+   */
+  instarCount?: number
+  /**
+   * Seconds per instar before the next moult is triggered. Default 30. Issue #3341.
+   */
+  instarDuration?: number
+  /**
+   * Extra predation fill bonus during moulting. Analogous to pupalVulnerability.
+   * When non-zero, a predator eating a moulting nymph gets (1 + moultVulnerability) ×
+   * normal fill — soft-shelled nymphs are easier prey. Issue #3341.
+   */
+  moultVulnerability?: number
 }
 
 /**
@@ -1215,9 +1240,13 @@ export interface Creature {
    * herbivory damage while active. Set when a network neighbor is attacked. Issue #3331. */
   defenseTimer?: number
   /** Current metamorphic stage — set at hatch time or after each transition. Issue #3336. */
-  lifeStage?: 'larva' | 'pupa' | 'adult'
+  lifeStage?: 'larva' | 'pupa' | 'adult' | 'nymph'
   /** Countdown seconds until adult emergence. Only set on pupa-stage creatures. Issue #3336. */
   pupalTimer?: number
+  /** Current instar number (1..N) for hemimetabolous nymphs. Issue #3340. */
+  instar?: number
+  /** Countdown seconds remaining in a moult pause. Set when moulting begins. Issue #3341. */
+  moultingTimer?: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements incomplete metamorphosis: nymphs are mobile adult-like creatures that moult between instars (no pupal stage)
- Between instars, nymphs pause for 2 seconds (soft exoskeleton — maximally vulnerable to predation)
- Each moult places a **shed-skin tile** at the moulting site as evidence of species presence
- Final moult transitions nymph to adult blueprint via `metamorphosesInto`
- Adds new `shed-skin` material (solid, fertile, warm parchment color)
- New species: Meadow Locust (3 instars, plant-eater) + Dragonfly (5 aquatic instars, predator)

## Issues closed
Closes #3340
Closes #3341

## New blueprint fields
| Field | Type | Purpose |
|---|---|---|
| `hemimetabolous` | `boolean` | Parent lays eggs that hatch as nymphs |
| `nymphBlueprint` | `string` | Blueprint ID to spawn at hatch |
| `instarCount` | `number` | Moults before adult (default 3) |
| `instarDuration` | `number` | Seconds per instar |
| `moultVulnerability` | `number` | Fill multiplier during moult (e.g. 1.2 = 2.2× fill) |

## Test plan
- [ ] Meadow Locust lays eggs → eggs hatch as nymphs (lifeStage='nymph', instar=1)
- [ ] Nymph moults 3 times → shed-skin tiles appear at moult sites
- [ ] Final moult → adult Meadow Locust (flying)
- [ ] Dragonfly nymph appears in water, moults 5 times → adult Dragonfly
- [ ] Predators preferentially eat moulting nymphs (moultVulnerability boost)
- [ ] Vercel preview builds clean