### PR TITLE
feat(micro-land): island dwarfism and gigantism — isolated populations evolve different body sizes

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -2635,6 +2635,36 @@ export function tickCreatures(
               const mutated = midpoint + (rng() * 20 - 10)
               child.phenoOffset = Math.max(-200, Math.min(200, mutated))
             }
+            // Island dwarfism / gigantism: isolated land populations evolve different body sizes. Issue #3271.
+            if (bp.bodyMass !== undefined && bp.move.kind === 'walk') {
+              const cx = Math.floor(c.x), cy = Math.floor(c.y)
+              const ISLAND_RADIUS = 20
+              let waterLeft = false, waterRight = false
+              for (let dx = 1; dx <= ISLAND_RADIUS; dx++) {
+                const rowL = cy * WORLD_W + ((cx - dx + WORLD_W) % WORLD_W)
+                const rowR = cy * WORLD_W + ((cx + dx) % WORLD_W)
+                if (IS_LIQUID[w.tiles[rowL]] === 1) { waterLeft = true }
+                if (IS_LIQUID[w.tiles[rowR]] === 1) { waterRight = true }
+                if (waterLeft && waterRight) break
+              }
+              if (waterLeft && waterRight) {
+                // Isolated island: prey shrink (no predation pressure), predators grow (no competition)
+                const isPrey = bp.diet.eats.includes('plant') && !bp.diet.eats.includes('meat')
+                const isPredator = bp.diet.eats.includes('meat')
+                if (isPrey) {
+                  // Check if any predator of this species is nearby
+                  const nearPredator = w.creatures.some(p => {
+                    if (p.blueprintId === c.blueprintId) return false
+                    const pbp = w.blueprints[p.blueprintId]
+                    return pbp?.diet.eats.includes('meat') &&
+                      Math.abs(p.x - c.x) < ISLAND_RADIUS && Math.abs(p.y - c.y) < ISLAND_RADIUS
+                  })
+                  if (!nearPredator) child.traits.size = Math.max(0.8, child.traits.size - 0.02)
+                } else if (isPredator) {
+                  child.traits.size = Math.min(1.2, child.traits.size + 0.02)
+                }
+              }
+            }
             child.lifeLog = [{ elapsed: w.elapsed, text: `Born (gen ${child.generation})` }]
             // Record birth position for anadromous migration homing.
             if (bp.anadromous) child.natalX = Math.floor(child.x)
@@ -2896,6 +2926,32 @@ export function tickCreatures(
         if (hatchling) {
           hatchling.generation = egg.generation
           hatchling.traits = egg.traits
+          // Island dwarfism / gigantism at egg hatch. Issue #3271.
+          if (ebp.bodyMass !== undefined && ebp.move.kind === 'walk') {
+            const ex = Math.floor(egg.x), ey = Math.floor(egg.y)
+            const ISLAND_R = 20
+            let wL = false, wR = false
+            for (let idx2 = 1; idx2 <= ISLAND_R; idx2++) {
+              if (IS_LIQUID[w.tiles[ey * WORLD_W + ((ex - idx2 + WORLD_W) % WORLD_W)]] === 1) wL = true
+              if (IS_LIQUID[w.tiles[ey * WORLD_W + ((ex + idx2) % WORLD_W)]] === 1) wR = true
+              if (wL && wR) break
+            }
+            if (wL && wR) {
+              const isPrey2 = ebp.diet.eats.includes('plant') && !ebp.diet.eats.includes('meat')
+              const isPred2 = ebp.diet.eats.includes('meat')
+              if (isPrey2) {
+                const nearPred2 = w.creatures.some(p2 => {
+                  if (p2.blueprintId === egg.blueprintId) return false
+                  const p2bp = w.blueprints[p2.blueprintId]
+                  return p2bp?.diet.eats.includes('meat') &&
+                    Math.abs(p2.x - egg.x) < ISLAND_R && Math.abs(p2.y - egg.y) < ISLAND_R
+                })
+                if (!nearPred2) hatchling.traits.size = Math.max(0.8, hatchling.traits.size - 0.02)
+              } else if (isPred2) {
+                hatchling.traits.size = Math.min(1.2, hatchling.traits.size + 0.02)
+              }
+            }
+          }
           hatchling.lifeLog = [{ elapsed: w.elapsed, text: `Born (gen ${egg.generation})` }]
           // Mark life stage from hatch. Issue #3336.
           if (parentBp?.holometabolous) {


### PR DESCRIPTION
## Summary
- At each birth (live or egg hatch), for land-walking species with `bodyMass` defined, detect **island isolation** by scanning ±20 tiles horizontally for water tiles on both sides
- When isolated:
  - **Prey species** (plant-eaters) with no nearby predators: offspring `size` trait nudged **-0.02** (dwarfism — no predation pressure reduces selection for large size; Flores dwarf elephant pattern)
  - **Predator species** (meat-eaters) on island: offspring `size` trait nudged **+0.02** (gigantism — no competition reduces food-limiting pressure; Komodo dragon pattern)
- Clamped to [0.8, 1.2]. Compounds over generations for dramatic isolated-population divergence

## Closes
Closes #3271

## Test plan
- [ ] Place prey species on a small land platform bounded by water on both sides — after many generations, average `size` should drift toward 0.8
- [ ] Place predator species on same island — average `size` should drift toward 1.2
- [ ] Same species in open terrain (no water boundaries) — no systematic island drift
- [ ] Prey species on island WITH predators present — no dwarfism drift (predation pressure maintained)
- [ ] CI typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)