### PR TITLE
feat(micro-land): population dynamics — carrying capacity, Allee effect, stochastic extinction, overshoot collapse, age pyramid

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -98,6 +98,7 @@ export function FieldGuidePane() {
   const compareId = useMicroLand(s => s.compareId)
   const setCompareId = useMicroLand(s => s.setCompareId)
   const traitHistory = useMicroLand(s => s.traitHistory)
+  const agePyramid = useMicroLand(s => s.agePyramid)
   const heatmapBlueprintId = useMicroLand(s => s.heatmapBlueprintId)
   const setHeatmapBlueprint = useMicroLand(s => s.setHeatmapBlueprint)
   const elapsed = useMicroLand(s => s.elapsed)
@@ -478,6 +479,7 @@ export function FieldGuidePane() {
             onCompare={() => handleCompare(bp.id)}
             isComparePin={compareId === bp.id}
             traitHistory={traitHistory[bp.id]}
+            agePyramidEntry={agePyramid[bp.id]}
             compact={compact}
             isHeatmap={heatmapBlueprintId === bp.id}
             onHeatmap={() => setHeatmapBlueprint(heatmapBlueprintId === bp.id ? null : bp.id)}
@@ -926,6 +928,7 @@ function GuideEntry({
   onCompare,
   isComparePin,
   traitHistory,
+  agePyramidEntry,
   compact,
   isHeatmap,
   onHeatmap,
@@ -940,6 +943,7 @@ function GuideEntry({
   onCompare?: () => void
   isComparePin?: boolean
   traitHistory?: TraitHistoryEntry[]
+  agePyramidEntry?: { j: number; a: number; e: number }
   compact?: boolean
   isHeatmap?: boolean
   onHeatmap?: () => void
@@ -988,6 +992,18 @@ function GuideEntry({
           ))}
         </div>
       )}
+      {agePyramidEntry && (() => {
+        const { j, a, e } = agePyramidEntry
+        const total = j + a + e
+        if (total === 0) return null
+        return (
+          <div style={{ display: 'flex', height: '4px', width: '100%', marginTop: '2px', borderRadius: '2px', overflow: 'hidden' }}>
+            <div style={{ width: `${(j / total * 100).toFixed(1)}%`, background: '#88cc44' }} title={`Juvenile: ${j}`} />
+            <div style={{ width: `${(a / total * 100).toFixed(1)}%`, background: '#4488cc' }} title={`Adult: ${a}`} />
+            <div style={{ width: `${(e / total * 100).toFixed(1)}%`, background: '#cc8844' }} title={`Elder: ${e}`} />
+          </div>
+        )
+      })()}
       <div className={`flex gap-3 px-4 ${compact ? 'py-1.5' : 'py-3'}`}>
       {!compact && (
         <div className="shrink-0 pt-0.5">

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -686,6 +686,8 @@ export function sanitizeBlueprint(
     colonizedStructure: Array.isArray(b.colonizedStructure) ? (b.colonizedStructure as string[]) : undefined,
     damBuilder: typeof b.damBuilder === 'boolean' ? b.damBuilder : undefined,
     landmarkMemory: typeof b.landmarkMemory === 'boolean' ? b.landmarkMemory : undefined,
+    populationCap: typeof b.populationCap === 'number' ? Math.max(1, Math.floor(b.populationCap)) : undefined,
+    alleeThreshold: typeof b.alleeThreshold === 'number' ? Math.max(1, Math.floor(b.alleeThreshold)) : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -463,7 +463,7 @@ export interface SimEvent {
    * going locally extinct (speciesCount was 0 at the moment of germination). The
    * field guide removes the species from the extinctions list on receiving this.
    */
-  kind: 'born' | 'eaten' | 'ate' | 'starved' | 'drowned' | 'burned' | 'aged' | 'diseased' | 'sick' | 'diversity-rescue' | 'notice'
+  kind: 'born' | 'eaten' | 'ate' | 'starved' | 'drowned' | 'burned' | 'aged' | 'diseased' | 'sick' | 'diversity-rescue' | 'notice' | 'extinction'
   blueprintId: string
   /** Only set on `ate`: the blueprint id of what was caught. */
   victimId?: string
@@ -909,6 +909,35 @@ export function tickCreatures(
       if (w.invasionFrontX[c.blueprintId] === undefined || cx > w.invasionFrontX[c.blueprintId]) {
         w.invasionFrontX[c.blueprintId] = cx
       }
+    }
+  }
+
+  // Stochastic extinction: tiny populations face random crashes. Issue #3291.
+  if (tickCount % 300 === 0) {
+    for (const [bpId, cnt] of Object.entries(speciesCount)) {
+      if (cnt < 5 && cnt > 0 && rng() < 0.01) {
+        const toExtinct = w.creatures.filter(c2 => c2.blueprintId === bpId)
+        const extBp = w.blueprints[bpId]
+        if (extBp) {
+          for (const c2 of toExtinct) kill(w, c2, extBp, dead, events, 'aged')
+          events.push({ kind: 'extinction', blueprintId: bpId, x: 0, y: 0, text: `${extBp.name} went locally extinct` })
+        }
+      }
+    }
+  }
+
+  // Population overshoot and collapse. Issue #3292.
+  if (tickCount % 60 === 0) {
+    for (const [bpId, cnt] of Object.entries(speciesCount)) {
+      const obp = w.blueprints[bpId]
+      if (!obp?.populationCap || cnt <= obp.populationCap * 1.5) continue
+      const victims2 = w.creatures.filter(c2 => c2.blueprintId === bpId)
+      const killCnt = Math.floor(victims2.length * 0.3)
+      for (let ki = 0; ki < killCnt; ki++) {
+        const v = victims2[Math.floor(rng() * victims2.length)]
+        if (v) kill(w, v, obp, dead, events, 'starved')
+      }
+      events.push({ kind: 'notice', blueprintId: bpId, x: 0, y: 0, text: `${obp.name} population collapsed from overshoot` })
     }
   }
 
@@ -2412,6 +2441,27 @@ export function tickCreatures(
       if (bp.biomeRequirements && bp.biomeRequirements.length > 0) {
         const zones = biomeZonesAtWithEcotone(w, Math.floor(c.y))
         if (!zones.some(z => bp.biomeRequirements!.includes(z))) continue
+      }
+
+      // Carrying capacity density penalty. Issue #3287.
+      if (bp.populationCap) {
+        const pop = speciesCount[c.blueprintId] ?? 0
+        const density = pop / bp.populationCap
+        if (density >= 1.0) continue  // at or above capacity: skip reproduction
+        if (density >= 0.8) {
+          // linear decline from 100% → 0% as density goes from 0.8 → 1.0
+          const penalty = (density - 0.8) / 0.2
+          if (rng() < penalty) continue
+        }
+      }
+
+      // Allee effect: mate scarcity reduces reproduction. Issue #3288.
+      if (bp.alleeThreshold) {
+        const pop = speciesCount[c.blueprintId] ?? 0
+        if (pop < bp.alleeThreshold) {
+          const alleeFactor = pop / bp.alleeThreshold
+          if (rng() >= alleeFactor) continue
+        }
       }
 
       /**

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -940,6 +940,18 @@ export interface CreatureBlueprint {
    * Issue #3326.
    */
   landmarkMemory?: boolean
+  /**
+   * Carrying capacity for this species. When the species population exceeds this
+   * value, reproduction is progressively penalized. At 1.5× the cap, 30% of the
+   * population is culled per overshoot event. Issue #3287, #3292.
+   */
+  populationCap?: number
+  /**
+   * Minimum viable population for normal reproduction (Allee effect).
+   * When the species population falls below this threshold, reproduction rate is
+   * scaled down proportionally to population / alleeThreshold. Issue #3288.
+   */
+  alleeThreshold?: number
 }
 
 /**

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -562,6 +562,13 @@ export class GameInstance {
       if (isSoundEnabled()) playExtinction()
     }
 
+    // Stochastic extinction notice: fire a player notification when an extinction
+    // event is pushed by the small-population random crash. Issue #3291.
+    for (const event of events) {
+      if (event.kind !== 'extinction') continue
+      if (event.text) notify(event.text)
+    }
+
     // Seed bank diversity rescue: a species that went locally extinct has
     // germinated from dormant seeds still in the soil. Remove it from the
     // field guide's memorial list and let the player know.
@@ -992,6 +999,23 @@ export class GameInstance {
       const flat: Record<string, TraitHistoryEntry[]> = {}
       for (const [id, hist] of this.traitHistory) flat[id] = hist
       useMicroLand.getState().setTraitHistory(flat)
+    }
+
+    // Age class pyramid computation. Issue #3290.
+    {
+      const agePyramid: Record<string, { j: number; a: number; e: number }> = {}
+      for (const c of this.world.creatures) {
+        const cbp = this.world.blueprints[c.blueprintId]
+        if (!cbp) continue
+        const lifespan = lifespanOf(c, cbp) * TUNING.lifespanScale
+        const age = c.ageSeconds
+        const entry = agePyramid[c.blueprintId] ?? { j: 0, a: 0, e: 0 }
+        if (age < lifespan * 0.2) entry.j++
+        else if (age < lifespan * 0.75) entry.a++
+        else entry.e++
+        agePyramid[c.blueprintId] = entry
+      }
+      useMicroLand.getState().setAgePyramid(agePyramid)
     }
 
     // A running world is different every tick, so there is no cheaper signal

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -475,6 +475,13 @@ interface MicroLandState {
   atmosphericCO2: number
   setAtmosphericCO2: (v: number) => void
   /**
+   * Age class pyramid per species. Keyed by blueprintId; each entry holds the
+   * count of juveniles (j), adults (a), and elders (e) alive in this species.
+   * Updated by pushStats() each stats tick. Issue #3290.
+   */
+  agePyramid: Record<string, { j: number; a: number; e: number }>
+  setAgePyramid: (v: Record<string, { j: number; a: number; e: number }>) => void
+  /**
    * Atmospheric O2 level relative to baseline [0, 2]. 1.0 = normal.
    * Mirrored from WorldState on each stats tick. Used by the Field Guide
    * to show the O2 level. Issues #3275, #3276.
@@ -720,6 +727,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   biomeZones: [],
   atmosphericCO2: 0,
   atmosphericO2: 1.0,
+  agePyramid: {},
   migrationStats: {},
   locateCreatureRequest: null,
   traitOverlay: null,
@@ -858,6 +866,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setBiomeZones: zones => set({ biomeZones: zones }),
   setAtmosphericCO2: v => set({ atmosphericCO2: v }),
   setAtmosphericO2: v => set({ atmosphericO2: v }),
+  setAgePyramid: v => set({ agePyramid: v }),
   setMigrationStats: stats => set({ migrationStats: stats }),
   requestLocateCreature: id =>
     set({ locateCreatureRequest: { id, serial: ++locateCreatureSerial } }),


### PR DESCRIPTION
## Summary

Implements five population dynamics mechanics from the Population Dynamics epic (#3286):

- **Carrying capacity** (#3287): `populationCap` blueprint field — reproduction probability ramps down linearly from 80%→100% of cap and is fully blocked at cap. Requires no configuration for species without caps.
- **Allee effect** (#3288): `alleeThreshold` blueprint field — at populations below the threshold, per-capita reproduction rate scales as `pop / threshold`, modelling mate scarcity in small populations.
- **Stochastic extinction** (#3291): every 300 ticks, species with < 5 individuals face a 1% chance of random total wipeout. Fires an `'extinction'` SimEvent that triggers a player notification.
- **Overshoot and collapse** (#3292): every 60 ticks, species exceeding 1.5× their `populationCap` lose 30% of their population to a simulated crash. Player is notified via a `'notice'` event.
- **Age class pyramid** (#3290): Field Guide entry now shows a 4px colour bar below each species header — green for juveniles (<20% of lifespan), blue for adults (20–75%), amber for elders (75%+). Updated by `pushStats()` each stats tick.

## Closed issues

Closes #3287, #3288, #3290, #3291, #3292

## Test plan

- [ ] Spawn a species with `populationCap: 20`; observe reproduction stops when population hits 20 and crashes when it reaches 30
- [ ] Spawn a species with `alleeThreshold: 10` at count 2; observe very low reproduction rate vs. at count 15
- [ ] Run world long enough for a small population to hit stochastic extinction; verify player notification fires
- [ ] Age pyramid bar appears in Field Guide for any live species
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)