### PR TITLE
feat(micro-land): secondary habitat colonization — abandoned nests, mounds, and burrows attract new occupants (#3423)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -682,6 +682,8 @@ export function sanitizeBlueprint(
     hardShelled: typeof b.hardShelled === 'boolean' ? b.hardShelled : undefined,
     stickProber: typeof b.stickProber === 'boolean' ? b.stickProber : undefined,
     stickProbeDamage: typeof b.stickProbeDamage === 'number' ? Math.max(0, Math.min(1, b.stickProbeDamage)) : undefined,
+    secondaryColonizer: typeof b.secondaryColonizer === 'boolean' ? b.secondaryColonizer : undefined,
+    colonizedStructure: Array.isArray(b.colonizedStructure) ? (b.colonizedStructure as string[]) : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -2561,6 +2561,79 @@ const CALEDONIAN_CROW = builtin('caledonian-crow', {
   objectManipulator: true,
 })
 
+// ---------------------------------------------------------------------------
+// Barn Owl — silent nocturnal hunter that squats in abandoned nests. Issue #3423.
+// ---------------------------------------------------------------------------
+
+const BARN_OWL = builtin('barn-owl', {
+  name: 'Barn Owl',
+  blurb: 'A silent nocturnal hunter that squats in abandoned nests, repurposing them as hunting perches.',
+  size: 1,
+  tags: ['meat', 'bird', 'flier'],
+  art: {
+    palette: { w: '#f5ead8', b: '#8a7050', g: '#ffffff' },
+    frames: [
+      ['gwg', 'wbw', 'gwg'],
+      ['.g.', 'wbw', '.g.'],
+    ],
+    frameMs: 180,
+    faceMotion: true,
+  },
+  body: { mass: 0.3, bounce: 0.0, drag: 0.5, buoyancy: 1.5, immuneTo: [] },
+  move: { kind: 'fly', speed: 2.0, jump: 0, hop: 0, restlessness: 0.2 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.00003,
+    starveSeconds: 30,
+    breedAt: 0.75,
+    lifespanSeconds: 300,
+  },
+  senses: { sight: 18 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#f5ead8', particleCount: 3 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  secondaryColonizer: true,
+  colonizedStructure: ['nest'],
+})
+
+// ---------------------------------------------------------------------------
+// Monitor Lizard — opportunistic predator that takes over abandoned mounds and burrows. Issue #3423.
+// ---------------------------------------------------------------------------
+
+const MONITOR_LIZARD = builtin('monitor-lizard', {
+  name: 'Monitor Lizard',
+  blurb: 'An opportunistic predator that takes over abandoned termite mounds and burrows as a ready-made den.',
+  size: 1,
+  tags: ['meat', 'reptile'],
+  art: {
+    palette: { w: '#7a9060', b: '#3a4830', g: '#aab888' },
+    frames: [['bwb', 'wgw', 'bwb']],
+    frameMs: 300,
+    faceMotion: true,
+  },
+  body: { mass: 1.0, bounce: 0.0, drag: 0.4, buoyancy: 0.9, immuneTo: [] },
+  move: { kind: 'walk', speed: 1.1, jump: 4, hop: 0, restlessness: 0.3 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.000035,
+    starveSeconds: 40,
+    breedAt: 0.75,
+    lifespanSeconds: 250,
+  },
+  senses: { sight: 14 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#7a9060', particleCount: 3 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  secondaryColonizer: true,
+  colonizedStructure: ['mound', 'burrow'],
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -2627,6 +2700,8 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   CLAM,
   SEA_OTTER,
   CALEDONIAN_CROW,
+  BARN_OWL,
+  MONITOR_LIZARD,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1732,6 +1732,33 @@ export function tickCreatures(
       }
     }
 
+    // Secondary colonization: move into vacant built structures. Issue #3423.
+    if (bp.secondaryColonizer && c.occupiedStructureKey === undefined && w.nestSites && tickCount % 120 === c.id % 120) {
+      const cx = Math.round(c.x), cy = Math.round(c.y)
+      const livingOwnerIds = new Set(w.creatures.map(cr => cr.id))
+      const occupiedKeys = new Set(
+        w.creatures.filter(cr => cr.occupiedStructureKey != null).map(cr => cr.occupiedStructureKey!)
+      )
+      for (const [key, site] of Object.entries(w.nestSites)) {
+        if (livingOwnerIds.has(site.ownerId)) continue  // owner still alive
+        if (occupiedKeys.has(key)) continue              // already occupied by someone else
+        const sdx = site.x - cx, sdy = site.y - cy
+        const sdist = Math.sqrt(sdx * sdx + sdy * sdy)
+        if (sdist > 20) continue  // too far away
+        // Steer toward this vacant structure
+        if (sdist > 1) {
+          c.vx += (sdx / sdist) * 0.3 * dt
+          c.vy += (sdy / sdist) * 0.3 * dt
+        }
+        if (sdist < 2) {
+          // Move in!
+          c.occupiedStructureKey = key
+          site.ownerId = c.id  // update occupant
+        }
+        break
+      }
+    }
+
     // --- movement -------------------------------------------------------
     if (bp.move.kind !== 'root') {
       steer(w, c, bp, dt, rng)
@@ -3031,6 +3058,8 @@ function look(
     if (!obp) continue
     // Burrowed creatures are safe from non-burrowing, non-probing predators. Issues #3419, #3414.
     if (other.inBurrow && !bp.burrowDigger && !bp.stickProber) continue
+    // Colonized structure shelter: colonizers in occupied structures are hidden. Issue #3423.
+    if (other.occupiedStructureKey && !bp.secondaryColonizer && !bp.burrowDigger && !bp.moundDestroyer) continue
 
     // Hard-shelled prey: requires anvil (stone tile nearby). Issue #3413.
     if (obp.hardShelled) {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -918,6 +918,17 @@ export interface CreatureBlueprint {
    * Defaults to 0.08 when unset. Only meaningful when stickProber is true. Issue #3414.
    */
   stickProbeDamage?: number
+  /**
+   * When true, this creature seeks out and moves into vacant built structures
+   * (abandoned nests, burrows, mounds) left by dead owners. Gains shelter safety
+   * similar to burrowing creatures while occupying a structure. Issue #3423.
+   */
+  secondaryColonizer?: boolean
+  /**
+   * Types of structures this secondary colonizer will occupy.
+   * Values match structure type keys: 'nest' | 'burrow' | 'mound'. Issue #3423.
+   */
+  colonizedStructure?: string[]
 }
 
 /**
@@ -1348,6 +1359,11 @@ export interface Creature {
   cachedFood?: number
   /** True while this creature is underground at its burrow site. Issue #3419. */
   inBurrow?: boolean
+  /**
+   * WorldState.nestSites key (e.g. "12,34") of the structure this secondary
+   * colonizer is currently occupying. Undefined when not in a structure. Issue #3423.
+   */
+  occupiedStructureKey?: string
 }
 
 /**


### PR DESCRIPTION
## Summary
- Secondary colonizers (`secondaryColonizer: true`) search for vacant built structures (nestSites with dead owners, not yet re-occupied) and move in
- Colonization search is staggered per creature (`tickCount % 120 === c.id % 120`) to avoid O(n×m) scans every tick
- **Shelter safety**: colonizers in occupied structures are hidden from predators that lack `secondaryColonizer`, `burrowDigger`, or `moundDestroyer` — the structure provides protection
- New species: **Barn Owl** (takes over abandoned bird nests) + **Monitor Lizard** (squats in empty termite mounds and burrows)

## Issues closed
Closes #3423

## Ecological chain this enables
1. Weaver Bird builds nest → lays eggs → eventually dies
2. Barn Owl detects vacant nest within 20 tiles → moves in
3. Barn Owl is sheltered in structure (non-colonizers skip it as prey)
4. Same pattern for Termite mound → Monitor Lizard; Badger burrow → Monitor Lizard

## New blueprint fields
| Field | Type | Purpose |
|---|---|---|
| `secondaryColonizer` | `boolean` | Seeks out and occupies vacant structures |
| `colonizedStructure` | `string[]` | Which structure types to prefer (informational) |

## Test plan
- [ ] Barn Owl appears and detects vacant Weaver Bird nest within 20 tiles
- [ ] Barn Owl moves toward nest and claims it (`occupiedStructureKey` set)
- [ ] Non-colonizer predators skip Barn Owl while occupying structure
- [ ] Monitor Lizard colonizes defunct termite mounds/burrows
- [ ] Vercel preview builds clean