### PR TITLE
feat(micro-land): Amphitheater Ants, Bear Banking, Quail Quarantine Zone, Raccoon Real Estate (#3294, #3295, #3310, #3311)

### DIFF
--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -796,6 +796,10 @@ export function sanitizeBlueprint(
     territoryRadius: typeof b.territoryRadius === 'number' ? Math.max(1, b.territoryRadius) : undefined,
     deepWaterSpecialist: typeof b.deepWaterSpecialist === 'boolean' ? b.deepWaterSpecialist : undefined,
     shallowWaterSpecialist: typeof b.shallowWaterSpecialist === 'boolean' ? b.shallowWaterSpecialist : undefined,
+    antTheater: typeof b.antTheater === 'boolean' ? b.antTheater : undefined,
+    bearBanking: typeof b.bearBanking === 'boolean' ? b.bearBanking : undefined,
+    quailQuarantine: typeof b.quailQuarantine === 'boolean' ? b.quailQuarantine : undefined,
+    raccoonRealEstate: typeof b.raccoonRealEstate === 'boolean' ? b.raccoonRealEstate : undefined,
   }
 }
 

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -3015,6 +3015,120 @@ const PLATYPUS = builtin('platypus', {
 })
 
 // ---------------------------------------------------------------------------
+// Ant — eusocial insect with Amphitheater performance mechanic. Issue #3294.
+// ---------------------------------------------------------------------------
+
+const ANT = builtin('ant', {
+  name: 'Ant',
+  blurb: 'Eusocial insect that constructed a 47-seat amphitheater in Season 2. Attendance is mandatory. Reviews are mixed.',
+  size: 0,
+  tags: ['plant', 'insect'],
+  art: {
+    palette: { b: '#1a0a00', r: '#4a1a00', w: '#e0a060' },
+    frames: [
+      ['.b.', 'rbr', '.r.'],
+      ['.r.', 'rbr', '.b.'],
+    ],
+    frameMs: 150,
+    faceMotion: false,
+  },
+  body: { mass: 0.05, bounce: 0.05, drag: 0.2, buoyancy: 0.1, immuneTo: [] },
+  move: { kind: 'walk', speed: 1.8, jump: 0.1, hop: 0, restlessness: 0.9 },
+  diet: {
+    eats: ['plant'],
+    fears: ['meat'],
+    hungerRate: 0.00008,
+    starveSeconds: 35,
+    breedAt: 0.6,
+    lifespanSeconds: 80,
+  },
+  senses: { sight: 5 },
+  habitat: { needs: [] },
+  death: { becomes: null, particleColor: '#1a0a00', particleCount: 2 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  antTheater: true,
+  bodyMass: 0.001,
+})
+
+// ---------------------------------------------------------------------------
+// Bear — omnivore with communal nut banking. Issue #3295.
+// ---------------------------------------------------------------------------
+
+const BEAR = builtin('bear', {
+  name: 'Brown Bear',
+  blurb: 'Founded the First National Nut Bank in Season 1. Has not read the terms and conditions. Neither has anyone else. The bank is thriving.',
+  size: 1,
+  tags: ['meat', 'mammal'],
+  art: {
+    palette: { b: '#2a1a0a', w: '#6a4a2a', g: '#8a6a4a' },
+    frames: [
+      ['gwg', 'wbw', 'gwg'],
+      ['.g.', 'wbw', '.g.'],
+    ],
+    frameMs: 300,
+    faceMotion: true,
+  },
+  body: { mass: 2.0, bounce: 0.05, drag: 0.3, buoyancy: 0.6, immuneTo: [] },
+  move: { kind: 'walk', speed: 0.8, jump: 0.3, hop: 0, restlessness: 0.3 },
+  diet: {
+    eats: ['meat', 'plant'],
+    fears: [],
+    hungerRate: 0.00004,
+    starveSeconds: 90,
+    breedAt: 0.8,
+    lifespanSeconds: 350,
+  },
+  senses: { sight: 10 },
+  habitat: { needs: [] },
+  death: { becomes: null, particleColor: '#2a1a0a', particleCount: 5 },
+  aura: null,
+  glow: 0,
+  egglayer: false,
+  bearBanking: true,
+  bodyMass: 3.0,
+})
+
+// ---------------------------------------------------------------------------
+// Quail — small bird under quarantine mechanic. Issue #3310.
+// ---------------------------------------------------------------------------
+
+const QUAIL = builtin('quail', {
+  name: 'Common Quail',
+  blurb: 'An entire settlement was quarantined in Season 4 due to a suspicious sneeze. The sneezer has never been identified. The quarantine may never fully end.',
+  size: 0,
+  tags: ['plant', 'bird'],
+  art: {
+    palette: { b: '#3a2a1a', w: '#c0a060', g: '#6a5a3a', r: '#8a6a3a' },
+    frames: [
+      ['.w.', 'wbw', '.g.'],
+      ['.g.', 'wbw', '.w.'],
+    ],
+    frameMs: 200,
+    faceMotion: true,
+  },
+  body: { mass: 0.15, bounce: 0.1, drag: 0.2, buoyancy: 0.3, immuneTo: [] },
+  move: { kind: 'walk', speed: 1.4, jump: 0.8, hop: 0, restlessness: 0.6 },
+  diet: {
+    eats: ['plant'],
+    fears: ['meat'],
+    hungerRate: 0.00007,
+    starveSeconds: 45,
+    breedAt: 0.65,
+    lifespanSeconds: 110,
+  },
+  senses: { sight: 6 },
+  habitat: { needs: [] },
+  death: { becomes: null, particleColor: '#3a2a1a', particleCount: 3 },
+  aura: null,
+  glow: 0,
+  egglayer: true,
+  quailQuarantine: true,
+  bodyMass: 0.15,
+})
+
+// ---------------------------------------------------------------------------
 // Toad — Toad Taxation. Issue #3313.
 // ---------------------------------------------------------------------------
 
@@ -3087,6 +3201,44 @@ const SEA_URCHIN = builtin('sea-urchin', {
   egglayer: false,
   urchinUnion: true,
   bodyMass: 0.2,
+})
+
+// ---------------------------------------------------------------------------
+// Raccoon — omnivore with real estate flipping mechanic. Issue #3311.
+// ---------------------------------------------------------------------------
+
+const RACCOON = builtin('raccoon', {
+  name: 'Raccoon',
+  blurb: 'Flipped 14 den sites last season. Does not disclose commission rates. Market is described as "HOT" in all materials regardless of conditions.',
+  size: 1,
+  tags: ['meat', 'mammal'],
+  art: {
+    palette: { b: '#1a1a1a', w: '#c0c0c0', g: '#6a6a6a', r: '#4a3a2a' },
+    frames: [
+      ['grg', 'wbw', 'gwg'],
+      ['gwg', 'wbw', 'grg'],
+    ],
+    frameMs: 220,
+    faceMotion: true,
+  },
+  body: { mass: 0.5, bounce: 0.1, drag: 0.3, buoyancy: 0.5, immuneTo: [] },
+  move: { kind: 'walk', speed: 1.2, jump: 0.6, hop: 0, restlessness: 0.7 },
+  diet: {
+    eats: ['meat', 'plant'],
+    fears: [],
+    hungerRate: 0.00006,
+    starveSeconds: 55,
+    breedAt: 0.7,
+    lifespanSeconds: 140,
+  },
+  senses: { sight: 8 },
+  habitat: { needs: [] },
+  death: { becomes: null, particleColor: '#1a1a1a', particleCount: 3 },
+  aura: null,
+  glow: 0,
+  egglayer: false,
+  raccoonRealEstate: true,
+  bodyMass: 0.5,
 })
 
 export const BUILTIN_CREATURES: CreatureBlueprint[] = [
@@ -3168,6 +3320,10 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   PLATYPUS,
   TOAD,
   SEA_URCHIN,
+  ANT,
+  BEAR,
+  QUAIL,
+  RACCOON,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1005,6 +1005,129 @@ export function tickCreatures(
     }
   }
 
+  // Amphitheater Ants: periodic mandatory performance reviews. Issue #3294.
+  if (TUNING.seasonPeriod > 0) {
+    const currentSeasonIdx = Math.floor(w.elapsed / TUNING.seasonPeriod)
+    if ((w.antLastPerformanceSeason ?? -1) < currentSeasonIdx) {
+      w.antLastPerformanceSeason = currentSeasonIdx
+      const ants = w.creatures.filter(c => w.blueprints[c.blueprintId]?.antTheater)
+      if (ants.length > 0) {
+        // Clear all performers
+        for (const a of ants) a.isPerformer = false
+        // Elect performer: most-fed ant
+        const performer = ants.reduce((best, a) => a.mealsEaten > best.mealsEaten ? a : best, ants[0])
+        performer.isPerformer = true
+        // Audience: all ants within 10 tiles
+        let audience = 0
+        for (const a of ants) {
+          const dx = a.x - performer.x, dy = a.y - performer.y
+          if (dx * dx + dy * dy < 100) audience++
+        }
+        w.antAudience = audience
+        events.push({ kind: 'notice', blueprintId: performer.blueprintId, x: performer.x, y: performer.y, text: `Mandatory attendance review at the Amphitheater. Attendance: ${audience}/${ants.length}. The committee is not satisfied.` })
+        // Reward: attending ants get a breed cooldown boost
+        for (const a of ants) {
+          const dx = a.x - performer.x, dy = a.y - performer.y
+          if (dx * dx + dy * dy < 25) {
+            a.breedCooldown = Math.max(0, (a.breedCooldown ?? 0) - 5)
+          }
+        }
+      }
+    }
+  }
+
+  // Bear Banking: communal savings with seasonal interest. Issue #3295.
+  if (TUNING.seasonPeriod > 0) {
+    const currentSeasonIdx = Math.floor(w.elapsed / TUNING.seasonPeriod)
+    if ((w.bearBankLastSeasonIdx ?? -1) < currentSeasonIdx) {
+      w.bearBankLastSeasonIdx = currentSeasonIdx
+      const bears = w.creatures.filter(c => w.blueprints[c.blueprintId]?.bearBanking)
+      if (bears.length > 0) {
+        w.bearBankBalance ??= 0
+        // Deposits: well-fed bears add to bank
+        for (const b of bears) {
+          if (b.hunger < 0.5) {
+            const deposit = (0.5 - b.hunger) * 10
+            w.bearBankBalance += deposit
+          }
+        }
+        // Interest: 5% per season, cap at 100
+        w.bearBankBalance = Math.min(100, w.bearBankBalance * 1.05)
+        // Withdrawals: hungry bears draw from bank
+        for (const b of bears) {
+          if (b.hunger > 0.8 && w.bearBankBalance > 5) {
+            const withdrawal = Math.min(5, w.bearBankBalance)
+            b.hunger = Math.max(0, b.hunger - withdrawal * 0.02)
+            w.bearBankBalance -= withdrawal
+          }
+        }
+        const bpId = bears[0].blueprintId
+        if (w.bearBankBalance > 80) {
+          events.push({ kind: 'notice', blueprintId: bpId, x: bears[0].x, y: bears[0].y, text: `Bear Bank seasonal dividend declared. Balance: ${w.bearBankBalance.toFixed(1)} nuts. The auditors are impressed.` })
+        } else {
+          events.push({ kind: 'notice', blueprintId: bpId, x: bears[0].x, y: bears[0].y, text: `Bear Bank balance: ${w.bearBankBalance.toFixed(1)} nuts. Interest rate: 5%. All deposits guaranteed.` })
+        }
+      }
+    }
+  }
+
+  // Quail Quarantine Zone: quarantine triggered by single sneeze in Season 4. Issue #3310.
+  if (TUNING.seasonPeriod > 0) {
+    const currentSeasonIdx = Math.floor(w.elapsed / TUNING.seasonPeriod)
+    const quails = w.creatures.filter(c => w.blueprints[c.blueprintId]?.quailQuarantine)
+    if (quails.length > 0) {
+      const bpId = quails[0].blueprintId
+      // Season 4 triggers quarantine (season index 3)
+      if (!w.quailQuarantineActive && currentSeasonIdx === 3 && (w.quailQuarantineSeasonIdx ?? -1) < 3) {
+        w.quailQuarantineActive = true
+        w.quailQuarantineSeasonIdx = currentSeasonIdx
+        events.push({ kind: 'notice', blueprintId: bpId, x: quails[0].x, y: quails[0].y, text: `QUARANTINE NOTICE: Quail Settlement placed under quarantine following a suspicious sneeze on Day 1 of Season 4. Breeding suspended pending investigation.` })
+      }
+      // Lift quarantine after 1 season or when pop < 5
+      if (w.quailQuarantineActive) {
+        if (currentSeasonIdx > (w.quailQuarantineSeasonIdx ?? 3) || quails.length < 5) {
+          w.quailQuarantineActive = false
+          events.push({ kind: 'notice', blueprintId: bpId, x: quails[0].x, y: quails[0].y, text: `Quarantine lifted. Health Inspector Vole declared the settlement safe. The original sneezer was unavailable for comment.` })
+        }
+      }
+    }
+  }
+
+  // Raccoon Real Estate: seasonal property appraisal and flipping. Issue #3311.
+  if (TUNING.seasonPeriod > 0) {
+    const currentSeasonIdx = Math.floor(w.elapsed / TUNING.seasonPeriod)
+    if ((w.raccoonRealEstateLastSeasonIdx ?? -1) < currentSeasonIdx) {
+      w.raccoonRealEstateLastSeasonIdx = currentSeasonIdx
+      const raccoons = w.creatures.filter(c => w.blueprints[c.blueprintId]?.raccoonRealEstate)
+      if (raccoons.length > 0) {
+        w.raccoonDenSites ??= {}
+        let topFlipper: typeof raccoons[0] | null = null
+        let topGarbage = -1
+        for (const r of raccoons) {
+          // Appraise location: value = recent meals × 10 capped
+          const value = Math.min(10, r.mealsEaten / 10)
+          const key = `${Math.floor(r.x)},${Math.floor(r.y)}`
+          w.raccoonDenSites[key] = value
+          r.garbageCurrency = (r.garbageCurrency ?? 0) + value
+          if (r.garbageCurrency > topGarbage) {
+            topGarbage = r.garbageCurrency
+            topFlipper = r
+          }
+        }
+        if (topFlipper) {
+          // Find most valuable site
+          let bestSite = '', bestVal = -1
+          for (const [k, v] of Object.entries(w.raccoonDenSites)) {
+            if (v > bestVal) { bestVal = v; bestSite = k }
+          }
+          const bpId = topFlipper.blueprintId
+          events.push({ kind: 'notice', blueprintId: bpId, x: topFlipper.x, y: topFlipper.y, text: `Raccoon Real Estate Report: ${raccoons.length} listings. Top flipper holds ${topGarbage.toFixed(0)} garbage units. Market: HOT.` })
+          topFlipper.garbageCurrency = 0  // spent on the flip
+        }
+      }
+    }
+  }
+
   // Invasion front tracking: for each invasive species, record origin and
   // track the historical maximum X spread. Runs every 60 ticks (once per
   // second). Issue #3366.
@@ -3027,6 +3150,9 @@ export function tickCreatures(
       !bp.phenology?.breedingGdd ||
       worldGdd(w.elapsed) >= bp.phenology.breedingGdd + (c.phenoOffset ?? 0)
     )
+    // Quail Quarantine: breeding suspended while quarantine is active. Issue #3310.
+    if (bp.quailQuarantine && w.quailQuarantineActive) continue
+
     if (
       inBreedingSeason &&
       readyToBreed(c, bp) &&

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1061,6 +1061,14 @@ export interface CreatureBlueprint {
   coordinationRange?: number
   /** Minimum bodyMass of prey that requires pack take-down. Default 2.0. Issue #3228. */
   packSizeThreshold?: number
+  /** Ants build mandatory-attendance performance venues each season. Issue #3294. */
+  antTheater?: boolean
+  /** Bears maintain a communal nut bank with seasonal interest rates. Issue #3295. */
+  bearBanking?: boolean
+  /** A quail village under perpetual quarantine since a suspicious sneeze in Season 4. Issue #3310. */
+  quailQuarantine?: boolean
+  /** Raccoons appraise and flip den sites using garbage as currency. Issue #3311. */
+  raccoonRealEstate?: boolean
   /**
    * When true, this species stays near its nest when eggs are present, and
    * intercepts predators approaching those eggs. Issue #3258.
@@ -1528,6 +1536,10 @@ export interface Creature {
   wisdom?: number
   /** Countdown seconds until next philosophical contemplation. Issue #3309. */
   philosophyTimer?: number
+  /** Whether this ant is currently performing at the Amphitheater. Issue #3294. */
+  isPerformer?: boolean
+  /** Raccoon's accumulated garbage currency from property flipping. Issue #3311. */
+  garbageCurrency?: number
   /**
    * Sprint fatigue, 0–1. Accumulates while chasing or fleeing; drains while
    * resting or eating. Above 0.5 it reduces effective speed; at 0.9 the
@@ -2052,6 +2064,22 @@ export interface WorldState {
   chiefVoleId?: number
   /** Season index of the last Vole Voting election. Issue #3315. */
   chiefVoleLastElectionSeason?: number
+  /** Season index of last Amphitheater Ant performance. Issue #3294. */
+  antLastPerformanceSeason?: number
+  /** Current audience count at the ant performance. Issue #3294. */
+  antAudience?: number
+  /** Total nut balance in the Bear Bank. Issue #3295. */
+  bearBankBalance?: number
+  /** Season index of last Bear Bank cycle. Issue #3295. */
+  bearBankLastSeasonIdx?: number
+  /** Whether the Quail Quarantine is currently active. Issue #3310. */
+  quailQuarantineActive?: boolean
+  /** Season index when quarantine was triggered. Issue #3310. */
+  quailQuarantineSeasonIdx?: number
+  /** Raccoon property registry: "x,y" → value. Issue #3311. */
+  raccoonDenSites?: Record<string, number>
+  /** Season index of last Raccoon Real Estate appraisal. Issue #3311. */
+  raccoonRealEstateLastSeasonIdx?: number
   /**
    * Per-tile edge mask: 1 if the tile is at a habitat boundary (adjacent to a
    * different material type), 0 otherwise. Computed every 300 ticks.

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -2110,6 +2110,7 @@ export interface WorldState {
 // Event history
 // ---------------------------------------------------------------------------
 
+
 export type HistoryEventKind = 'born' | 'died' | 'plant_died' | 'ate' | 'named' | 'plant' | 'sick'
 
 export interface HistoryEntry {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -2110,7 +2110,6 @@ export interface WorldState {
 // Event history
 // ---------------------------------------------------------------------------
 
-
 export type HistoryEventKind = 'born' | 'died' | 'plant_died' | 'ate' | 'named' | 'plant' | 'sick'
 
 export interface HistoryEntry {


### PR DESCRIPTION
## Summary
- **Amphitheater Ants (#3294)**: Each season the most-fed ant holds a mandatory performance review at the Amphitheater; nearby attendees get a breed cooldown reduction; committee remains unsatisfied
- **Bear Banking (#3295)**: Bears deposit satiation into a communal nut bank each season, earn 5% interest, and withdraw when hungry; bank declares dividends when balance > 80 nuts
- **Quail Quarantine Zone (#3310)**: A quail village is placed under breeding quarantine in Season 4 due to a suspicious sneeze; quarantine lifts after one season or when population drops below 5
- **Raccoon Real Estate (#3311)**: Each season raccoons appraise their location based on food density, accumulate garbage currency, and the top flipper announces market conditions (always HOT)

## New creatures
- **Ant** (`ant`) — tiny eusocial herbivore that builds performance venues
- **Brown Bear** (`bear`) — large omnivore with communal banking instincts
- **Common Quail** (`quail`) — small herbivorous bird under perpetual quarantine
- **Raccoon** (`raccoon`) — opportunistic omnivore with a passion for property flipping

## Test plan
- [ ] TypeScript compiles without errors
- [ ] Ant performance review events appear in event log each season
- [ ] Bear Bank balance updates and interest accrues each season
- [ ] Quail quarantine notice fires in Season 4 (elapsed ≈ 3 × seasonPeriod)
- [ ] Raccoon Real Estate Report appears in event log each season

🤖 Generated with [Claude Code](https://claude.com/claude-code)