### PR TITLE
feat(micro-land): burrow systems — burrowing creatures excavate soil, retreat underground for safety (#3419)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -673,6 +673,8 @@ export function sanitizeBlueprint(
     nestCompleteAt: typeof b.nestCompleteAt === 'number' ? Math.max(1, Math.floor(b.nestCompleteAt)) : undefined,
     nestHatchBonus: typeof b.nestHatchBonus === 'number' ? Math.max(0.1, Math.min(1, b.nestHatchBonus)) : undefined,
     nestRadius: typeof b.nestRadius === 'number' ? Math.max(1, b.nestRadius) : undefined,
+    burrowDigger: typeof b.burrowDigger === 'boolean' ? b.burrowDigger : undefined,
+    burrowCacheSize: typeof b.burrowCacheSize === 'number' ? Math.max(0, Math.min(1, b.burrowCacheSize)) : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -2300,6 +2300,80 @@ const WEAVER_BIRD = builtin('weaver-bird', {
   nestRadius: 3,
 })
 
+// ---------------------------------------------------------------------------
+// Prairie Dog — colonial burrowing herbivore. Issue #3419.
+// ---------------------------------------------------------------------------
+
+const PRAIRIE_DOG = builtin('prairie-dog', {
+  name: 'Prairie Dog',
+  blurb: 'A colonial burrower that excavates vast underground towns, ducking below ground when danger strikes.',
+  size: 1,
+  tags: ['plant', 'mammal'],
+  art: {
+    palette: { w: '#c8963c', b: '#7a5c2a', g: '#e8c07a' },
+    frames: [
+      ['gwg', 'wbw', 'gwg'],
+    ],
+    frameMs: 400,
+    faceMotion: true,
+  },
+  body: { mass: 1, bounce: 0.05, drag: 0.5, buoyancy: 0.8, immuneTo: [] },
+  move: { kind: 'walk', speed: 1.2, jump: 5, hop: 0, restlessness: 0.5 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.00007,
+    starveSeconds: 30,
+    breedAt: 0.75,
+    lifespanSeconds: 80,
+  },
+  senses: { sight: 1.1 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#c8963c', particleCount: 2 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  burrowDigger: true,
+  burrowCacheSize: 0.4,
+})
+
+// ---------------------------------------------------------------------------
+// Badger — powerful burrowing predator. Issue #3419.
+// ---------------------------------------------------------------------------
+
+const BADGER = builtin('badger', {
+  name: 'Badger',
+  blurb: 'A powerful burrowing predator that excavates setts and pursues prey even underground.',
+  size: 1,
+  tags: ['meat', 'mammal'],
+  art: {
+    palette: { w: '#c8c8c8', b: '#222222', g: '#888888' },
+    frames: [
+      ['bwb', 'wgw', 'bwb'],
+    ],
+    frameMs: 400,
+    faceMotion: true,
+  },
+  body: { mass: 1, bounce: 0.05, drag: 0.4, buoyancy: 0.8, immuneTo: [] },
+  move: { kind: 'walk', speed: 0.9, jump: 4, hop: 0, restlessness: 0.3 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.00004,
+    starveSeconds: 60,
+    breedAt: 0.75,
+    lifespanSeconds: 200,
+  },
+  senses: { sight: 0.8 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#888888', particleCount: 3 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  burrowDigger: true,
+  burrowCacheSize: 0.5,
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -2358,6 +2432,8 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   DRAGONFLY_NYMPH,
   DRAGONFLY,
   WEAVER_BIRD,
+  PRAIRIE_DOG,
+  BADGER,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1584,6 +1584,35 @@ export function tickCreatures(
       }
     }
 
+    // --- burrow excavation: dig through soil tiles downward. Issue #3419. ---
+    if (bp.burrowDigger) {
+      const digMats = ['dirt', 'mud', 'sand', 'grass', 'snow', 'ash']
+      for (const ddy of [0, 1]) {
+        const tx = Math.round(c.x), ty = Math.round(c.y) + ddy
+        if (tx < 0 || tx >= w.width || ty < 0 || ty >= w.height) continue
+        const tIdx = ty * w.width + tx
+        const matId = MATERIAL_BY_INDEX[w.tiles[tIdx]]?.id
+        if (matId !== undefined && digMats.includes(matId) && rng() < 0.15 * dt) {
+          if (c.burrowX === undefined) {
+            c.burrowX = tx
+            c.burrowY = ty
+          }
+          w.tiles[tIdx] = AIR
+          break
+        }
+      }
+    }
+
+    // --- in-burrow status: underground at burrow site = safe. Issue #3419. ---
+    if (bp.burrowDigger && c.burrowX !== undefined) {
+      const distToBurrow = Math.sqrt((c.x - c.burrowX) ** 2 + (c.y - c.burrowY!) ** 2)
+      const aboveIdx = (Math.round(c.y) - 1) * w.width + Math.round(c.x)
+      const hasRoof = aboveIdx >= 0 && aboveIdx < w.tiles.length && IS_SOLID[w.tiles[aboveIdx]]
+      c.inBurrow = distToBurrow < 3 && !!hasRoof
+    } else {
+      c.inBurrow = false
+    }
+
     // --- old age --------------------------------------------------------
     if (c.ageSeconds >= lifespanOf(c, bp) * TUNING.lifespanScale) {
       kill(w, c, bp, dead, events, 'aged')
@@ -1628,6 +1657,29 @@ export function tickCreatures(
     // --- senses ---------------------------------------------------------
     if ((tickCount + c.id) % SENSE_EVERY === 0) {
       look(w, c, bp, bw, bh, dead, events, rng)
+    }
+
+    // --- burrow retreat: when threatened or hungry, head back to burrow. Issue #3419. ---
+    if (bp.burrowDigger && c.burrowX !== undefined && (c.hunger > 0.7 || c.mood === 'flee')) {
+      const rdx = c.burrowX - c.x, rdy = c.burrowY! - c.y
+      const rdist = Math.sqrt(rdx * rdx + rdy * rdy)
+      if (rdist > 1) {
+        c.vx += (rdx / rdist) * 0.5 * dt
+        c.vy += (rdy / rdist) * 0.5 * dt
+      }
+    }
+
+    // --- food cache: store/draw surplus energy in burrow. Issue #3419. ---
+    if (bp.burrowDigger && c.inBurrow) {
+      const cacheMax = bp.burrowCacheSize ?? 0.3
+      if (c.hunger < 0.2 && (c.cachedFood ?? 0) < cacheMax) {
+        c.cachedFood = Math.min(cacheMax, (c.cachedFood ?? 0) + 0.05 * dt)
+      }
+      if (c.hunger > 0.8 && (c.cachedFood ?? 0) > 0) {
+        const draw = Math.min(c.cachedFood ?? 0, 0.3 * dt)
+        c.cachedFood = (c.cachedFood ?? 0) - draw
+        c.hunger = Math.max(0, c.hunger - draw)
+      }
     }
 
     // --- movement -------------------------------------------------------
@@ -2927,6 +2979,8 @@ function look(
     if (other.id === c.id || dead.has(other.id)) continue
     const obp = w.blueprints[other.blueprintId]
     if (!obp) continue
+    // Burrowed creatures are safe from non-burrowing predators. Issue #3419.
+    if (other.inBurrow && !bp.burrowDigger) continue
 
     const { w: ow, h: oh } = artSize(obp)
     // The short way round, so a creature by the seam hunts across it rather than

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -866,6 +866,17 @@ export interface CreatureBlueprint {
   nestHatchBonus?: number
   /** Radius in tiles within which eggs benefit from the nest. Default 3. Issue #3418. */
   nestRadius?: number
+  /**
+   * When true, this creature physically excavates soil tiles (dirt, mud, sand,
+   * grass, snow, ash) to dig a burrow tunnel. The first tile dug becomes the
+   * creature's tracked burrow entrance (burrowX, burrowY). Issue #3419.
+   */
+  burrowDigger?: boolean
+  /**
+   * Maximum food reserves this creature can store in its burrow, on the 0–1
+   * hunger scale. Drawn from when starving at the burrow. Default 0.3. Issue #3419.
+   */
+  burrowCacheSize?: number
 }
 
 /**
@@ -1288,6 +1299,14 @@ export interface Creature {
   nestY?: number
   /** Number of tiles delivered to the nest so far. Issue #3418. */
   nestProgress?: number
+  /** X tile of this creature's self-dug burrow entrance. Issue #3419. */
+  burrowX?: number
+  /** Y tile of this creature's self-dug burrow entrance. Issue #3419. */
+  burrowY?: number
+  /** Food energy reserves cached in the burrow, 0–1 hunger-scale. Issue #3419. */
+  cachedFood?: number
+  /** True while this creature is underground at its burrow site. Issue #3419. */
+  inBurrow?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- Creatures with `burrowDigger: true` excavate soil/dirt tiles as they move, creating underground tunnels
- Burrowers track their burrow entrance (`burrowX/Y`) from the first tile they dig
- When hungry (>70%) or fleeing, creatures steer back toward their burrow entrance
- **Burrow safety**: `inBurrow` creatures cannot be targeted by non-burrowing predators
- **Food cache**: burrowers deposit energy reserves when full; draw from cache when starving underground
- New species: **Prairie Dog** (colonial burrowing herbivore) + **Badger** (burrowing predator that can hunt burrowed prey)

## Issues closed
Closes #3419

## New blueprint fields
| Field | Type | Default | Purpose |
|---|---|---|---|
| `burrowDigger` | `boolean` | — | Actively excavates soil tiles |
| `burrowCacheSize` | `number` | 0.3 | Max food reserves stored in burrow |

## Predator-prey dynamics
- Prairie Dogs retreat underground when threatened
- Badgers are also `burrowDigger` — they CAN pursue burrowed prairie dogs
- Non-burrowing predators are foiled by the burrow

## Test plan
- [ ] Prairie Dog appears in simulation and digs tunnels in dirt/grass tiles
- [ ] Prairie Dogs with hunger > 0.7 steer back to their burrow entrance
- [ ] Non-burrowing predators skip Prairie Dogs that are `inBurrow`
- [ ] Badger can hunt burrowed Prairie Dogs (both are burrowDiggers)
- [ ] Full prairie dogs deposit food cache; starving prairie dogs draw from it
- [ ] Vercel preview builds clean