### PR TITLE
feat(micro-land): Kestrel Kingdom — hereditary monarchy, throne to the hungriest hunter

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -689,6 +689,7 @@ export function sanitizeBlueprint(
     populationCap: typeof b.populationCap === 'number' ? Math.max(1, Math.floor(b.populationCap)) : undefined,
     alleeThreshold: typeof b.alleeThreshold === 'number' ? Math.max(1, Math.floor(b.alleeThreshold)) : undefined,
     bodyMass: typeof b.bodyMass === 'number' ? Math.max(0.01, b.bodyMass) : undefined,
+    kestrelKingdom: typeof b.kestrelKingdom === 'boolean' ? b.kestrelKingdom : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -2689,6 +2689,43 @@ const BEAVER = builtin('beaver', {
 // Arctic Tern — landmark-learning migratory seabird. Issue #3326.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Kestrel — hovering raptor with hereditary monarchy. Issue #3304.
+// ---------------------------------------------------------------------------
+
+const KESTREL = builtin('kestrel', {
+  name: 'Kestrel',
+  blurb: 'Hovers on the wind, scanning for mice. The hungriest one wears the crown.',
+  size: 2,
+  tags: ['meat', 'bird', 'flier'],
+  art: {
+    palette: { r: '#c05020', b: '#3a2010', c: '#e8c090', w: '#d09850' },
+    frames: [
+      ['.rr...rr.', 'rwwwwwwwr', '..rcrrc..', '...r.r...'],
+      ['rwwwwwwwr', '.rr...rr.', '..rcrrc..', '...r.r...'],
+    ],
+    frameMs: 160,
+    faceMotion: true,
+  },
+  body: { mass: 0.35, bounce: 0.1, drag: 0.4, buoyancy: 1.2, immuneTo: [] },
+  move: { kind: 'fly', speed: 5.5, jump: 0, restlessness: 0.4 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.022,
+    starveSeconds: 55,
+    breedAt: 0.85,
+    lifespanSeconds: 350,
+  },
+  senses: { sight: 28 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#c05020', particleCount: 8 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  kestrelKingdom: true,
+})
+
 const ARCTIC_TERN = builtin('arctic-tern', {
   name: 'Arctic Tern',
   blurb: "The world's longest migrant — navigates 70,000 km annually using memorized landmarks and following experienced elders.",
@@ -2792,6 +2829,7 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   MONITOR_LIZARD,
   BEAVER,
   ARCTIC_TERN,
+  KESTREL,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -893,6 +893,35 @@ export function tickCreatures(
     speciesCount[c.blueprintId] = (speciesCount[c.blueprintId] ?? 0) + 1
   }
 
+  // Kestrel Kingdom: at each seasonal boundary, the individual with the most
+  // cumulative meals is crowned Monarch and hunts at 110% speed. The throne
+  // is re-awarded each season with no memory of the previous holder. No
+  // interregnum — if the Monarch dies mid-season kestrels continue normally.
+  // Issue #3304.
+  if (TUNING.seasonPeriod > 0) {
+    const currentSeasonIdx = Math.floor(w.elapsed / TUNING.seasonPeriod)
+    if ((w.kestrelLastSeasonIdx ?? -1) < currentSeasonIdx) {
+      w.kestrelLastSeasonIdx = currentSeasonIdx
+      let bestMeals = -1
+      let newMonarch: typeof w.creatures[0] | null = null
+      for (const c of w.creatures) {
+        const cbp = w.blueprints[c.blueprintId]
+        c.isMonarch = false  // clear throne from everyone
+        if (!cbp?.kestrelKingdom) continue
+        if (c.mealsEaten > bestMeals) {
+          bestMeals = c.mealsEaten
+          newMonarch = c
+        }
+      }
+      if (newMonarch) {
+        newMonarch.isMonarch = true
+        w.kestrelMonarchId = newMonarch.id
+      } else {
+        w.kestrelMonarchId = undefined
+      }
+    }
+  }
+
   // Invasion front tracking: for each invasive species, record origin and
   // track the historical maximum X spread. Runs every 60 ticks (once per
   // second). Issue #3366.
@@ -4453,6 +4482,7 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
       (c.symbiosisTimer > 0 ? 1.15 : 1) *
       (c.insightTimer && c.insightTimer > 0 ? 0.05 : 1) *  // insight pause
       (c.drifting ? 0.4 : 1) *  // drift — slower passive flow
+      (c.isMonarch && c.mood === 'hunt' ? 1.1 : 1) *  // Kestrel Kingdom throne bonus. Issue #3304.
       (1 - Math.max(0, (c.fatigue ?? 0) - 0.5))) /
       sizeOf(c)) *
     (1 - diurnalPenalty)

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -960,6 +960,15 @@ export interface CreatureBlueprint {
    * predator). Default 1.0 when undefined. Issues #3269, #3272, #3273.
    */
   bodyMass?: number     // body mass in relative units (1.0 = reference size); default 1.0
+  /**
+   * When true, this species participates in the Kestrel Kingdom mechanic.
+   *
+   * At each seasonal boundary the individual with the highest cumulative
+   * `mealsEaten` is crowned Monarch. The Monarch hunts at 110% speed.
+   * There is no court, no succession plan — the crown is re-awarded each
+   * season regardless of what happened to the previous holder. Issue #3304.
+   */
+  kestrelKingdom?: boolean
 }
 
 /**
@@ -1290,6 +1299,16 @@ export interface Creature {
    * memory — the same species can be tried again next session. Issue #3303.
    */
   judiciaryPriorityTimer?: number
+  /**
+   * Whether this individual currently holds the Kestrel Kingdom throne.
+   *
+   * Set at each seasonal boundary on the kestrelKingdom individual with the
+   * highest mealsEaten. Grants 10% hunting speed. Cleared on all individuals
+   * before each re-election. When the Monarch dies mid-season the crown sits
+   * vacant until the next reckoning — no interregnum protocol exists.
+   * Issue #3304.
+   */
+  isMonarch?: boolean
   /**
    * Sprint fatigue, 0–1. Accumulates while chasing or fleeing; drains while
    * resting or eating. Above 0.5 it reduces effective speed; at 0.9 the
@@ -1761,6 +1780,17 @@ export interface WorldState {
    * tiles delivered. Used for egg hatch bonus and nest rendering. Issues #3412, #3418.
    */
   nestSites?: Record<string, { progress: number; ownerId: number; x: number; y: number }>
+  /**
+   * ID of the currently-reigning Monarch Kestrel (kestrelKingdom species).
+   * Updated each season by the reckoning logic. Cleared when no kestrel survives.
+   * Issue #3304.
+   */
+  kestrelMonarchId?: number
+  /**
+   * Index of the last season for which the Kestrel Kingdom reckoning ran.
+   * Prevents the election from firing on every tick. Issue #3304.
+   */
+  kestrelLastSeasonIdx?: number
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the **Kestrel Kingdom** mechanic from issue #3304.

At each seasonal boundary the **Kestrel** (a new hovering raptor) with the highest cumulative meal count is crowned **Monarch**. The Monarch hunts at **110% speed**. The crown is re-awarded each season with no memory of the previous holder. There is no court, no nobility, and no succession plan — when the Monarch dies mid-season, kestrels continue normally and wait for the next reckoning.

## New creature: Kestrel

- Size 2, flying, sight 28, speed 5.5
- Hunts `'meat'`-tagged prey
- Russet/cream pixel sprite in hovering pose
- `kestrelKingdom: true` — participates in the monarchy mechanic

## Mechanic

Each time `floor(elapsed / seasonPeriod)` increments:
1. All `isMonarch` flags are cleared across the entire population
2. The kestrel with the highest `mealsEaten` is crowned (`isMonarch = true`)
3. `w.kestrelMonarchId` records the winner
4. The Monarch receives a 10% speed bonus while in `'hunt'` mood

When no kestrel is alive, the throne sits vacant until the next reckoning.

## Closes

Closes #3304

## Test plan

- [ ] Kestrel spawns and hunts normally
- [ ] After one season (300s default), the kestrel with the most meals becomes Monarch
- [ ] Monarch moves faster while hunting than non-monarchs
- [ ] If Monarch dies, other kestrels continue without special status
- [ ] Next season, throne re-awarded to whoever ate the most
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)