### PR TITLE
feat(micro-land): body size ecology — Kleiber metabolic scaling, size-based predation gates

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -688,6 +688,7 @@ export function sanitizeBlueprint(
     landmarkMemory: typeof b.landmarkMemory === 'boolean' ? b.landmarkMemory : undefined,
     populationCap: typeof b.populationCap === 'number' ? Math.max(1, Math.floor(b.populationCap)) : undefined,
     alleeThreshold: typeof b.alleeThreshold === 'number' ? Math.max(1, Math.floor(b.alleeThreshold)) : undefined,
+    bodyMass: typeof b.bodyMass === 'number' ? Math.max(0.01, b.bodyMass) : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -36,6 +36,7 @@ const SUNLEAF = builtin('sunleaf', {
   blurb: 'A little green sprout. Almost everything eats these.',
   size: 1,
   tags: ['plant'],
+  bodyMass: 0.5,  // small plant. Issue #3269.
   art: {
     palette: { a: '#ffd166', b: '#3f7d2a' },
     frames: [
@@ -72,6 +73,7 @@ const BRAMBLE = builtin('bramble', {
   blurb: 'A tangled berry bush. Bigger meals for bigger mouths.',
   size: 2,
   tags: ['plant'],
+  bodyMass: 0.5,  // small plant. Issue #3269.
   art: {
     palette: { s: '#2f6b3a', l: '#57b04a', b: '#d1466f' },
     frames: [
@@ -1994,6 +1996,7 @@ const SHIMMER_LARVA = builtin('shimmer-larva', {
   flowZonePreference: 'run',  // intermediate flow — grips substrate but stays in current
   metamorphosesInto: 'shimmer-pupa',  // larva → pupa at 60 s. Issue #3336.
   metamorphosisAge: 60,
+  bodyMass: 0.1,  // small insect larva. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2071,6 +2074,7 @@ const SHIMMER_FLY = builtin('shimmer-fly', {
   holometabolous: true,       // eggs hatch as shimmer-larva. Issue #3336.
   larvaeBlueprint: 'shimmer-larva',
   adultTrophicLevel: 'none',  // adult Shimmer Flies do not eat — breed and die. Issue #3337.
+  bodyMass: 0.3,  // small flying insect. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2107,6 +2111,7 @@ const MEADOW_LOCUST_NYMPH = builtin('meadow-locust-nymph', {
   instarCount: 3,
   instarDuration: 30,
   moultVulnerability: 1.2,
+  bodyMass: 0.1,  // small insect nymph. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2145,6 +2150,7 @@ const MEADOW_LOCUST = builtin('meadow-locust', {
   egglayer: true,
   hemimetabolous: true,
   nymphBlueprint: 'meadow-locust-nymph',
+  bodyMass: 0.2,  // medium insect adult. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2257,6 +2263,7 @@ const GARDEN_SPIDER = builtin('garden-spider', {
   webSpinner: true,
   webRange: 5,
   webBuildInterval: 4,
+  bodyMass: 0.2,  // medium insect. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2335,6 +2342,7 @@ const PRAIRIE_DOG = builtin('prairie-dog', {
   egglayer: true,
   burrowDigger: true,
   burrowCacheSize: 0.4,
+  bodyMass: 0.3,  // small vertebrate. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2398,6 +2406,7 @@ const TERMITE = builtin('termite', {
   glow: 0,
   egglayer: true,
   termiteWorker: true,
+  bodyMass: 0.1,  // small insect. Issue #3269.
 })
 
 const AARDVARK = builtin('aardvark', {
@@ -2424,6 +2433,7 @@ const AARDVARK = builtin('aardvark', {
   glow: 0,
   egglayer: true,
   moundDestroyer: true,
+  bodyMass: 2.0,  // large mammal. Issue #3269.
 })
 
 const BARK_GECKO = builtin('bark-gecko', {
@@ -2450,6 +2460,7 @@ const BARK_GECKO = builtin('bark-gecko', {
   glow: 0,
   egglayer: true,
   moundCommensal: true,
+  bodyMass: 0.15,  // tiny lizard. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2521,6 +2532,7 @@ const SEA_OTTER = builtin('sea-otter', {
   glow: 0,
   egglayer: true,
   anvilUser: true,
+  bodyMass: 2.0,  // large mammal. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2559,6 +2571,7 @@ const CALEDONIAN_CROW = builtin('caledonian-crow', {
   egglayer: true,
   stickProber: true,
   objectManipulator: true,
+  bodyMass: 1.5,  // large predatory bird. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2597,6 +2610,7 @@ const BARN_OWL = builtin('barn-owl', {
   egglayer: true,
   secondaryColonizer: true,
   colonizedStructure: ['nest'],
+  bodyMass: 1.5,  // large predatory bird. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2632,6 +2646,7 @@ const MONITOR_LIZARD = builtin('monitor-lizard', {
   egglayer: true,
   secondaryColonizer: true,
   colonizedStructure: ['mound', 'burrow'],
+  bodyMass: 1.5,  // large predatory reptile. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2667,6 +2682,7 @@ const BEAVER = builtin('beaver', {
   egglayer: true,
   damBuilder: true,
   objectManipulator: true,
+  bodyMass: 2.0,  // large mammal. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1164,9 +1164,13 @@ export function tickCreatures(
       const isLeader = c.id % 3 === 0
       return isLeader ? 1.0 : 0.7
     })()
+    // Kleiber's metabolic scaling: hunger rate ∝ bodyMass^0.75. Issue #3272.
+    // Large animals need more total food but are more efficient per unit mass.
+    // At mass=1.0 this is 1.0 (no change). At mass=4.0 it's 4^0.75 ≈ 2.83 (more hungry).
+    const klieber = Math.pow(bp.bodyMass ?? 1.0, 0.75)
     c.hunger = Math.min(
       1,
-      c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * symbiosisFed * metabolicRate * cognitiveOverhead * migratoryHyperphagia * vFormationFactor * dt
+      c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * symbiosisFed * metabolicRate * cognitiveOverhead * migratoryHyperphagia * vFormationFactor * klieber * dt
     )
     // Phenological mismatch penalty: species breeding far from the summer GDD peak
     // (≈ 500) face elevated hunger during their breeding season — prey/plants are
@@ -3205,6 +3209,16 @@ function look(
         }
       }
       if (!hasAnvil) continue
+    }
+
+    // Size-based predation gate: prey must be within mass ratio [0.1, 3.0] of predator. Issue #3273.
+    // Only applies when both predator and prey have bodyMass defined (non-default).
+    // Default mass 1.0 / 1.0 ratio = 1.0 which is within [0.1, 3.0], so unset species are unaffected.
+    if (bp.bodyMass !== undefined && obp.bodyMass !== undefined) {
+      const predMass = bp.bodyMass
+      const preyMass = obp.bodyMass
+      const massRatio = preyMass / predMass
+      if (massRatio < 0.1 || massRatio > 3.0) continue  // prey too small or too large
     }
 
     const { w: ow, h: oh } = artSize(obp)

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -952,6 +952,14 @@ export interface CreatureBlueprint {
    * scaled down proportionally to population / alleeThreshold. Issue #3288.
    */
   alleeThreshold?: number
+  /**
+   * Body mass in relative units (1.0 = reference size).
+   *
+   * Used for Kleiber's metabolic scaling (hunger rate ∝ bodyMass^0.75) and the
+   * size-based predation gate (prey must be within mass ratio [0.1, 3.0] of
+   * predator). Default 1.0 when undefined. Issues #3269, #3272, #3273.
+   */
+  bodyMass?: number     // body mass in relative units (1.0 = reference size); default 1.0
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements three body-size ecology mechanics from the Body Size Ecology epic (#3268):

- **`bodyMass` blueprint field** (#3269): a relative mass anchor (1.0 = reference size). Added to 12 existing creatures as representative anchors: sunleaf/bramble (0.5), shimmer-larva/termite (0.1), garden-spider/meadow-locust-nymph (0.1–0.2), meadow-locust/bark-gecko (0.2), prairie-dog (0.3), barn-owl/monitor-lizard (1.5), sea-otter/aardvark/beaver (2.0). Species without `bodyMass` default to 1.0 (no change in behaviour).
- **Kleiber's law** (#3272): `hunger rate *= bodyMass^0.75` each tick. Large animals burn more absolute energy; small animals are proportionally more efficient. At mass 0.1 (~10% of reference) hunger rate is 0.1^0.75 ≈ 0.18× reference; at mass 4.0 it is 4^0.75 ≈ 2.83×.
- **Size-based predation gate** (#3273): during the sense pass, prey with mass ratio outside `[0.1, 3.0]` relative to the predator are filtered out. A lion ignores gnats; a spider ignores cows. Only applies when *both* predator and prey have explicit `bodyMass` set — unset species are unaffected (safe default).

## Closes

Closes #3269, #3272, #3273

## Test plan

- [ ] A large creature (bodyMass 2.0) hungers faster than a small one (bodyMass 0.1)
- [ ] A large predator does not chase very small prey when both have bodyMass set
- [ ] Creatures without bodyMass behave identically to before
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)