### PR TITLE
feat(micro-land): mineral veins — ore deposits affect water chemistry and plant growth (#3179)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -67,6 +67,7 @@ import {
   tickCorridorMask,
   tickEdgeMask,
   tickMarshDetritus,
+  tickMineralVeins,
   tickMoisture,
   tickMycorrhizalNetwork,
   tickSalinity,
@@ -879,6 +880,7 @@ export function tickCreatures(
   tickAcidRain(w, tickCount, rng)
   tickMycorrhizalNetwork(w, tickCount, rng)
   tickWebDecay(w, tickCount, rng)
+  tickMineralVeins(w, tickCount, rng)
   tickEdgeMask(w, tickCount)
   tickCorridorMask(w, tickCount)
   updateBiomeZones(w, tickCount, seasonFactor)

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -1523,3 +1523,69 @@ export function tickAcidRain(w: WorldState, tickCount: number, _rng: () => numbe
     }
   }
 }
+
+/**
+ * Mineral vein exposure: periodically converts exposed stone tiles to ore deposits
+ * and applies local effects (water chemistry, plant nutrition). Issue #3179.
+ *
+ * Runs every 1200 ticks (every ~20 seconds of sim time at 60 ticks/s).
+ * Uses a fixed random probe rather than a full scan.
+ */
+export function tickMineralVeins(w: WorldState, tickCount: number, rng: () => number): void {
+  if (tickCount % 1200 !== 0) return
+  const stoneIdx = MATERIAL_INDEX.stone
+  const waterIdx = MATERIAL_INDEX.water
+
+  // Ore materials and their local nutrient effects
+  const ores: Array<{ id: string; nutrientBoost: number; pHShift: number }> = [
+    { id: 'iron', nutrientBoost: -0.02, pHShift: -0.3 },   // iron → acidifies water, reduces fertility
+    { id: 'gold', nutrientBoost: 0.05, pHShift: 0 },       // gold → inert, mild fertility boost
+    { id: 'gem', nutrientBoost: 0.03, pHShift: 0.1 },      // gem crystal → slightly alkaline
+    { id: 'crystal', nutrientBoost: 0.04, pHShift: 0 },    // crystal → enhances plant growth
+  ]
+
+  // Probe a random column, look for exposed stone in the upper-middle depth
+  // (not at the very surface, which is already well-modelled)
+  const tx = Math.floor(rng() * WORLD_W)
+  const startY = Math.floor(WORLD_H * 0.25)
+  const endY = Math.floor(WORLD_H * 0.75)
+
+  for (let ty = startY; ty < endY; ty++) {
+    const ti = ty * WORLD_W + tx
+    if (w.tiles[ti] !== stoneIdx) continue
+
+    // Only expose ore if adjacent to air or liquid (crack in the rock)
+    const above = ty > 0 ? w.tiles[(ty - 1) * WORLD_W + tx] : 0
+    const hasGap = !IS_SOLID[above] || (ty < WORLD_H - 1 && !IS_SOLID[w.tiles[(ty + 1) * WORLD_W + tx]])
+    if (!hasGap) continue
+
+    // Small chance to convert stone to ore (1 in 8 when conditions met)
+    if (rng() > 0.125) break
+
+    const ore = ores[Math.floor(rng() * ores.length)]
+    setTile(w, tx, ty, MATERIAL_INDEX[ore.id as keyof typeof MATERIAL_INDEX])
+
+    // Apply effects to adjacent water tiles (chemistry) and caveNutrient (plant growth)
+    for (let dy = -3; dy <= 3; dy++) {
+      for (let dx = -3; dx <= 3; dx++) {
+        const nx = (tx + dx + WORLD_W) % WORLD_W
+        const ny = ty + dy
+        if (ny < 0 || ny >= WORLD_H) continue
+        const ni = ny * WORLD_W + nx
+
+        if (w.tiles[ni] === waterIdx) {
+          // pH effect on water chemistry (uses existing tilePH system if present)
+          if (w.tilePH && ore.pHShift !== 0) {
+            w.tilePH[ni] = Math.max(0, Math.min(14, (w.tilePH[ni] ?? 7) + ore.pHShift * 0.1))
+          }
+        }
+
+        // Plant nutrition effect via caveNutrient (affects soil fertility)
+        if (ore.nutrientBoost !== 0 && w.caveNutrient) {
+          w.caveNutrient[ni] = Math.max(0, Math.min(1, (w.caveNutrient[ni] ?? 0) + ore.nutrientBoost * 0.05))
+        }
+      }
+    }
+    break
+  }
+}


### PR DESCRIPTION
Implements mineral vein exposure as a periodic world mechanic:

- **#3179** tickMineralVeins() runs every 1200 ticks; probes a random column and converts exposed stone tiles (adjacent to gaps) to ore (iron/gold/gem/crystal) with low probability
- Iron deposits acidify nearby water tiles (via tilePH) and reduce cave nutrient
- Gold/gem/crystal deposits boost nearby cave nutrient (plant nutrition)
- Effects apply within a 3-tile radius of the exposed ore

Closes #3179