### PR TITLE
feat(micro-land): Earthworm Elevator + Frog Fundamentalism + Gopher Government + Insect Internet

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -716,6 +716,10 @@ export function sanitizeBlueprint(
     matingSystem: ['monogamy', 'polygyny', 'polyandry', 'promiscuity'].includes(b.matingSystem as string) ? b.matingSystem as 'monogamy' | 'polygyny' | 'polyandry' | 'promiscuity' : undefined,
     semelparous: typeof b.semelparous === 'boolean' ? b.semelparous : undefined,
     ageReproductionCurve: ['peak-early', 'peak-middle', 'peak-late'].includes(b.ageReproductionCurve as string) ? b.ageReproductionCurve as 'peak-early' | 'peak-middle' | 'peak-late' : undefined,
+    earthwormElevator: typeof b.earthwormElevator === 'boolean' ? b.earthwormElevator : undefined,
+    frogFundamentalism: typeof b.frogFundamentalism === 'boolean' ? b.frogFundamentalism : undefined,
+    gopherGovernment: typeof b.gopherGovernment === 'boolean' ? b.gopherGovernment : undefined,
+    beetleInternet: typeof b.beetleInternet === 'boolean' ? b.beetleInternet : undefined,
     winteringX: typeof b.winteringX === 'number' ? Math.round(b.winteringX) : undefined,
     summerX: typeof b.summerX === 'number' ? Math.round(b.summerX) : undefined,
     stopoverHabitat: Array.isArray(b.stopoverHabitat)

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1134,6 +1134,38 @@ export function tickCreatures(
     if (w.urchinStrikeActive && !wasStriking) {
       events.push({ kind: 'notice', blueprintId: bpId, x: 0, y: 0, text: `${ubp.name} Union on strike. Demands: stronger currents, fewer predators. Management has not responded.` })
     }
+    break
+  }
+
+  // --- Frog Fundamentalism: annual Founding Rain ritual. Issue #3299. ---
+  if (tickCount % 60 === 0) {
+    for (const [bpId, cnt] of Object.entries(speciesCount)) {
+      const fbp = w.blueprints[bpId]
+      if (!fbp?.frogFundamentalism || cnt < 1) continue
+      const currentSeason = TUNING.seasonPeriod > 0 ? Math.floor(w.elapsed / TUNING.seasonPeriod) : 0
+      if ((w.lastFrogRitualSeason ?? -1) < currentSeason) {
+        w.lastFrogRitualSeason = currentSeason
+        // Founding Rain: frogs near water are faithful; distant frogs are apostates
+        const frogsNearWater: number[] = []
+        const apostateFrogs: Creature[] = []
+        for (const frog of w.creatures) {
+          if (frog.blueprintId !== bpId) continue
+          const fx = Math.floor(frog.x), fy = Math.floor(frog.y)
+          let nearWater = false
+          for (let dy = -3; dy <= 3 && !nearWater; dy++) {
+            for (let dx = -3; dx <= 3 && !nearWater; dx++) {
+              const ty = fy + dy, tx = (fx + dx + WORLD_W) % WORLD_W
+              if (ty < 0 || ty >= w.tiles.length / WORLD_W) continue
+              if (IS_LIQUID[w.tiles[ty * WORLD_W + tx]] === 1) nearWater = true
+            }
+          }
+          if (nearWater) frogsNearWater.push(frog.id)
+          else { frog.frogApostate = TUNING.seasonPeriod / 18; apostateFrogs.push(frog) }
+        }
+        events.push({ kind: 'notice', blueprintId: bpId, x: 0, y: 0, text: `${fbp.name} Founding Rain observed. ${frogsNearWater.length} faithful, ${apostateFrogs.length} apostates. No theology. Only the rain matters.` })
+      }
+      break
+    }
   }
 
   // MVP warning and rescue effect. Issues #3284, #3285.
@@ -2210,6 +2242,90 @@ export function tickCreatures(
       c.vx = 0
       c.vy = 0
     }
+
+    // --- Earthworm Elevator: express vertical shaft for worms. Issue #3298. ---
+    if (bp.earthwormElevator) {
+      if (Math.abs(c.vy) > Math.abs(c.vx) * 1.5 && Math.abs(c.vy) > 0.2) {
+        c.vy *= 1 + 2 * dt  // small continuous boost that compounds
+      }
+      w.earthwormElevatorNextRebuild ??= w.elapsed + TUNING.seasonPeriod
+      if (w.elapsed >= w.earthwormElevatorNextRebuild) {
+        w.earthwormElevatorNextRebuild = w.elapsed + TUNING.seasonPeriod * (0.8 + rng() * 0.4)
+        w.earthwormElevatorRebuildCount = (w.earthwormElevatorRebuildCount ?? 0) + 1
+        events.push({ kind: 'notice', blueprintId: bp.id, x: c.x, y: c.y, text: `${bp.name} rebuilt the elevator. (Rebuild #${w.earthwormElevatorRebuildCount}) This always surprises them.` })
+      }
+    }
+
+    // --- Frog Fundamentalism: apostates have breeding penalty. Issue #3299. ---
+    if (bp.frogFundamentalism && (c.frogApostate ?? 0) > 0) {
+      c.frogApostate = (c.frogApostate ?? 0) - dt
+      // Breeding penalty: breed cooldown drains 70% slower
+      if (c.breedCooldown > 0) c.breedCooldown += 0.3 * dt  // net: slower recovery
+    }
+
+    // --- Gopher Government: one gopher holds all 17 cabinet positions. Issue #3300. ---
+    if (bp.gopherGovernment) {
+      if (w.gopherAdminId === undefined) {
+        w.gopherAdminId = c.id
+        c.isGopherAdmin = true
+        const CABINET = ['Minister of Tunnels', 'Secretary of Roots', 'Undersecretary of Subterranean Affairs',
+          'Chief Inspector of Moisture', 'Director of Emergency Soil', 'Ambassador to the Surface',
+          'Deputy Commissioner of Worms', 'Minister Without Portfolio (also Tunnels)',
+          'Secretary of State for Mole Relations', 'Administrator General of Burrow Standards',
+          'Chief of Staff (Subterranean Division)', 'Treasurer (no treasury exists)',
+          'Secretary of Defense (against owls)', 'Director of Interior (quite literal)',
+          'Commissioner for Tunnel Safety and Also Danger', 'Undersecretary for Undersecretary Affairs',
+          'Minister Plenipotentiary for Everything Else']
+        const sample = CABINET.slice(0, 3).join(', ') + `, and ${CABINET.length - 3} more`
+        events.push({ kind: 'notice', blueprintId: bp.id, x: c.x, y: c.y, text: `${bp.name} Administrator appointed: ${sample}. Has never attended a meeting with themselves.` })
+      } else if (c.id === w.gopherAdminId) {
+        c.isGopherAdmin = true
+      }
+    }
+
+    // --- Insect Internet: beetles relay stale pheromone messages. Issue #3302. ---
+    if (bp.beetleInternet) {
+      const BEETLE_DELAY = 135  // ~45 in-game minutes
+      // Record food location when eating
+      if (c.mood === 'eat' && c.beetleMailRecordedAt === undefined) {
+        c.beetleMailRecordedAt = w.elapsed
+        c.beetleMailType = 'food'
+        c.beetleMailX = Math.floor(c.x)
+        c.beetleMailY = Math.floor(c.y)
+      }
+      // Record predator location when fleeing
+      if (c.mood === 'flee' && c.targetId !== null && c.beetleMailRecordedAt === undefined) {
+        c.beetleMailRecordedAt = w.elapsed
+        c.beetleMailType = 'predator'
+        c.beetleMailX = Math.floor(c.x)
+        c.beetleMailY = Math.floor(c.y)
+      }
+      // After delay, broadcast stale info to nearby beetles
+      if (c.beetleMailRecordedAt !== undefined && (w.elapsed - c.beetleMailRecordedAt) >= BEETLE_DELAY) {
+        const msgType = c.beetleMailType ?? 'food'
+        const msgX = c.beetleMailX!, msgY = c.beetleMailY!
+        if (rng() < 0.05 * dt) {
+          events.push({ kind: 'notice', blueprintId: bp.id, x: c.x, y: c.y, text: `${bp.name} network packet delivered: "${msgType} here" (${Math.floor(w.elapsed - c.beetleMailRecordedAt)}s out of date). The network is considered a marvel.` })
+        }
+        // Nudge nearby beetles toward old location (probably wrong)
+        for (const recv of w.creatures) {
+          if (recv.id === c.id || recv.blueprintId !== c.blueprintId) continue
+          const rd = Math.sqrt((recv.x - c.x) ** 2 + (recv.y - c.y) ** 2)
+          if (rd > 12 || recv.mood !== 'wander') continue
+          const mdx = msgX - recv.x, mdy = msgY - recv.y
+          const md = Math.sqrt(mdx * mdx + mdy * mdy)
+          if (md > 1) {
+            recv.vx += (mdx / md) * 0.2 * dt
+            recv.vy += (mdy / md) * 0.2 * dt
+          }
+        }
+        c.beetleMailRecordedAt = undefined
+        c.beetleMailType = undefined
+        c.beetleMailX = undefined
+        c.beetleMailY = undefined
+      }
+    }
+
 
     // --- burrow excavation: dig through soil tiles downward. Issue #3419. ---
     if (bp.burrowDigger) {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1176,6 +1176,14 @@ export interface CreatureBlueprint {
    * still attack freely. Issue #3237.
    */
   aposematic?: boolean
+  /** When true, this species builds a vertical express shaft and earns a vertical movement bonus. Issue #3298. */
+  earthwormElevator?: boolean
+  /** When true, this species observes the annual Founding Rain ritual; absent frogs become apostates. Issue #3299. */
+  frogFundamentalism?: boolean
+  /** When true, the first individual becomes the Administrator holding all 17 cabinet positions. Issue #3300. */
+  gopherGovernment?: boolean
+  /** When true, this species relays pheromone messages with a 135s delay. Issue #3302. */
+  beetleInternet?: boolean
 }
 
 /**
@@ -2076,6 +2084,14 @@ export interface WorldState {
    * Slow sinusoidal oscillation; updated each tick. Issue #3153.
    */
   windY?: number
+  /** How many times the earthworm elevator has been rebuilt this world session. Issue #3298. */
+  earthwormElevatorRebuildCount?: number
+  /** World elapsed time at which the next earthworm elevator rebuild notice fires. Issue #3298. */
+  earthwormElevatorNextRebuild?: number
+  /** Season index of the last Frog Fundamentalism ritual. Issue #3299. */
+  lastFrogRitualSeason?: number
+  /** Creature id of the Gopher Government Administrator. Issue #3300. */
+  gopherAdminId?: number
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1689,6 +1689,18 @@ export interface Creature {
   alarmCallTimer?: number
   /** Set of blueprint IDs this predator has learned to avoid (aposematism). Issue #3237. */
   learnedAversions?: string[]
+  /** Seconds of frog apostasy countdown — dissenting frog moving away from fundamentalist mob. Issue #3xxx. */
+  frogApostate?: number
+  /** True when this gopher holds the current admin role in the Gopher Grid. Issue #3xxx. */
+  isGopherAdmin?: boolean
+  /** World elapsed time when this beetle recorded its mail message (undefined = no message queued). Issue #3xxx. */
+  beetleMailRecordedAt?: number
+  /** Type of beetle mail queued: 'food' or 'predator'. Issue #3xxx. */
+  beetleMailType?: string
+  /** X tile coordinate where the beetle mail event occurred. Issue #3xxx. */
+  beetleMailX?: number
+  /** Y tile coordinate where the beetle mail event occurred. Issue #3xxx. */
+  beetleMailY?: number
 }
 
 /**

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1892,6 +1892,10 @@ export interface BiomeZone {
   precipitation: number
 }
 
+// ---------------------------------------------------------------------------
+// Live world state
+// ---------------------------------------------------------------------------
+
 export interface WorldState {
   width: number
   height: number


### PR DESCRIPTION
## Summary

### Earthworm Elevator (#3298)
- New **Earthworm** creature with `earthwormElevator: true` + `burrowDigger: true`
- When moving primarily vertically (|vy| > |vx| × 1.5), earns a continuous speed bonus
- Periodically emits: "Earthworm rebuilt the elevator. (Rebuild #N) This always surprises them."

### Frog Fundamentalism (#3299)
- New **Frog** creature with `frogFundamentalism: true`
- Once per season (the Founding Rain), frogs near water are "faithful"; distant frogs become **apostates**
- Apostates have slower breed cooldown recovery for ~17 sim-seconds (5 in-game days)
- No theology. Only the rain matters.

### Gopher Government (#3300)
- New **Gopher** creature with `gopherGovernment: true` + `burrowDigger: true`
- First gopher in the world becomes the Administrator, holding all 17 cabinet positions simultaneously
- Emits: "Minister of Tunnels, Secretary of Roots, Undersecretary of Subterranean Affairs... (and 14 more). Has never attended a meeting with themselves."
- Tunneling behavior is identical to all other gophers.

### Insect Internet (#3302)
- New **Beetle** creature with `beetleInternet: true`
- Records food/predator location when eating or fleeing; broadcasts after 135-second delay
- Nearby beetles get nudged toward the stale location (probably wrong)
- 5% chance per second of emitting a notice: "food here (Xs out of date). The network is considered a marvel."

## Closes
Closes #3298, #3299, #3300, #3302

## Test plan
- [ ] Earthworm: place in world, should dig and move; periodic "surprised by rebuild" notices
- [ ] Frog: once per season, notice shows faithful vs. apostate count
- [ ] Frog apostates: check `frogApostate` timer actively slows breedCooldown recovery
- [ ] Gopher: first gopher spawned becomes Administrator; notice with cabinet titles fires once
- [ ] Beetle: after 135s of eating, nearby beetles should get nudged toward old food location
- [ ] CI typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)