### PR TITLE
feat(micro-land): termite mound ecology — workers build mound tiles, aardvarks destroy mounds releasing nutrients (#3421)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -675,6 +675,9 @@ export function sanitizeBlueprint(
     nestRadius: typeof b.nestRadius === 'number' ? Math.max(1, b.nestRadius) : undefined,
     burrowDigger: typeof b.burrowDigger === 'boolean' ? b.burrowDigger : undefined,
     burrowCacheSize: typeof b.burrowCacheSize === 'number' ? Math.max(0, Math.min(1, b.burrowCacheSize)) : undefined,
+    termiteWorker: typeof b.termiteWorker === 'boolean' ? b.termiteWorker : undefined,
+    moundCommensal: typeof b.moundCommensal === 'boolean' ? b.moundCommensal : undefined,
+    moundDestroyer: typeof b.moundDestroyer === 'boolean' ? b.moundDestroyer : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -2374,6 +2374,84 @@ const BADGER = builtin('badger', {
   burrowCacheSize: 0.5,
 })
 
+const TERMITE = builtin('termite', {
+  name: 'Termite',
+  blurb: 'A eusocial engineer that builds towering mounds from digested soil, creating habitat for dozens of other species.',
+  size: 1,
+  tags: ['plant', 'bug'],
+  art: {
+    palette: { w: '#cc9966', b: '#6b4422', g: '#e8b888' },
+    frames: [['bwb', 'wgw', 'bwb']],
+    frameMs: 200,
+    faceMotion: false,
+  },
+  movement: { canFly: false, canSwim: false, canClimb: false, canBurrow: false, speed: 0.5, wanderBias: 0.7 },
+  diet: { eats: 'plant', huntRadius: 3 },
+  reproduction: { rate: 0.012, eggCount: 6, eggsNeedSolid: true },
+  lifespan: 40,
+  hunger: { rate: 0.00008, starvationRate: 0.0004 },
+  senses: { sight: 0.4, smell: 0.8 },
+  trophicLevel: 1,
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#cc9966', particleCount: 1 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  termiteWorker: true,
+})
+
+const AARDVARK = builtin('aardvark', {
+  name: 'Aardvark',
+  blurb: 'A powerful nocturnal excavator that demolishes termite mounds to feast on the colony within.',
+  size: 1,
+  tags: ['meat', 'mammal'],
+  art: {
+    palette: { w: '#c8a07a', b: '#7a5040', g: '#e8c8a8' },
+    frames: [['gwg', 'wbw', 'gwg']],
+    frameMs: 300,
+    faceMotion: true,
+  },
+  movement: { canFly: false, canSwim: false, canClimb: false, canBurrow: true, speed: 0.8, wanderBias: 0.3 },
+  diet: { eats: 'meat', huntRadius: 8 },
+  reproduction: { rate: 0.001, eggCount: 1, eggsNeedSolid: true },
+  lifespan: 300,
+  hunger: { rate: 0.00003, starvationRate: 0.0001 },
+  senses: { sight: 0.6, smell: 1.2 },
+  trophicLevel: 2,
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#c8a07a', particleCount: 4 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  moundDestroyer: true,
+})
+
+const BARK_GECKO = builtin('bark-gecko', {
+  name: 'Bark Gecko',
+  blurb: 'A quick insectivore that lives on the surface of termite mounds, exploiting the steady stream of insects.',
+  size: 1,
+  tags: ['meat', 'reptile'],
+  art: {
+    palette: { w: '#8a8060', b: '#4a3830', g: '#c8b888' },
+    frames: [['bwb', 'wgw', 'bwb']],
+    frameMs: 250,
+    faceMotion: true,
+  },
+  movement: { canFly: false, canSwim: false, canClimb: true, canBurrow: false, speed: 1.4, wanderBias: 0.4 },
+  diet: { eats: 'meat', huntRadius: 5 },
+  reproduction: { rate: 0.003, eggCount: 2, eggsNeedSolid: true },
+  lifespan: 120,
+  hunger: { rate: 0.00005, starvationRate: 0.0002 },
+  senses: { sight: 1.0, smell: 0.3 },
+  trophicLevel: 2,
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#8a8060', particleCount: 2 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  moundCommensal: true,
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -2434,6 +2512,9 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   WEAVER_BIRD,
   PRAIRIE_DOG,
   BADGER,
+  TERMITE,
+  AARDVARK,
+  BARK_GECKO,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/config/materials.ts
+++ b/src/app/micro-land/domain/config/materials.ts
@@ -81,6 +81,7 @@ export const BASE_MATERIAL_IDS = [
   'acid',
   'shed-skin',
   'web',
+  'termite-mound',
 ] as const satisfies readonly BaseMaterialId[]
 
 const BASE_MATERIALS: Record<BaseMaterialId, Material> = {
@@ -187,6 +188,11 @@ const BASE_MATERIALS: Record<BaseMaterialId, Material> = {
     solid: false,
     viscous: 0.95,
     glow: 0.04,
+  }),
+  'termite-mound': material('termite-mound', 'Termite Mound', '#a0724c', {
+    grain: 0.22,
+    solid: true,
+    fertile: false,
   }),
 }
 

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1682,6 +1682,56 @@ export function tickCreatures(
       }
     }
 
+    // Termite mound construction: workers build mound tiles upward. Issue #3421.
+    if (bp.termiteWorker && rng() < 0.02 * dt) {
+      const tx = Math.round(c.x), ty = Math.round(c.y) - 1
+      if (tx >= 0 && tx < w.width && ty >= 0 && ty < w.height) {
+        const tIdx = ty * w.width + tx
+        if (w.tiles[tIdx] === AIR) {
+          w.tiles[tIdx] = MATERIAL_INDEX['termite-mound']
+        }
+      }
+    }
+
+    // Mound destroyer: breaks termite-mound tiles and eats termites. Issue #3421.
+    if (bp.moundDestroyer) {
+      const tx = Math.round(c.x), ty = Math.round(c.y)
+      const tIdx = ty * w.width + tx
+      if (tIdx >= 0 && tIdx < w.tiles.length && w.tiles[tIdx] === MATERIAL_INDEX['termite-mound'] && rng() < 0.1 * dt) {
+        w.tiles[tIdx] = AIR
+        c.hunger = Math.max(0, c.hunger - 0.1)
+        // Nutrient release: mound material enriches surrounding soil
+        if (w.caveNutrient) {
+          for (let ndy = -3; ndy <= 3; ndy++) {
+            for (let ndx = -3; ndx <= 3; ndx++) {
+              const ni = (ty + ndy) * w.width + (tx + ndx)
+              if (ni >= 0 && ni < w.tiles.length) {
+                w.caveNutrient[ni] = Math.min(1, (w.caveNutrient[ni] ?? 0) + 0.15)
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Mound commensal: stay near termite mound habitat. Issue #3421.
+    if (bp.moundCommensal) {
+      const cx = Math.round(c.x), cy = Math.round(c.y)
+      let nearMound = false
+      for (let ndy = -4; ndy <= 4 && !nearMound; ndy++) {
+        for (let ndx = -4; ndx <= 4 && !nearMound; ndx++) {
+          const ni = (cy + ndy) * w.width + (cx + ndx)
+          if (ni >= 0 && ni < w.tiles.length && w.tiles[ni] === MATERIAL_INDEX['termite-mound']) {
+            nearMound = true
+          }
+        }
+      }
+      if (!nearMound) {
+        c.vx *= 0.97  // slow drift when away from mound — tendency to find one
+        c.vy *= 0.97
+      }
+    }
+
     // --- movement -------------------------------------------------------
     if (bp.move.kind !== 'root') {
       steer(w, c, bp, dt, rng)

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -48,6 +48,7 @@ export type BaseMaterialId =
   | 'acid'
   | 'shed-skin'
   | 'web'
+  | 'termite-mound'
 
 /** The colors a tintable material can be painted in. */
 export type TintId =
@@ -877,6 +878,24 @@ export interface CreatureBlueprint {
    * hunger scale. Drawn from when starving at the burrow. Default 0.3. Issue #3419.
    */
   burrowCacheSize?: number
+  /**
+   * Eusocial worker that builds termite-mound tiles upward from its position.
+   * Each tick has a small chance to place a mound tile above the worker,
+   * growing the colony's mound over time. Issue #3421.
+   */
+  termiteWorker?: boolean
+  /**
+   * Creature that prefers to live near termite-mound tiles.
+   * When not within range of a mound, movement is dampened, creating
+   * a tendency to find and stay near mound habitat. Issue #3421.
+   */
+  moundCommensal?: boolean
+  /**
+   * Predator that destroys termite-mound tiles and feeds on the colony within.
+   * Breaking mound tiles reduces hunger and releases nutrients into surrounding
+   * soil via caveNutrient. Issue #3421.
+   */
+  moundDestroyer?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- Termite workers (`termiteWorker: true`) periodically place `termite-mound` tiles above themselves, gradually constructing an above-ground structure
- Aardvarks (`moundDestroyer: true`) break mound tiles on contact, reducing hunger (eating termites inside) and releasing a +0.15 nutrient burst in a 7×7 radius
- Commensal species (`moundCommensal: true`) dampen movement when away from mound tiles, maintaining habitat fidelity
- New species: **Termite** (eusocial builder) + **Aardvark** (mound-demolishing predator) + **Bark Gecko** (mound-commensal insectivore)
- New material: `termite-mound` (brown solid tile, #a0724c)

## Issues closed
Closes #3421

## Cascade event
When an Aardvark destroys mound tiles, surrounding soil becomes temporarily nutrient-rich (+0.15 caveNutrient per broken tile in 7×7 area) — models the documented ecological consequence of mound destruction

## Test plan
- [ ] Termites appear and gradually place mound tiles above their position
- [ ] Aardvark destroys mound tiles and reduces own hunger
- [ ] caveNutrient values spike around destroyed mound tiles
- [ ] Bark Gecko damps movement velocity when no mound tile is within 4 tiles
- [ ] Vercel preview builds clean