### PR TITLE
feat(micro-land): dam hydrology + landmark learning — beavers block waterways, migratory species navigate home (#3422, #3326)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -684,6 +684,8 @@ export function sanitizeBlueprint(
     stickProbeDamage: typeof b.stickProbeDamage === 'number' ? Math.max(0, Math.min(1, b.stickProbeDamage)) : undefined,
     secondaryColonizer: typeof b.secondaryColonizer === 'boolean' ? b.secondaryColonizer : undefined,
     colonizedStructure: Array.isArray(b.colonizedStructure) ? (b.colonizedStructure as string[]) : undefined,
+    damBuilder: typeof b.damBuilder === 'boolean' ? b.damBuilder : undefined,
+    landmarkMemory: typeof b.landmarkMemory === 'boolean' ? b.landmarkMemory : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -2634,6 +2634,78 @@ const MONITOR_LIZARD = builtin('monitor-lizard', {
   colonizedStructure: ['mound', 'burrow'],
 })
 
+// ---------------------------------------------------------------------------
+// Beaver — dam-building ecosystem engineer. Issue #3422.
+// ---------------------------------------------------------------------------
+
+const BEAVER = builtin('beaver', {
+  name: 'Beaver',
+  blurb: 'An industrious ecosystem engineer that dams streams with wood and mud, creating ponds from dry valleys.',
+  size: 1,
+  tags: ['meat', 'mammal'],
+  art: {
+    palette: { w: '#8a5c30', b: '#4a2c10', g: '#c8905a' },
+    frames: [['gwg', 'wbw', 'gwg']],
+    frameMs: 300,
+    faceMotion: true,
+  },
+  body: { mass: 1.0, bounce: 0.0, drag: 0.5, buoyancy: 1.1, immuneTo: [] },
+  move: { kind: 'walk', speed: 0.8, jump: 4, hop: 0, restlessness: 0.3 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.00004,
+    starveSeconds: 60,
+    breedAt: 0.75,
+    lifespanSeconds: 200,
+  },
+  senses: { sight: 8 },
+  habitat: { needs: null, drowns: false },
+  death: { becomes: null, particleColor: '#8a5c30', particleCount: 3 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  damBuilder: true,
+  objectManipulator: true,
+})
+
+// ---------------------------------------------------------------------------
+// Arctic Tern — landmark-learning migratory seabird. Issue #3326.
+// ---------------------------------------------------------------------------
+
+const ARCTIC_TERN = builtin('arctic-tern', {
+  name: 'Arctic Tern',
+  blurb: "The world's longest migrant — navigates 70,000 km annually using memorized landmarks and following experienced elders.",
+  size: 1,
+  tags: ['meat', 'bird', 'flier'],
+  art: {
+    palette: { w: '#f0f0f8', b: '#cc2222', g: '#ddddee' },
+    frames: [
+      ['gwg', 'wbw', 'gwg'],
+      ['.g.', 'wbw', '.g.'],
+    ],
+    frameMs: 120,
+    faceMotion: true,
+  },
+  body: { mass: 0.3, bounce: 0.1, drag: 0.6, buoyancy: 1.5, immuneTo: [] },
+  move: { kind: 'fly', speed: 2.5, jump: 0, hop: 0, restlessness: 0.2 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.00003,
+    starveSeconds: 40,
+    breedAt: 0.75,
+    lifespanSeconds: 400,
+  },
+  senses: { sight: 18 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#f0f0f8', particleCount: 2 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  landmarkMemory: true,
+})
+
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -2702,6 +2774,8 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   CALEDONIAN_CROW,
   BARN_OWL,
   MONITOR_LIZARD,
+  BEAVER,
+  ARCTIC_TERN,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1011,6 +1011,12 @@ export function tickCreatures(
       if (!IS_LIQUID[driftTile]) c.drifting = false
     }
 
+    // Initialize home landmark on first tick. Issue #3326.
+    if (bp.landmarkMemory && c.homeLandmarkX === undefined) {
+      c.homeLandmarkX = c.x
+      c.homeLandmarkY = c.y
+    }
+
     // Circadian clock: advance internal phase at individual period (±10% of day length).
     // Issue #3357, #3358, #3359.
     if (TUNING.dayLengthSeconds > 0) {
@@ -1756,6 +1762,70 @@ export function tickCreatures(
           site.ownerId = c.id  // update occupant
         }
         break
+      }
+    }
+
+    // Landmark homing: navigate back toward memorized home territory. Issue #3326.
+    if (bp.landmarkMemory && c.homeLandmarkX !== undefined && c.ageSeconds > 60) {
+      const lmDx = c.homeLandmarkX - c.x, lmDy = c.homeLandmarkY! - c.y
+      const lmDist = Math.sqrt(lmDx * lmDx + lmDy * lmDy)
+      if (lmDist > 25 && c.hunger > 0.5) {
+        // Strongly displaced and hungry — head home
+        c.vx += (lmDx / lmDist) * 0.4 * dt
+        c.vy += (lmDy / lmDist) * 0.4 * dt
+      }
+    }
+
+    // Juvenile following: young creatures follow experienced adults. Issue #3326.
+    if (bp.landmarkMemory && c.ageSeconds < 30) {
+      let nearestAdult: { x: number; y: number } | null = null
+      let nearestDist = 15
+      for (const other of w.creatures) {
+        if (other.id === c.id || other.blueprintId !== c.blueprintId || other.ageSeconds < 30) continue
+        const jdx = other.x - c.x, jdy = other.y - c.y
+        const jdist = Math.sqrt(jdx * jdx + jdy * jdy)
+        if (jdist < nearestDist) {
+          nearestDist = jdist
+          nearestAdult = other
+        }
+      }
+      if (nearestAdult) {
+        const jdx2 = nearestAdult.x - c.x, jdy2 = nearestAdult.y - c.y
+        const jdist2 = Math.sqrt(jdx2 * jdx2 + jdy2 * jdy2)
+        if (jdist2 > 1) {
+          c.vx += (jdx2 / jdist2) * 0.5 * dt
+          c.vy += (jdy2 / jdist2) * 0.5 * dt
+        }
+      }
+    }
+
+    // Dam construction: beavers place wood tiles to block water channels. Issue #3422.
+    if (bp.damBuilder && rng() < 0.05 * dt) {
+      const cx = Math.round(c.x), cy = Math.round(c.y)
+      const woodMat = MATERIAL_INDEX['wood']
+      const waterMat = MATERIAL_INDEX['water']
+      const airMat = AIR
+      // Find a water tile within 2 radius, with an adjacent air tile (flow gap)
+      damSearch:
+      for (let ddy = -2; ddy <= 2; ddy++) {
+        for (let ddx = -2; ddx <= 2; ddx++) {
+          const tx = cx + ddx, ty = cy + ddy
+          if (tx < 0 || tx >= w.width || ty < 0 || ty >= w.height) continue
+          const tIdx = ty * w.width + tx
+          if (w.tiles[tIdx] !== waterMat) continue
+          // Check for an adjacent air tile we can block
+          for (const [odx, ody] of [[-1,0],[1,0],[0,-1],[0,1]] as const) {
+            const otx = tx + odx, oty = ty + ody
+            if (otx < 0 || otx >= w.width || oty < 0 || oty >= w.height) continue
+            const otIdx = oty * w.width + otx
+            if (w.tiles[otIdx] === airMat) {
+              // Place wood to dam the gap
+              w.tiles[otIdx] = woodMat
+              c.damProgress = (c.damProgress ?? 0) + 1
+              break damSearch
+            }
+          }
+        }
       }
     }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -929,6 +929,17 @@ export interface CreatureBlueprint {
    * Values match structure type keys: 'nest' | 'burrow' | 'mound'. Issue #3423.
    */
   colonizedStructure?: string[]
+  /**
+   * When true, this creature builds dam structures by placing wood tiles across
+   * water channels, backing up water flow into ponds. Issue #3422.
+   */
+  damBuilder?: boolean
+  /**
+   * When true, this creature memorizes its birth position as a home landmark
+   * and navigates back when displaced. Young creatures follow experienced adults.
+   * Issue #3326.
+   */
+  landmarkMemory?: boolean
 }
 
 /**
@@ -1364,6 +1375,12 @@ export interface Creature {
    * colonizer is currently occupying. Undefined when not in a structure. Issue #3423.
    */
   occupiedStructureKey?: string
+  /** Running count of wood tiles placed by a damBuilder creature. Issue #3422. */
+  damProgress?: number
+  /** X tile of memorized home landmark (set at first tick for landmarkMemory creatures). Issue #3326. */
+  homeLandmarkX?: number
+  /** Y tile of memorized home landmark (set at first tick for landmarkMemory creatures). Issue #3326. */
+  homeLandmarkY?: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Dam hydrology (#3422)**: Beavers (`damBuilder: true`) scan nearby water tiles and place wood tiles to block adjacent air gaps, gradually damming water channels. The existing falling-sand water physics handles the backing-up naturally.
- **Landmark learning (#3326)**: Creatures with `landmarkMemory: true` record their birth position as a home landmark. When displaced >25 tiles and hungry (>50%), they steer back toward home. Young creatures (<30s old) follow the nearest same-species adult within 15 tiles.
- New species: **Beaver** (semi-aquatic dam builder) + **Arctic Tern** (landmark-navigating long-distance migrant)

## Issues closed
Closes #3422
Closes #3326

## New blueprint fields
| Field | Type | Purpose |
|---|---|---|
| `damBuilder` | `boolean` | Places wood tiles adjacent to water to construct dams |
| `landmarkMemory` | `boolean` | Memorizes birth position; navigates home when displaced |

## Ecological interactions
- Beaver dams back up water upstream (falling-sand physics) → creates new wetland habitat
- Arctic Terns born in one area return there when displaced, modeling natal homing
- Young Arctic Terns follow older birds, modeling cultural migration route transmission

## Test plan
- [ ] Beaver appears near water and places wood tiles against water edges
- [ ] Water backs up behind wood tile barriers
- [ ] Arctic Tern displaced far from birth tile steers back when hungry
- [ ] Young Arctic Terns (<30s) follow nearest adult of same species
- [ ] Vercel preview builds clean