### PR TITLE
feat(micro-land): object manipulation + nest construction — nestBuilders collect materials, protect eggs (#3412, #3418)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -667,6 +667,12 @@ export function sanitizeBlueprint(
     webSpinner: typeof b.webSpinner === 'boolean' ? b.webSpinner : undefined,
     webRange: typeof b.webRange === 'number' ? Math.max(1, Math.floor(b.webRange)) : undefined,
     webBuildInterval: typeof b.webBuildInterval === 'number' ? Math.max(0.5, b.webBuildInterval) : undefined,
+    objectManipulator: typeof b.objectManipulator === 'boolean' ? b.objectManipulator : undefined,
+    nestBuilder: typeof b.nestBuilder === 'boolean' ? b.nestBuilder : undefined,
+    nestMaterials: Array.isArray(b.nestMaterials) ? (b.nestMaterials as string[]) : undefined,
+    nestCompleteAt: typeof b.nestCompleteAt === 'number' ? Math.max(1, Math.floor(b.nestCompleteAt)) : undefined,
+    nestHatchBonus: typeof b.nestHatchBonus === 'number' ? Math.max(0.1, Math.min(1, b.nestHatchBonus)) : undefined,
+    nestRadius: typeof b.nestRadius === 'number' ? Math.max(1, b.nestRadius) : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -2259,6 +2259,47 @@ const GARDEN_SPIDER = builtin('garden-spider', {
   webBuildInterval: 4,
 })
 
+// ---------------------------------------------------------------------------
+// Weaver Bird — nest-building seed-eater. Issue #3418.
+// ---------------------------------------------------------------------------
+
+const WEAVER_BIRD = builtin('weaver-bird', {
+  name: 'Weaver Bird',
+  blurb: 'A master builder that weaves intricate nests from grass and moss, protecting eggs from predation.',
+  size: 1,
+  tags: ['plant', 'bird', 'flier'],
+  art: {
+    palette: { w: '#e8b84b', b: '#7a4f10', g: '#ffd97a' },
+    frames: [
+      ['gwg', 'wbw', 'gwg'],
+      ['.g.', 'wbw', '.g.'],
+    ],
+    frameMs: 130,
+    faceMotion: true,
+  },
+  body: { mass: 0.4, bounce: 0.1, drag: 0.5, buoyancy: 1.0, immuneTo: [] },
+  move: { kind: 'fly', speed: 1.5, jump: 0, hop: 0, restlessness: 0.4 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.00006,
+    starveSeconds: 30,
+    breedAt: 0.75,
+    lifespanSeconds: 200,
+  },
+  senses: { sight: 16 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#e8b84b', particleCount: 3 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  nestBuilder: true,
+  nestMaterials: ['grass', 'moss'],
+  nestCompleteAt: 6,
+  nestHatchBonus: 0.65,
+  nestRadius: 3,
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -2316,6 +2357,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   MEADOW_LOCUST,
   DRAGONFLY_NYMPH,
   DRAGONFLY,
+  WEAVER_BIRD,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -17,7 +17,7 @@ import {
   isPlantLike,
 } from '@/app/micro-land/domain/blueprint'
 import type { BodyBox } from '@/app/micro-land/domain/blueprint'
-import { IS_DEADLY, IS_LIQUID, IS_SOLID, MATERIAL_BY_INDEX, MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { AIR, IS_DEADLY, IS_LIQUID, IS_SOLID, MATERIAL_BY_INDEX, MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
 import {
   BREATH_SECONDS,
   FORAGE_HUNGER,
@@ -1537,6 +1537,53 @@ export function tickCreatures(
       }
     }
 
+    // --- object manipulation: pick up nearby collectable tiles. Issues #3412, #3418. ---
+    if ((bp.objectManipulator || bp.nestBuilder) && c.carriedMaterial === undefined && c.hunger < 0.5) {
+      const collectibles: string[] = bp.nestMaterials ?? ['grass', 'moss', 'wood']
+      const cx = Math.round(c.x), cy = Math.round(c.y)
+      outerPickup:
+      for (let dy = -2; dy <= 2; dy++) {
+        for (let dx2 = -2; dx2 <= 2; dx2++) {
+          const tx = cx + dx2, ty = cy + dy
+          if (tx < 0 || tx >= w.width || ty < 0 || ty >= w.height) continue
+          const tIdx = ty * w.width + tx
+          const matId = MATERIAL_BY_INDEX[w.tiles[tIdx]]?.id
+          if (matId !== undefined && collectibles.includes(matId) && rng() < 0.05 * dt) {
+            c.carriedMaterial = w.tiles[tIdx]
+            w.tiles[tIdx] = AIR
+            break outerPickup
+          }
+        }
+      }
+    }
+    // --- nest delivery: when carrying, steer toward nest site and place tile. Issue #3418. ---
+    if (bp.nestBuilder && c.carriedMaterial !== undefined && c.nestX !== undefined && c.nestY !== undefined) {
+      const ddx = c.nestX - c.x, ddy = c.nestY - c.y
+      const dist = Math.sqrt(ddx * ddx + ddy * ddy)
+      if (dist < 2) {
+        // Place the tile at or near the nest anchor
+        const placeIdx = Math.round(c.nestY) * w.width + Math.round(c.nestX)
+        if (placeIdx >= 0 && placeIdx < w.tiles.length && w.tiles[placeIdx] === AIR) {
+          w.tiles[placeIdx] = c.carriedMaterial
+        }
+        c.carriedMaterial = undefined
+        c.nestProgress = (c.nestProgress ?? 0) + 1
+        // Register/update nest in WorldState
+        w.nestSites = w.nestSites ?? {}
+        const nestKey = `${Math.round(c.nestX)},${Math.round(c.nestY)}`
+        w.nestSites[nestKey] = {
+          progress: c.nestProgress,
+          ownerId: c.id,
+          x: Math.round(c.nestX),
+          y: Math.round(c.nestY),
+        }
+      } else {
+        // Bias velocity toward nest site
+        c.vx += (ddx / dist) * 0.2 * dt
+        c.vy += (ddy / dist) * 0.2 * dt
+      }
+    }
+
     // --- old age --------------------------------------------------------
     if (c.ageSeconds >= lifespanOf(c, bp) * TUNING.lifespanScale) {
       kill(w, c, bp, dead, events, 'aged')
@@ -2200,6 +2247,11 @@ export function tickCreatures(
             generation,
             hatchIn: TUNING.eggHatchSeconds,
           })
+          // Assign nest site when first egg is laid. Issue #3418.
+          if (bp.nestBuilder && c.nestX === undefined) {
+            c.nestX = c.x
+            c.nestY = c.y
+          }
           c.children++
           if (c.children === 1) logLife(c, w.elapsed, 'First offspring')
           else if (c.children % 10 === 0) logLife(c, w.elapsed, `${c.children} offspring`)
@@ -2471,6 +2523,23 @@ export function tickCreatures(
   const hatchedEggIds = new Set<number>()
   for (const egg of w.eggs) {
     egg.hatchIn -= dt
+    // Nest hatch bonus: eggs near a complete nest hatch faster. Issue #3418.
+    if (w.nestSites && egg.hatchIn > 0) {
+      const nestBpForEgg = w.blueprints[egg.blueprintId]
+      if (nestBpForEgg?.nestBuilder) {
+        const completeAt = nestBpForEgg.nestCompleteAt ?? 8
+        const radius = nestBpForEgg.nestRadius ?? 3
+        const hatchBonus = nestBpForEgg.nestHatchBonus ?? 0.7
+        for (const nest of Object.values(w.nestSites)) {
+          const ex = egg.x - nest.x, ey = egg.y - nest.y
+          if (nest.progress >= completeAt && Math.sqrt(ex * ex + ey * ey) <= radius) {
+            // Accelerate hatch: reduce remaining time proportionally this tick
+            egg.hatchIn -= dt * (1 / hatchBonus - 1)  // net effect: hatchIn depletes faster
+            break
+          }
+        }
+      }
+    }
     if (egg.hatchIn <= 0) {
       const parentBp = w.blueprints[egg.blueprintId]
       // Holometabolous: eggs from this adult hatch as the larval form. Issue #3336.

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -848,6 +848,24 @@ export interface CreatureBlueprint {
   webRange?: number
   /** Seconds between placing a web tile. Default 5. Issue #3420. */
   webBuildInterval?: number
+  /**
+   * When true, this creature can pick up and carry portable tile materials.
+   * Issues #3412, #3418.
+   */
+  objectManipulator?: boolean
+  /**
+   * When true, this creature actively collects nest materials and delivers them
+   * to a chosen nest site. Eggs laid near a complete nest hatch faster. Issue #3418.
+   */
+  nestBuilder?: boolean
+  /** Materials this nestBuilder collects (e.g. ['grass', 'moss']). Issue #3418. */
+  nestMaterials?: string[]
+  /** Number of tiles needed to consider the nest complete. Default 8. Issue #3418. */
+  nestCompleteAt?: number
+  /** Hatch time multiplier for eggs near a complete nest. Default 0.7 (30% faster). Issue #3418. */
+  nestHatchBonus?: number
+  /** Radius in tiles within which eggs benefit from the nest. Default 3. Issue #3418. */
+  nestRadius?: number
 }
 
 /**
@@ -1262,6 +1280,14 @@ export interface Creature {
   webBuildTimer?: number
   /** True when this flying creature has been caught in a web tile. Issue #3420. */
   webTrapped?: boolean
+  /** Numeric material index this creature is currently carrying. Issue #3412, #3418. */
+  carriedMaterial?: number
+  /** X tile of this nestBuilder's chosen nest site. Issue #3418. */
+  nestX?: number
+  /** Y tile of this nestBuilder's chosen nest site. Issue #3418. */
+  nestY?: number
+  /** Number of tiles delivered to the nest so far. Issue #3418. */
+  nestProgress?: number
 }
 
 /**
@@ -1600,6 +1626,13 @@ export interface WorldState {
    * until first mycorrhizal plant establishes. Issue #3329.
    */
   mycorrhizalLinks?: Record<string, number[]>
+  /**
+   * Active nest sites built by nestBuilder creatures.
+   *
+   * Keyed as `"x,y"`. Each entry tracks the owner, coordinates and number of
+   * tiles delivered. Used for egg hatch bonus and nest rendering. Issues #3412, #3418.
+   */
+  nestSites?: Record<string, { progress: number; ownerId: number; x: number; y: number }>
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Object manipulation (#3412)**: Creatures with `objectManipulator: true` or `nestBuilder: true` can pick up collectable tiles (grass, moss, wood) from their surroundings and carry them
- **Nest construction (#3418)**: `nestBuilder` creatures deliver carried materials to their chosen nest site (set when they first lay eggs); eggs near a complete nest hatch up to 35% faster
- New species: **Weaver Bird** — a flying seed-eater that weaves nests from grass and moss (nestCompleteAt=6 tiles, nestHatchBonus=0.65)
- Nest sites tracked in `WorldState.nestSites` record

## Issues closed
Closes #3412
Closes #3418

## New blueprint fields
| Field | Type | Default | Purpose |
|---|---|---|---|
| `objectManipulator` | `boolean` | — | Can pick up portable tiles |
| `nestBuilder` | `boolean` | — | Actively collects + places materials at nest site |
| `nestMaterials` | `string[]` | `['grass','moss','wood']` | Which tile types to collect |
| `nestCompleteAt` | `number` | 8 | Tiles needed for complete nest |
| `nestHatchBonus` | `number` | 0.7 | Hatch time multiplier near complete nest |
| `nestRadius` | `number` | 3 | Egg protection radius |

## Test plan
- [ ] Weaver Bird appears in simulation and picks up grass/moss tiles
- [ ] Carried tiles are removed from world; delivered to nest site
- [ ] Nest progress tracked in WorldState.nestSites
- [ ] Eggs laid near complete Weaver Bird nest hatch faster than normal
- [ ] Non-nestBuilder creatures unaffected
- [ ] Vercel preview builds clean