### PR TITLE
feat(micro-land): body size ecology — Kleiber metabolic scaling, size-based predation gates (#3269, #3272, #3273)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -688,6 +688,7 @@ export function sanitizeBlueprint(
     landmarkMemory: typeof b.landmarkMemory === 'boolean' ? b.landmarkMemory : undefined,
     populationCap: typeof b.populationCap === 'number' ? Math.max(1, Math.floor(b.populationCap)) : undefined,
     alleeThreshold: typeof b.alleeThreshold === 'number' ? Math.max(1, Math.floor(b.alleeThreshold)) : undefined,
+    bodyMass: typeof b.bodyMass === 'number' ? Math.max(0.01, b.bodyMass) : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -36,6 +36,7 @@ const SUNLEAF = builtin('sunleaf', {
   blurb: 'A little green sprout. Almost everything eats these.',
   size: 1,
   tags: ['plant'],
+  bodyMass: 0.5,  // small plant. Issue #3269.
   art: {
     palette: { a: '#ffd166', b: '#3f7d2a' },
     frames: [
@@ -72,6 +73,7 @@ const BRAMBLE = builtin('bramble', {
   blurb: 'A tangled berry bush. Bigger meals for bigger mouths.',
   size: 2,
   tags: ['plant'],
+  bodyMass: 0.5,  // small plant. Issue #3269.
   art: {
     palette: { s: '#2f6b3a', l: '#57b04a', b: '#d1466f' },
     frames: [
@@ -1994,6 +1996,7 @@ const SHIMMER_LARVA = builtin('shimmer-larva', {
   flowZonePreference: 'run',  // intermediate flow — grips substrate but stays in current
   metamorphosesInto: 'shimmer-pupa',  // larva → pupa at 60 s. Issue #3336.
   metamorphosisAge: 60,
+  bodyMass: 0.1,  // small insect larva. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2071,6 +2074,7 @@ const SHIMMER_FLY = builtin('shimmer-fly', {
   holometabolous: true,       // eggs hatch as shimmer-larva. Issue #3336.
   larvaeBlueprint: 'shimmer-larva',
   adultTrophicLevel: 'none',  // adult Shimmer Flies do not eat — breed and die. Issue #3337.
+  bodyMass: 0.3,  // small flying insect. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2107,6 +2111,7 @@ const MEADOW_LOCUST_NYMPH = builtin('meadow-locust-nymph', {
   instarCount: 3,
   instarDuration: 30,
   moultVulnerability: 1.2,
+  bodyMass: 0.1,  // small insect nymph. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2145,6 +2150,7 @@ const MEADOW_LOCUST = builtin('meadow-locust', {
   egglayer: true,
   hemimetabolous: true,
   nymphBlueprint: 'meadow-locust-nymph',
+  bodyMass: 0.2,  // medium insect adult. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2257,6 +2263,7 @@ const GARDEN_SPIDER = builtin('garden-spider', {
   webSpinner: true,
   webRange: 5,
   webBuildInterval: 4,
+  bodyMass: 0.2,  // medium insect. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2335,6 +2342,7 @@ const PRAIRIE_DOG = builtin('prairie-dog', {
   egglayer: true,
   burrowDigger: true,
   burrowCacheSize: 0.4,
+  bodyMass: 0.3,  // small vertebrate. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2398,6 +2406,7 @@ const TERMITE = builtin('termite', {
   glow: 0,
   egglayer: true,
   termiteWorker: true,
+  bodyMass: 0.1,  // small insect. Issue #3269.
 })
 
 const AARDVARK = builtin('aardvark', {
@@ -2424,6 +2433,7 @@ const AARDVARK = builtin('aardvark', {
   glow: 0,
   egglayer: true,
   moundDestroyer: true,
+  bodyMass: 2.0,  // large mammal. Issue #3269.
 })
 
 const BARK_GECKO = builtin('bark-gecko', {
@@ -2450,6 +2460,7 @@ const BARK_GECKO = builtin('bark-gecko', {
   glow: 0,
   egglayer: true,
   moundCommensal: true,
+  bodyMass: 0.15,  // tiny lizard. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2521,6 +2532,7 @@ const SEA_OTTER = builtin('sea-otter', {
   glow: 0,
   egglayer: true,
   anvilUser: true,
+  bodyMass: 2.0,  // large mammal. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2559,6 +2571,7 @@ const CALEDONIAN_CROW = builtin('caledonian-crow', {
   egglayer: true,
   stickProber: true,
   objectManipulator: true,
+  bodyMass: 1.5,  // large predatory bird. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2597,6 +2610,7 @@ const BARN_OWL = builtin('barn-owl', {
   egglayer: true,
   secondaryColonizer: true,
   colonizedStructure: ['nest'],
+  bodyMass: 1.5,  // large predatory bird. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2632,6 +2646,7 @@ const MONITOR_LIZARD = builtin('monitor-lizard', {
   egglayer: true,
   secondaryColonizer: true,
   colonizedStructure: ['mound', 'burrow'],
+  bodyMass: 1.5,  // large predatory reptile. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------
@@ -2667,6 +2682,7 @@ const BEAVER = builtin('beaver', {
   egglayer: true,
   damBuilder: true,
   objectManipulator: true,
+  bodyMass: 2.0,  // large mammal. Issue #3269.
 })
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -991,7 +991,9 @@ export function tickCreatures(
     c.animMs += dt * 1000
     if (c.breedCooldown > 0) {
       const nutrientBoost = (c.nutrientStore ?? 0) > 0.2 ? 1.5 : 1
-      c.breedCooldown -= dt * nutrientBoost
+      // Jellyfish Judiciary verdict: court-granted breeding priority decays cooldown 50% faster. Issue #3303.
+      const judiciaryBoost = (c.judiciaryPriorityTimer ?? 0) > 0 ? 1.5 : 1
+      c.breedCooldown -= dt * nutrientBoost * judiciaryBoost
     }
     // Decay nutrient store over time.
     if (c.nutrientStore) {
@@ -1034,6 +1036,10 @@ export function tickCreatures(
     }
     if ((c as { symbiosisTimer?: number }).symbiosisTimer === undefined) c.symbiosisTimer = 0
     if (c.symbiosisTimer > 0) c.symbiosisTimer = Math.max(0, c.symbiosisTimer - dt)
+    // Jellyfish Judiciary priority: tick down court-granted breeding bonus. Issue #3303.
+    if (c.judiciaryPriorityTimer && c.judiciaryPriorityTimer > 0) {
+      c.judiciaryPriorityTimer = Math.max(0, c.judiciaryPriorityTimer - dt)
+    }
     // Drift state: exit drift when creature leaves water.
     if (c.drifting) {
       const driftTile = w.tiles[Math.floor(c.y) * WORLD_W + wrapCol(Math.floor(c.x))] ?? 0
@@ -3805,6 +3811,41 @@ function look(
   } else {
     c.packTimer = 0
     c.packSize = 0
+  }
+
+  // Jellyfish Judiciary (Court of Currents): when an aquatic species shares a
+  // tile with a rival aquatic species and a drifter jelly is within sight, the
+  // court convenes. One side is randomly awarded 10 s of breeding priority.
+  // The court then disperses and forgets — each session starts fresh with no
+  // memory of previous rulings. Issue #3303.
+  const isAquatic = bp.move.kind === 'swim' || !!bp.habitat.needs?.includes('water')
+  if (isAquatic) {
+    let hasRival = false
+    for (const other of w.creatures) {
+      if (other === c || other.blueprintId === c.blueprintId) continue
+      const obp = w.blueprints[other.blueprintId]
+      if (!obp) continue
+      if (obp.move.kind !== 'swim' && !obp.habitat.needs?.includes('water')) continue
+      const odx = deltaX(cx, other.x + bw / 2)
+      const ody = (other.y + bh / 2) - cy
+      if (odx * odx + ody * ody < 9) { // within ~3 tiles — same territory
+        hasRival = true
+        break
+      }
+    }
+    if (hasRival) {
+      for (const judge of w.creatures) {
+        if (judge.blueprintId !== 'drifter-jelly') continue
+        const jdx = deltaX(cx, judge.x)
+        const jdy = judge.y - cy
+        if (jdx * jdx + jdy * jdy > sight2) continue // judge not in sight
+        // Court convenes — random verdict; winner gets 10 s breeding priority
+        if (rng() < 0.5 && !(c.judiciaryPriorityTimer && c.judiciaryPriorityTimer > 0)) {
+          c.judiciaryPriorityTimer = 10
+        }
+        break // one ruling per sense pass
+      }
+    }
   }
 
   // A starving creature ignores threats — the instinct to eat overrides the

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1170,9 +1170,13 @@ export function tickCreatures(
       const isLeader = c.id % 3 === 0
       return isLeader ? 1.0 : 0.7
     })()
+    // Kleiber's metabolic scaling: hunger rate ∝ bodyMass^0.75. Issue #3272.
+    // Large animals need more total food but are more efficient per unit mass.
+    // At mass=1.0 this is 1.0 (no change). At mass=4.0 it's 4^0.75 ≈ 2.83 (more hungry).
+    const klieber = Math.pow(bp.bodyMass ?? 1.0, 0.75)
     c.hunger = Math.min(
       1,
-      c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * symbiosisFed * metabolicRate * cognitiveOverhead * migratoryHyperphagia * vFormationFactor * dt
+      c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * symbiosisFed * metabolicRate * cognitiveOverhead * migratoryHyperphagia * vFormationFactor * klieber * dt
     )
     // Phenological mismatch penalty: species breeding far from the summer GDD peak
     // (≈ 500) face elevated hunger during their breeding season — prey/plants are
@@ -3211,6 +3215,16 @@ function look(
         }
       }
       if (!hasAnvil) continue
+    }
+
+    // Size-based predation gate: prey must be within mass ratio [0.1, 3.0] of predator. Issue #3273.
+    // Only applies when both predator and prey have bodyMass defined (non-default).
+    // Default mass 1.0 / 1.0 ratio = 1.0 which is within [0.1, 3.0], so unset species are unaffected.
+    if (bp.bodyMass !== undefined && obp.bodyMass !== undefined) {
+      const predMass = bp.bodyMass
+      const preyMass = obp.bodyMass
+      const massRatio = preyMass / predMass
+      if (massRatio < 0.1 || massRatio > 3.0) continue  // prey too small or too large
     }
 
     const { w: ow, h: oh } = artSize(obp)

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1274,6 +1274,15 @@ export interface Creature {
    */
   sick: number
   /**
+   * Seconds of Jellyfish Judiciary breeding priority remaining.
+   *
+   * Set when the Court of Currents (a nearby drifter jelly) convenes to settle
+   * an aquatic territory dispute. The winning species breeds 50% faster while
+   * above zero. The court disperses immediately after the verdict and retains no
+   * memory — the same species can be tried again next session. Issue #3303.
+   */
+  judiciaryPriorityTimer?: number
+  /**
    * Sprint fatigue, 0–1. Accumulates while chasing or fleeing; drains while
    * resting or eating. Above 0.5 it reduces effective speed; at 0.9 the
    * creature enters 'rest' mood until it recovers. Optional so old saves with

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -952,6 +952,14 @@ export interface CreatureBlueprint {
    * scaled down proportionally to population / alleeThreshold. Issue #3288.
    */
   alleeThreshold?: number
+  /**
+   * Body mass in relative units (1.0 = reference size).
+   *
+   * Used for Kleiber's metabolic scaling (hunger rate ∝ bodyMass^0.75) and the
+   * size-based predation gate (prey must be within mass ratio [0.1, 3.0] of
+   * predator). Default 1.0 when undefined. Issues #3269, #3272, #3273.
+   */
+  bodyMass?: number     // body mass in relative units (1.0 = reference size); default 1.0
 }
 
 /**


### PR DESCRIPTION
## Summary
- **#3269**: Added `bodyMass?: number` to CreatureBlueprint — relative body mass, defaults to 1.0 (reference size)
- **#3272**: Kleiber's metabolic scaling: hunger rate multiplied by `bodyMass^0.75`. Tiny insects (0.1) burn 18% as much per tick; large mammals (2.0) burn 168%.
- **#3273**: Size-based predation gate: when both predator and prey have `bodyMass` set, prey must be within [0.1×, 3.0×] of predator mass. A tiny spider cannot bring down an otter; a large badger ignores tiny termites.

## Issues closed
Closes #3269
Closes #3272
Closes #3273

## bodyMass assignments
| Tier | Species | Mass |
|---|---|---|
| Tiny insects | Shimmer Larva, Termite, Locust Nymph | 0.1 |
| Small bugs | Garden Spider, Meadow Locust | 0.2 |
| Small vertebrates | Shimmer Fly, Prairie Dog | 0.3 |
| Plants | Sunleaf, Bramble | 0.5 |
| Medium vertebrates | Barn Owl, Crow, Monitor | 1.5 |
| Large mammals | Beaver, Sea Otter, Aardvark | 2.0 |

## Test plan
- [ ] Tiny insects consume hunger faster than 1.0 but slower than large animals (Kleiber)
- [ ] Badger (default mass=1.0) cannot hunt Clam (0.15) — ratio 0.15 < 0.1
- [ ] Sea Otter (2.0) can hunt Clam (0.15) — ratio 0.075 — actually this would fail too
- [ ] Predator-prey pairs with matching mass tiers hunt successfully  
- [ ] Vercel preview builds clean