### PR TITLE
feat(micro-land): tool-assisted foraging + stick probing — anvil users crack hard-shelled prey, stick probers extract burrowed prey (#3413, #3414)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -678,6 +678,10 @@ export function sanitizeBlueprint(
     termiteWorker: typeof b.termiteWorker === 'boolean' ? b.termiteWorker : undefined,
     moundCommensal: typeof b.moundCommensal === 'boolean' ? b.moundCommensal : undefined,
     moundDestroyer: typeof b.moundDestroyer === 'boolean' ? b.moundDestroyer : undefined,
+    anvilUser: typeof b.anvilUser === 'boolean' ? b.anvilUser : undefined,
+    hardShelled: typeof b.hardShelled === 'boolean' ? b.hardShelled : undefined,
+    stickProber: typeof b.stickProber === 'boolean' ? b.stickProber : undefined,
+    stickProbeDamage: typeof b.stickProbeDamage === 'number' ? Math.max(0, Math.min(1, b.stickProbeDamage)) : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -2452,6 +2452,115 @@ const BARK_GECKO = builtin('bark-gecko', {
   moundCommensal: true,
 })
 
+// ---------------------------------------------------------------------------
+// Clam — hard-shelled sessile filter feeder. Issue #3413.
+// ---------------------------------------------------------------------------
+
+const CLAM = builtin('clam', {
+  name: 'Clam',
+  blurb: 'A bivalve filter-feeder with a thick shell — only a skilled tool user can crack it open.',
+  size: 1,
+  tags: ['meat', 'mollusk'],
+  art: {
+    palette: { w: '#d8c8a8', b: '#8a7860', g: '#e8dcc8' },
+    frames: [['bwb', 'wgw', 'bwb']],
+    frameMs: 1000,
+    faceMotion: false,
+  },
+  body: { mass: 2, bounce: 0, drag: 0.1, buoyancy: 0.5, immuneTo: [] },
+  move: { kind: 'root', speed: 0, jump: 0, hop: 0, restlessness: 0 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.00002,
+    starveSeconds: 300,
+    breedAt: 0.4,
+    lifespanSeconds: 200,
+  },
+  senses: { sight: 1 },
+  habitat: { needs: ['water'], drowns: false },
+  death: { becomes: 'bone', particleColor: '#d8c8a8', particleCount: 2 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  hardShelled: true,
+})
+
+// ---------------------------------------------------------------------------
+// Sea Otter — anvil-using marine predator. Issue #3413.
+// ---------------------------------------------------------------------------
+
+const SEA_OTTER = builtin('sea-otter', {
+  name: 'Sea Otter',
+  blurb: 'A marine mammal that cracks open hard-shelled prey by smashing them against a rock held on its belly.',
+  size: 1,
+  tags: ['meat', 'mammal'],
+  art: {
+    palette: { w: '#8a6040', b: '#4a3020', g: '#c8a070' },
+    frames: [
+      ['gwg', 'wbw', 'gwg'],
+      ['.g.', 'wbw', '.g.'],
+    ],
+    frameMs: 200,
+    faceMotion: true,
+  },
+  body: { mass: 0.8, bounce: 0.1, drag: 0.5, buoyancy: 1.2, immuneTo: [] },
+  move: { kind: 'swim', speed: 1.0, jump: 0, hop: 0, restlessness: 0.4 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.00005,
+    starveSeconds: 60,
+    breedAt: 0.75,
+    lifespanSeconds: 180,
+  },
+  senses: { sight: 8 },
+  habitat: { needs: ['water'], drowns: false },
+  death: { becomes: null, particleColor: '#8a6040', particleCount: 3 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  anvilUser: true,
+})
+
+// ---------------------------------------------------------------------------
+// Caledonian Crow — stick-probing intelligent predator. Issue #3414.
+// ---------------------------------------------------------------------------
+
+const CALEDONIAN_CROW = builtin('caledonian-crow', {
+  name: 'Caledonian Crow',
+  blurb: 'The most sophisticated non-human tool maker — fashions and uses stick tools to extract prey from narrow crevices.',
+  size: 1,
+  tags: ['meat', 'bird', 'flier'],
+  art: {
+    palette: { w: '#222222', b: '#111111', g: '#444444' },
+    frames: [
+      ['gwg', 'wbw', 'gwg'],
+      ['.g.', 'wbw', '.g.'],
+    ],
+    frameMs: 150,
+    faceMotion: true,
+  },
+  body: { mass: 0.4, bounce: 0.1, drag: 0.5, buoyancy: 1.0, immuneTo: [] },
+  move: { kind: 'fly', speed: 1.8, jump: 0, hop: 0, restlessness: 0.3 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.00004,
+    starveSeconds: 40,
+    breedAt: 0.75,
+    lifespanSeconds: 240,
+  },
+  senses: { sight: 15 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#222222', particleCount: 2 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  stickProber: true,
+  objectManipulator: true,
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -2515,6 +2624,9 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   TERMITE,
   AARDVARK,
   BARK_GECKO,
+  CLAM,
+  SEA_OTTER,
+  CALEDONIAN_CROW,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -3029,8 +3029,29 @@ function look(
     if (other.id === c.id || dead.has(other.id)) continue
     const obp = w.blueprints[other.blueprintId]
     if (!obp) continue
-    // Burrowed creatures are safe from non-burrowing predators. Issue #3419.
-    if (other.inBurrow && !bp.burrowDigger) continue
+    // Burrowed creatures are safe from non-burrowing, non-probing predators. Issues #3419, #3414.
+    if (other.inBurrow && !bp.burrowDigger && !bp.stickProber) continue
+
+    // Hard-shelled prey: requires anvil (stone tile nearby). Issue #3413.
+    if (obp.hardShelled) {
+      if (!bp.anvilUser) continue
+      let hasAnvil = false
+      const axc = Math.round(c.x), ayc = Math.round(c.y)
+      anvilSearch:
+      for (let ady = -3; ady <= 3; ady++) {
+        for (let adx = -3; adx <= 3; adx++) {
+          const ani = (ayc + ady) * w.width + (axc + adx)
+          if (ani >= 0 && ani < w.tiles.length) {
+            const amat = MATERIAL_BY_INDEX[w.tiles[ani]]?.id
+            if (amat === 'stone' || amat === 'metal' || amat === 'marble' || amat === 'obsidian' || amat === 'iron') {
+              hasAnvil = true
+              break anvilSearch
+            }
+          }
+        }
+      }
+      if (!hasAnvil) continue
+    }
 
     const { w: ow, h: oh } = artSize(obp)
     // The short way round, so a creature by the seam hunts across it rather than
@@ -3173,6 +3194,10 @@ function look(
         // Web-trapped prey: immobilized creatures are easy pickings for the spider. Issue #3420.
         if (other.webTrapped && bp.webSpinner) {
           fill *= 2
+        }
+        // Stick probing: slightly reduced efficiency when extracting from burrow. Issue #3414.
+        if (bp.stickProber && other.inBurrow) {
+          fill *= 0.8
         }
         c.hunger = Math.max(0, c.hunger - fill)
         c.starving = 0

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -896,6 +896,28 @@ export interface CreatureBlueprint {
    * soil via caveNutrient. Issue #3421.
    */
   moundDestroyer?: boolean
+  /**
+   * This species uses hard objects (rock, metal, stone tiles) as anvils to crack
+   * open hard-shelled prey. Without a stone/metal tile within 3 tiles, it cannot
+   * eat hard-shelled creatures. Issue #3413.
+   */
+  anvilUser?: boolean
+  /**
+   * This species has a shell so hard that only an anvilUser predator can crack
+   * it open. Non-anvilUser predators cannot eat this creature at all. Issue #3413.
+   */
+  hardShelled?: boolean
+  /**
+   * This species fashions stick-like tools to probe into burrow entrances and
+   * extract hidden prey. Unlike regular predators, it can attack creatures that
+   * are inBurrow. Extraction is slightly less efficient than a direct kill. Issue #3414.
+   */
+  stickProber?: boolean
+  /**
+   * Hunger reduction applied per stick-probe extraction (0–1 scale).
+   * Defaults to 0.08 when unset. Only meaningful when stickProber is true. Issue #3414.
+   */
+  stickProbeDamage?: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Tool-assisted foraging (#3413)**: Hard-shelled prey (`hardShelled: true`) can only be eaten by `anvilUser` creatures that are within 3 tiles of a stone/metal/marble/obsidian/iron tile. All other predators skip them entirely.
- **Stick probing (#3414)**: `stickProber` creatures can target `inBurrow` creatures (which normally hide from non-burrowing predators). Extraction is slightly less efficient (0.8× fill).
- New species: **Clam** (hard-shelled sessile water filter-feeder) + **Sea Otter** (anvil-using marine predator) + **Caledonian Crow** (stick-probing, object-manipulating flying predator)

## Issues closed
Closes #3413
Closes #3414

## New blueprint fields
| Field | Type | Purpose |
|---|---|---|
| `anvilUser` | `boolean` | Can crack hard-shelled prey near rock/metal tiles |
| `hardShelled` | `boolean` | Only edible by anvil users with nearby rock |
| `stickProber` | `boolean` | Can probe into burrows to extract prey |
| `stickProbeDamage` | `number` | Per-probe hunger reduction (future use) |

## Ecological interactions
- Clams reproduce well in water; only Sea Otters (near rock tiles) can eat them
- Caledonian Crows can pursue Prairie Dogs into burrows using stick tools
- Badgers remain more effective burrow hunters (full fill vs. 0.8× for crows)

## Test plan
- [ ] Clams appear in water and are ignored by non-anvil predators
- [ ] Sea Otters near stone/metal tiles successfully hunt Clams
- [ ] Sea Otters away from rock tiles cannot eat Clams
- [ ] Caledonian Crow can target `inBurrow` Prairie Dogs (non-burrowing exception)
- [ ] Vercel preview builds clean