### PR TITLE
feat(micro-land): spider web construction — webs passively capture flying prey, degrade over time (#3420)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -664,6 +664,9 @@ export function sanitizeBlueprint(
     instarCount: typeof b.instarCount === 'number' ? Math.max(1, Math.floor(b.instarCount)) : undefined,
     instarDuration: typeof b.instarDuration === 'number' ? Math.max(1, b.instarDuration) : undefined,
     moultVulnerability: typeof b.moultVulnerability === 'number' ? Math.max(0, b.moultVulnerability) : undefined,
+    webSpinner: typeof b.webSpinner === 'boolean' ? b.webSpinner : undefined,
+    webRange: typeof b.webRange === 'number' ? Math.max(1, Math.floor(b.webRange)) : undefined,
+    webBuildInterval: typeof b.webBuildInterval === 'number' ? Math.max(0.5, b.webBuildInterval) : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -2221,6 +2221,44 @@ const DRAGONFLY = builtin('dragonfly', {
   nymphBlueprint: 'dragonfly-nymph',
 })
 
+// ---------------------------------------------------------------------------
+// Garden Spider — web-spinning predator. Issue #3420.
+// ---------------------------------------------------------------------------
+
+const GARDEN_SPIDER = builtin('garden-spider', {
+  name: 'Garden Spider',
+  blurb: 'A patient architect, building geometric webs to passively harvest flying prey.',
+  size: 1,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { w: '#cc9955', b: '#442211', g: '#eecc88' },
+    frames: [
+      ['bwb', 'wgw', 'bwb'],
+    ],
+    frameMs: 500,
+    faceMotion: false,
+  },
+  body: { mass: 0.4, bounce: 0.05, drag: 0.4, buoyancy: 0.8, immuneTo: [] },
+  move: { kind: 'crawl', speed: 2.0, jump: 0, restlessness: 0.2 },
+  diet: {
+    eats: ['bug'],
+    fears: [],
+    hungerRate: 0.018,
+    starveSeconds: 60,
+    breedAt: 0.75,
+    lifespanSeconds: 180,
+  },
+  senses: { sight: 14 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#cc9955', particleCount: 2 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  webSpinner: true,
+  webRange: 5,
+  webBuildInterval: 4,
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -2263,6 +2301,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   RIMECLAW,
   SUNHAWK,
   GLOOMWEAVER,
+  GARDEN_SPIDER,
   CAVE_CRICKET,
   CAVE_SALAMANDER,
   BAT,

--- a/src/app/micro-land/domain/config/materials.ts
+++ b/src/app/micro-land/domain/config/materials.ts
@@ -80,6 +80,7 @@ export const BASE_MATERIAL_IDS = [
   'sap',
   'acid',
   'shed-skin',
+  'web',
 ] as const satisfies readonly BaseMaterialId[]
 
 const BASE_MATERIALS: Record<BaseMaterialId, Material> = {
@@ -180,6 +181,12 @@ const BASE_MATERIALS: Record<BaseMaterialId, Material> = {
     grain: 0.18,
     solid: true,
     fertile: true,
+  }),
+  web: material('web', 'Web', '#e8e8f0', {
+    grain: 0.05,
+    solid: false,
+    viscous: 0.95,
+    glow: 0.04,
   }),
 }
 

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -67,6 +67,7 @@ import {
   tickMoisture,
   tickMycorrhizalNetwork,
   tickSalinity,
+  tickWebDecay,
   tileAt,
   updateBiomeZones,
 } from './world'
@@ -873,6 +874,7 @@ export function tickCreatures(
   const plantCount = w.creatures.filter(c => w.blueprints[c.blueprintId]?.move.kind === 'root').length
   tickAtmosphericCO2(w, tickCount, plantCount)
   tickMycorrhizalNetwork(w, tickCount, rng)
+  tickWebDecay(w, tickCount, rng)
   updateBiomeZones(w, tickCount, seasonFactor)
 
   const creatures = w.creatures
@@ -1506,6 +1508,35 @@ export function tickCreatures(
       }
     }
 
+    // --- web building: spiders periodically place web tiles near solid anchor points. Issue #3420. ---
+    if (bp.webSpinner) {
+      c.webBuildTimer = (c.webBuildTimer ?? 0) - dt
+      if (c.webBuildTimer <= 0) {
+        c.webBuildTimer = bp.webBuildInterval ?? 5
+        const range = bp.webRange ?? 4
+        const cx = Math.round(c.x)
+        const cy = Math.round(c.y)
+        const webMat = MATERIAL_INDEX['web']
+        const airMat = 0  // AIR is always index 0
+        for (let attempt = 0; attempt < 8; attempt++) {
+          const tx = cx + Math.round((rng() * 2 - 1) * range)
+          const ty = cy + Math.round((rng() * 2 - 1) * range)
+          if (tx < 0 || tx >= w.width || ty < 0 || ty >= w.height) continue
+          const tIdx = ty * w.width + tx
+          if (w.tiles[tIdx] !== airMat) continue
+          const webOffsets: [number, number][] = [[-1, 0], [1, 0], [0, -1], [0, 1]]
+          const hasAnchor = webOffsets.some(([dx, dy]) => {
+            const ni = (ty + dy) * w.width + (tx + dx)
+            return ni >= 0 && ni < w.tiles.length && IS_SOLID[w.tiles[ni]]
+          })
+          if (hasAnchor) {
+            w.tiles[tIdx] = webMat
+            break
+          }
+        }
+      }
+    }
+
     // --- old age --------------------------------------------------------
     if (c.ageSeconds >= lifespanOf(c, bp) * TUNING.lifespanScale) {
       kill(w, c, bp, dead, events, 'aged')
@@ -1573,6 +1604,23 @@ export function tickCreatures(
        */
       c.vy = Math.max(0, c.vy)
       integrate(w, c, bp, bw, bh, dt, wet, gravityScale)
+    }
+
+    // --- web capture: flying creatures entering a web tile become trapped. Issue #3420. ---
+    if (bp.move.kind === 'fly' || bp.move.kind === 'drift') {
+      const capTileIdx = Math.round(c.y) * w.width + wrapCol(Math.round(c.x))
+      if (capTileIdx >= 0 && capTileIdx < w.tiles.length && w.tiles[capTileIdx] === MATERIAL_INDEX['web']) {
+        c.webTrapped = true
+      }
+    }
+    if (c.webTrapped) {
+      // Small chance to escape each second; otherwise freeze velocity.
+      if (rng() < 0.005 * dt) {
+        c.webTrapped = false
+      } else {
+        c.vx = 0
+        c.vy = 0
+      }
     }
 
     // --- fatigue --------------------------------------------------------
@@ -2948,6 +2996,10 @@ function look(
         // Moult vulnerability: moulting nymphs are soft-shelled and easy prey. Issue #3341.
         if (other.lifeStage === 'nymph' && other.moultingTimer !== undefined && obp.moultVulnerability) {
           fill *= 1 + obp.moultVulnerability
+        }
+        // Web-trapped prey: immobilized creatures are easy pickings for the spider. Issue #3420.
+        if (other.webTrapped && bp.webSpinner) {
+          fill *= 2
         }
         c.hunger = Math.max(0, c.hunger - fill)
         c.starving = 0

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -1369,4 +1369,33 @@ export function isInEcotone(w: WorldState, y: number): boolean {
   return (y - bandStart < ECOTONE_WIDTH) || (bandEnd - y <= ECOTONE_WIDTH)
 }
 
+/**
+ * Decay web tiles over time and destroy them when adjacent to water (rain damage).
+ * Each call (every 60 ticks) gives each web tile a 0.2% chance to become air.
+ * Issue #3420.
+ */
+const WEB_DECAY_CHANCE = 0.002
+export function tickWebDecay(w: WorldState, tickCount: number, rng: () => number): void {
+  if (tickCount % 60 !== 0) return
+  const webIdx = MATERIAL_INDEX.web
+  const waterIdx = MATERIAL_INDEX.water
+  for (let i = 0; i < w.tiles.length; i++) {
+    if (w.tiles[i] !== webIdx) continue
+    const x = i % w.width
+    const y = Math.floor(i / w.width)
+    // Check for adjacent water (rain damage)
+    let adjacentWater = false
+    const offsets: [number, number][] = [[-1, 0], [1, 0], [0, -1], [0, 1]]
+    for (const [dx, dy] of offsets) {
+      const nx = x + dx
+      const ny = y + dy
+      if (nx < 0 || nx >= w.width || ny < 0 || ny >= w.height) continue
+      if (w.tiles[ny * w.width + nx] === waterIdx) { adjacentWater = true; break }
+    }
+    if (adjacentWater || rng() < WEB_DECAY_CHANCE) {
+      w.tiles[i] = AIR
+    }
+  }
+}
+
 export { AIR }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -47,6 +47,7 @@ export type BaseMaterialId =
   | 'sap'
   | 'acid'
   | 'shed-skin'
+  | 'web'
 
 /** The colors a tintable material can be painted in. */
 export type TintId =
@@ -837,6 +838,16 @@ export interface CreatureBlueprint {
    * normal fill — soft-shelled nymphs are easier prey. Issue #3341.
    */
   moultVulnerability?: number
+  /**
+   * Spider-type creatures that spin web tiles between solid anchor points.
+   * Web tiles passively capture small flying creatures and degrade over time.
+   * Issue #3420.
+   */
+  webSpinner?: boolean
+  /** Radius within which webs are placed, in tiles. Default 4. Issue #3420. */
+  webRange?: number
+  /** Seconds between placing a web tile. Default 5. Issue #3420. */
+  webBuildInterval?: number
 }
 
 /**
@@ -1247,6 +1258,10 @@ export interface Creature {
   instar?: number
   /** Countdown seconds remaining in a moult pause. Set when moulting begins. Issue #3341. */
   moultingTimer?: number
+  /** Countdown seconds until this web-spinner places the next web tile. Issue #3420. */
+  webBuildTimer?: number
+  /** True when this flying creature has been caught in a web tile. Issue #3420. */
+  webTrapped?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- Spider-type creatures (`webSpinner: true`) build web tiles near solid anchor points on a configurable interval
- Web tiles passively capture flying/drifting creatures passing through — they become `webTrapped` and freeze in place
- Trapped creatures are easy prey for the spider (2× fill bonus)
- Webs decay over time (0.2% chance per tick-batch → air) and are instantly destroyed by adjacent water (rain damage)
- New `web` material: non-solid, viscous (0.95), pale blue-white glow
- New species: Garden Spider (patient ambush predator, webRange=5, webBuildInterval=4s)

## Issues closed
Closes #3420

## New blueprint fields
| Field | Type | Default | Purpose |
|---|---|---|---|
| `webSpinner` | `boolean` | — | Creature builds web tiles |
| `webRange` | `number` | 4 | Radius for web placement |
| `webBuildInterval` | `number` | 5s | Seconds between web placements |

## Test plan
- [ ] Garden Spider appears in simulation and builds web tiles near solid surfaces
- [ ] Flying creatures (Shimmer Fly, Dragonfly) entering web tiles become trapped
- [ ] Trapped creatures remain immobile until they escape (0.5%/s) or spider eats them
- [ ] Web tiles adjacent to water disappear (rain damage)
- [ ] Web tiles gradually degrade over ~30s average lifetime
- [ ] Vercel preview builds clean