### PR TITLE
feat(micro-land): Mole Mail + Newt Newspaper — stale postal service and pond journalism

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -720,6 +720,8 @@ export function sanitizeBlueprint(
     frogFundamentalism: typeof b.frogFundamentalism === 'boolean' ? b.frogFundamentalism : undefined,
     gopherGovernment: typeof b.gopherGovernment === 'boolean' ? b.gopherGovernment : undefined,
     beetleInternet: typeof b.beetleInternet === 'boolean' ? b.beetleInternet : undefined,
+    moleMailCarrier: typeof b.moleMailCarrier === 'boolean' ? b.moleMailCarrier : undefined,
+    newtNewspaper: typeof b.newtNewspaper === 'boolean' ? b.newtNewspaper : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -3241,6 +3241,82 @@ const RACCOON = builtin('raccoon', {
   bodyMass: 0.5,
 })
 
+// ---------------------------------------------------------------------------
+// Mole — underground postal service. Issue #3306.
+// ---------------------------------------------------------------------------
+
+const MOLE = builtin('mole', {
+  name: 'Mole',
+  blurb: 'Runs an underground postal service. Letters take 2 seasons. The food report is always from last season. Moles are aware of the problem.',
+  size: 1,
+  tags: ['meat', 'mammal'],
+  art: {
+    palette: { b: '#2a1a0a', w: '#d4b896', g: '#3a2a1a', p: '#5a3a2a' },
+    frames: [
+      ['bpb', 'wgw', '.b.'],
+      ['.b.', 'wgw', 'bpb'],
+    ],
+    frameMs: 220,
+    faceMotion: true,
+  },
+  body: { mass: 0.8, bounce: 0.05, drag: 0.5, buoyancy: 0, immuneTo: [] },
+  move: { kind: 'walk', speed: 2.5, jump: 1, restlessness: 0.6 },
+  diet: {
+    eats: ['meat'],
+    fears: ['meat'],
+    hungerRate: 0.010,
+    starveSeconds: 40,
+    breedAt: 0.65,
+    lifespanSeconds: 200,
+  },
+  senses: { sight: 8 },
+  habitat: { needs: null, drowns: true },
+  death: { becomes: null, particleColor: '#2a1a0a', particleCount: 5 },
+  aura: null,
+  glow: 0,
+  egglayer: false,
+  moleMailCarrier: true,
+  burrowDigger: true,
+  bodyMass: 0.08,
+})
+
+// ---------------------------------------------------------------------------
+// Newt — pond journalist. Issue #3307.
+// ---------------------------------------------------------------------------
+
+const NEWT = builtin('newt', {
+  name: 'Newt',
+  blurb: 'Maintains the only newspaper in the pond. Publishes every 14 days. Page 2 does not exist. Considering a podcast.',
+  size: 1,
+  tags: ['meat', 'amphibian'],
+  art: {
+    palette: { r: '#c04020', b: '#1a3020', w: '#a8c890', g: '#2a5030' },
+    frames: [
+      ['grg', 'wbw', '.g.'],
+      ['.g.', 'wbw', 'grg'],
+    ],
+    frameMs: 280,
+    faceMotion: true,
+  },
+  body: { mass: 0.4, bounce: 0.05, drag: 0.3, buoyancy: 0.8, immuneTo: [] },
+  move: { kind: 'walk', speed: 2.0, jump: 2, restlessness: 0.4 },
+  diet: {
+    eats: ['meat'],
+    fears: ['meat'],
+    hungerRate: 0.006,
+    starveSeconds: 50,
+    breedAt: 0.7,
+    lifespanSeconds: 240,
+  },
+  senses: { sight: 10 },
+  habitat: { needs: ['water'], drowns: false },
+  death: { becomes: null, particleColor: '#c04020', particleCount: 4 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  newtNewspaper: true,
+  bodyMass: 0.05,
+})
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   SUNLEAF,
   BRAMBLE,
@@ -3324,6 +3400,8 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   BEAR,
   QUAIL,
   RACCOON,
+  MOLE,
+  NEWT,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -2449,6 +2449,68 @@ export function tickCreatures(
       }
     }
 
+    // --- Mole Mail: record food location; broadcast stale info after 2 seasons. Issue #3306. ---
+    if (bp.moleMailCarrier) {
+      // Record food location when eating
+      if (c.mood === 'eat' && c.targetId !== null) {
+        if (c.moleMailRecordedAt === undefined) {
+          c.moleMailRecordedAt = w.elapsed
+          c.moleMailFoodX = Math.floor(c.x)
+          c.moleMailFoodY = Math.floor(c.y)
+        }
+      }
+      // After 2 seasons, broadcast stale food location to nearby conspecifics
+      const MAIL_DELAY = TUNING.seasonPeriod * 2
+      if (c.moleMailRecordedAt !== undefined && (w.elapsed - c.moleMailRecordedAt) >= MAIL_DELAY) {
+        const mailX = c.moleMailFoodX!
+        const mailY = c.moleMailFoodY!
+        // Nudge nearby conspecifics toward the (stale) food location
+        for (const recipient of w.creatures) {
+          if (recipient.id === c.id || recipient.blueprintId !== c.blueprintId) continue
+          const rdist = Math.sqrt((recipient.x - c.x) ** 2 + (recipient.y - c.y) ** 2)
+          if (rdist > 15) continue
+          // Push recipient toward old food location (probably empty now)
+          const mdx = mailX - recipient.x, mdy = mailY - recipient.y
+          const mdist = Math.sqrt(mdx * mdx + mdy * mdy)
+          if (mdist > 1 && recipient.mood === 'wander') {
+            recipient.vx += (mdx / mdist) * 0.3 * dt
+            recipient.vy += (mdy / mdist) * 0.3 * dt
+          }
+        }
+        // 99% delivery rate — occasionally fire a notice event
+        if (rng() < 0.01 * dt) {
+          events.push({ kind: 'notice', blueprintId: bp.id, x: c.x, y: c.y, text: `${bp.name} delivers mail: food was at (${mailX}, ${mailY}) two seasons ago` })
+        }
+        // Reset for next mail cycle
+        c.moleMailRecordedAt = undefined
+        c.moleMailFoodX = undefined
+        c.moleMailFoodY = undefined
+      }
+    }
+
+    // --- Newt Newspaper: periodic pond headlines. Issue #3307. ---
+    if (bp.newtNewspaper) {
+      const PAPER_PERIOD = TUNING.seasonPeriod / 7  // ~14 in-game days
+      if (c.newtNewsTimer === undefined) c.newtNewsTimer = PAPER_PERIOD * rng()
+      c.newtNewsTimer -= dt
+      if (c.newtNewsTimer <= 0) {
+        c.newtNewsTimer = PAPER_PERIOD
+        const HEADLINES = [
+          'LARGE ROCK DISPLACES WATER IN NORTH SECTOR',
+          'CREATURE SPOTTED, LEAVES WITHOUT COMMENT',
+          'ALGAE BLOOM: COVERAGE CONTINUES PAGE 2',
+          'LOCAL FISH DOES NOTHING OF NOTE FOR THIRD CONSECUTIVE DAY',
+          'CURRENT SLIGHTLY FASTER THAN YESTERDAY',
+          'POND EDGE REPORT: IT IS STILL THERE',
+          'REED CENSUS SHOWS REEDS',
+          'MYSTERIOUS SPLASH — INVESTIGATION ONGOING',
+          'WATER TEMPERATURE WITHIN NORMAL RANGE',
+          'EDITORIAL: THE CASE FOR STAYING IN THE POND',
+        ]
+        const headline = HEADLINES[Math.floor(rng() * HEADLINES.length)]
+        events.push({ kind: 'notice', blueprintId: bp.id, x: c.x, y: c.y, text: `${bp.name} Newspaper: ${headline}` })
+      }
+    }
 
     // --- burrow excavation: dig through soil tiles downward. Issue #3419. ---
     if (bp.burrowDigger) {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1192,6 +1192,10 @@ export interface CreatureBlueprint {
   gopherGovernment?: boolean
   /** When true, this species relays pheromone messages with a 135s delay. Issue #3302. */
   beetleInternet?: boolean
+  /** When true, this species records food locations and broadcasts them to conspecifics after a 2-season delay. Issue #3306. */
+  moleMailCarrier?: boolean
+  /** When true, this species periodically publishes headlines about local events. Issue #3307. */
+  newtNewspaper?: boolean
 }
 
 /**
@@ -1713,6 +1717,14 @@ export interface Creature {
   beetleMailX?: number
   /** Y tile coordinate where the beetle mail event occurred. Issue #3xxx. */
   beetleMailY?: number
+  /** Elapsed time when this mole last recorded a food location (for 2-season delay mail). Issue #3306. */
+  moleMailRecordedAt?: number
+  /** Recorded food X tile (the stale info moles broadcast). Issue #3306. */
+  moleMailFoodX?: number
+  /** Recorded food Y tile. Issue #3306. */
+  moleMailFoodY?: number
+  /** Countdown until this newt publishes the next headline. Issue #3307. */
+  newtNewsTimer?: number
 }
 
 /**


### PR DESCRIPTION
## Summary

### Mole Mail (#3306)
- New **Mole** creature with `moleMailCarrier: true` and `burrowDigger: true`
- When eating, moles record the food location and timestamp
- After a **2-season delay**, the mole broadcasts the stale food location to nearby conspecifics within 15 tiles
- Recipients (wandering moles) get nudged toward the old food location — which is probably empty now
- 1% chance per delivery cycle of firing a `notice` event ("delivers mail: food was at (X, Y) two seasons ago")

### Newt Newspaper (#3307)
- New **Newt** creature with `newtNewspaper: true` and water-adjacent habitat
- Every `seasonPeriod/7` (~14 in-game days), emits a notice event with a procedural headline
- Headlines include: `ALGAE BLOOM: COVERAGE CONTINUES PAGE 2`, `LARGE ROCK DISPLACES WATER IN NORTH SECTOR`, `MYSTERIOUS SPLASH — INVESTIGATION ONGOING`, etc.
- Page 2 does not exist.

## Closes
Closes #3306, #3307

## Test plan
- [ ] Add Mole to world — it should eat (meat-diet), burrow, and eventually start pushing nearby moles toward old food locations
- [ ] Add Newt to a water-adjacent world — headlines should appear in the notice log every ~45 sim-seconds
- [ ] Mole Mail broadcast: recipients move toward stale location even when food is gone
- [ ] Headline variety: sample multiple headlines to confirm rotation
- [ ] CI typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)