### PR TITLE
feat(micro-land): show creature detail panel when placing a creature (#3104)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { ElderRecord, SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import { canEat, isPlantLike, moveWord, sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
@@ -93,6 +93,7 @@ export function FieldGuidePane() {
   const worldStats = useMicroLand(s => s.worldStats)
   const namedCreatures = useMicroLand(s => s.namedCreatures)
   const foodWeb = useMicroLand(s => s.foodWeb)
+  const keystoneSpeciesIds = useMicroLand(s => s.keystoneSpeciesIds)
   const populationItems = useMicroLand(s => s.populationItems)
   const requestLocateCreature = useMicroLand(s => s.requestLocateCreature)
   const compareId = useMicroLand(s => s.compareId)
@@ -102,7 +103,17 @@ export function FieldGuidePane() {
   const heatmapBlueprintId = useMicroLand(s => s.heatmapBlueprintId)
   const setHeatmapBlueprint = useMicroLand(s => s.setHeatmapBlueprint)
   const elapsed = useMicroLand(s => s.elapsed)
+  const tool = useMicroLand(s => s.tool)
   const allBlueprintNames = Object.fromEntries(blueprints.map(b => [b.id, b.name]))
+
+  // When a creature is selected for placement, scroll its entry into view.
+  const listRef = useRef<HTMLUListElement>(null)
+  const placingBlueprintId = tool.kind === 'creature' ? tool.blueprintId : null
+  useEffect(() => {
+    if (!placingBlueprintId || !listRef.current) return
+    const el = listRef.current.querySelector<HTMLElement>(`[data-blueprint-id="${placingBlueprintId}"]`)
+    el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  }, [placingBlueprintId])
 
   const [plantsHidden, setPlantsHidden] = useState(false)
   const [compact, setCompact] = useState(() => {
@@ -466,7 +477,7 @@ export function FieldGuidePane() {
           </button>
         </div>
       </div>
-      <ul className="flex flex-col">
+      <ul ref={listRef} className="flex flex-col">
         {ordered.map(bp => (
           <GuideEntry
             key={bp.id}
@@ -484,6 +495,8 @@ export function FieldGuidePane() {
             isHeatmap={heatmapBlueprintId === bp.id}
             onHeatmap={() => setHeatmapBlueprint(heatmapBlueprintId === bp.id ? null : bp.id)}
             elapsed={elapsed}
+            keystoneSpeciesIds={keystoneSpeciesIds}
+            isPlacing={placingBlueprintId === bp.id}
           />
         ))}
       </ul>
@@ -933,6 +946,8 @@ function GuideEntry({
   isHeatmap,
   onHeatmap,
   elapsed,
+  keystoneSpeciesIds,
+  isPlacing,
 }: {
   bp: CreatureBlueprint
   alive: number
@@ -948,6 +963,8 @@ function GuideEntry({
   isHeatmap?: boolean
   onHeatmap?: () => void
   elapsed: number
+  keystoneSpeciesIds?: ReadonlySet<string>
+  isPlacing?: boolean
 }) {
   const eats = blueprints.filter(other => canEat(bp, other))
   const eatenBy = blueprints.filter(other => canEat(other, bp))
@@ -955,7 +972,11 @@ function GuideEntry({
 
   return (
     <li
-      style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+      data-blueprint-id={bp.id}
+      style={{
+        borderBottom: '1px solid var(--cc-panel-divider)',
+        ...(isPlacing && { outline: '2px solid var(--cc-mint)', outlineOffset: -2 }),
+      }}
     >
       {thumbs && thumbs.length > 0 && onLocateCreature && (
         <div
@@ -1149,6 +1170,37 @@ function GuideEntry({
             <br />
             <strong style={{ fontWeight: 600 }}>Eaten by:</strong>{' '}
             {eatenBy.length > 0 ? eatenBy.map(e => e.name).join(', ') : 'nothing here'}
+            {bp.trophicLevel !== undefined && (
+              <>
+                <br />
+                <strong style={{ fontWeight: 600 }}>Trophic level:</strong>{' '}
+                {bp.trophicLevel === 1 ? 'Producer (1)' : bp.trophicLevel === 2 ? 'Herbivore (2)' : bp.trophicLevel === 3 ? 'Carnivore (3)' : `Apex (${bp.trophicLevel})`}
+                {keystoneSpeciesIds?.has(bp.id) && (
+                  <span
+                    style={{
+                      marginLeft: 6,
+                      fontSize: 10,
+                      padding: '1px 5px',
+                      borderRadius: 4,
+                      background: 'var(--cc-primary)',
+                      color: '#fff',
+                      fontWeight: 700,
+                      letterSpacing: 0.5,
+                    }}
+                  >
+                    KEYSTONE
+                  </span>
+                )}
+              </>
+            )}
+            {bp.successionStage !== undefined && (
+              <>
+                <br />
+                <strong style={{ fontWeight: 600 }}>Succession stage:</strong>{' '}
+                {bp.successionStage === 1 ? 'Pioneer' : bp.successionStage === 2 ? 'Early' : bp.successionStage === 3 ? 'Mid' : 'Climax'}
+                {' '}({bp.successionStage}/4)
+              </>
+            )}
             {bp.symbiosisPartnerId && (() => {
               const partner = blueprints.find(b => b.id === bp.symbiosisPartnerId)
               return partner ? (

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -117,6 +117,8 @@ export function Hud({ onOpenHistory }: { onOpenHistory: () => void }) {
   const replaySnapshots = useMicroLand(s => s.replaySnapshots)
   const soundEnabled = useMicroLand(s => s.soundEnabled)
   const setSoundEnabled = useMicroLand(s => s.setSoundEnabled)
+  const tempOverlayEnabled = useMicroLand(s => s.tempOverlayEnabled)
+  const setTempOverlayEnabled = useMicroLand(s => s.setTempOverlayEnabled)
 
   const setSummonOpen = useMicroLand(s => s.setSummonOpen)
   const tool = useMicroLand(s => s.tool)
@@ -574,6 +576,23 @@ export function Hud({ onOpenHistory }: { onOpenHistory: () => void }) {
                 title="Toggle ambient sound"
               >
                 {soundEnabled ? 'Sound on' : 'Sound off'}
+              </button>
+
+              {/* Temperature overlay */}
+              <button
+                type="button"
+                className="cc-btn"
+                onClick={() => setTempOverlayEnabled(!tempOverlayEnabled)}
+                aria-pressed={tempOverlayEnabled}
+                title="Show a temperature gradient overlay across the world"
+                style={{
+                  ...overflowItem,
+                  ...(tempOverlayEnabled
+                    ? { borderColor: 'var(--cc-mint)', color: 'var(--cc-mint)', background: 'rgba(100,220,200,0.08)' }
+                    : {}),
+                }}
+              >
+                {tempOverlayEnabled ? 'Temp overlay on' : 'Temp overlay'}
               </button>
 
               {/* Settings */}

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -82,6 +82,7 @@ export function Toolbar({
 }) {
   const tool = useMicroLand(s => s.tool)
   const setTool = useMicroLand(s => s.setTool)
+  const setSidebar = useMicroLand(s => s.setSidebar)
   const brush = useMicroLand(s => s.brush)
   const setBrush = useMicroLand(s => s.setBrush)
   const brushShape = useMicroLand(s => s.brushShape)
@@ -821,11 +822,14 @@ export function Toolbar({
                   key={bp.id}
                   type="button"
                   className="cc-btn shrink-0"
-                  onClick={() =>
-                    removable
-                      ? onRemoveSpecies(bp.id)
-                      : setTool({ kind: 'creature', blueprintId: bp.id })
-                  }
+                  onClick={() => {
+                    if (removable) {
+                      onRemoveSpecies(bp.id)
+                    } else {
+                      setTool({ kind: 'creature', blueprintId: bp.id })
+                      setSidebar('guide')
+                    }
+                  }}
                   aria-pressed={removable ? undefined : selected}
                   aria-label={removable ? `Remove ${bp.name}` : undefined}
                   title={removable ? `Remove ${bp.name}` : bp.blurb}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -223,6 +223,9 @@ export class GameInstance {
   private heatmapCurrentBpId: string | null = null
   private heatmapTickCounter = 0
 
+  // --- temperature overlay ---
+  private tempHeatmap: Float32Array | null = null
+
   // --- pointer state ---
   private pointerDown = false
   private grabbed: Creature | null = null
@@ -382,7 +385,7 @@ export class GameInstance {
       const replayWorld = { ...this.world, creatures: snap.creatures }
       this.renderer.render(replayWorld, theme, undefined, undefined, null)
     } else {
-      this.renderer.render(this.world, theme, this.inspectedId, this.elderId, this.heatmap)
+      this.renderer.render(this.world, theme, this.inspectedId, this.elderId, this.heatmap, this.tempHeatmap)
     }
   }
 
@@ -493,6 +496,44 @@ export class GameInstance {
           const ty = Math.max(0, Math.min(WORLD_H - 1, Math.round(c.y)))
           this.heatmap[ty * WORLD_W + tx] += 1
         }
+      }
+
+      // --- temperature overlay ---
+      const tempEnabled = useMicroLand.getState().tempOverlayEnabled
+      if (tempEnabled) {
+        if (!this.tempHeatmap) this.tempHeatmap = new Float32Array(WORLD_W * WORLD_H)
+        const seasonFactor = 1 + TUNING.seasonAmplitude * Math.sin(2 * Math.PI * w.elapsed / (TUNING.seasonPeriod * 60))
+        const lavaIdx = MATERIAL_INDEX['lava'] ?? -1
+        for (let y = 0; y < WORLD_H; y++) {
+          // Warmer at the bottom (higher y in tile coords = deeper underground = warmer)
+          const baseFraction = y / WORLD_H
+          const baseTemp = baseFraction * 0.8 * seasonFactor
+          for (let x = 0; x < WORLD_W; x++) {
+            this.tempHeatmap[y * WORLD_W + x] = Math.max(0, Math.min(1, baseTemp))
+          }
+        }
+        // Lava tiles add local heat plumes
+        if (lavaIdx >= 0 && w.tiles) {
+          for (let i = 0; i < w.tiles.length; i++) {
+            if (w.tiles[i] !== lavaIdx) continue
+            const lx = i % WORLD_W
+            const ly = Math.floor(i / WORLD_W)
+            for (let dy = -3; dy <= 3; dy++) {
+              for (let dx = -3; dx <= 3; dx++) {
+                const dist = Math.max(Math.abs(dx), Math.abs(dy))
+                const nx = (lx + dx + WORLD_W) % WORLD_W
+                const ny = ly + dy
+                if (ny < 0 || ny >= WORLD_H) continue
+                const boost = 1 - dist * 0.25
+                if (boost <= 0) continue
+                const idx = ny * WORLD_W + nx
+                this.tempHeatmap[idx] = Math.min(1, this.tempHeatmap[idx] + boost)
+              }
+            }
+          }
+        }
+      } else {
+        this.tempHeatmap = null
       }
     }
   }
@@ -868,6 +909,11 @@ export class GameInstance {
       })
     } else {
       useMicroLand.getState().setNetworkStats(null)
+    }
+
+    // Push keystone species set to the store for Field Guide display. Issue #3122.
+    if (this.world.keystoneSpeciesIds) {
+      useMicroLand.getState().setKeystoneSpeciesIds(this.world.keystoneSpeciesIds)
     }
 
     // Speed run win/loss detection

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -551,7 +551,8 @@ export class Renderer {
     theme: Theme,
     highlightId: number | null = null,
     elderId: number | null = null,
-    heatmap: Float32Array | null = null
+    heatmap: Float32Array | null = null,
+    tempHeatmap: Float32Array | null = null
   ): void {
     const vx = this.viewLeft()
     const vw = Math.ceil(this.viewTiles)
@@ -597,6 +598,7 @@ export class Renderer {
       this.drawCarcasses(w)
       this.drawNests(w)
       this.drawTombstones(w)
+      if (tempHeatmap) this.drawHeatmap(tempHeatmap, vx, vw, '#ff6600', 0.35)
       if (heatmap) this.drawHeatmap(heatmap, vx, vw)
       this.drawEggs(w)
       this.drawSpawners(w)
@@ -883,7 +885,13 @@ export class Renderer {
     return top + (bottom - top) * ty
   }
 
-  private drawHeatmap(heatmap: Float32Array, vx: number, vw: number): void {
+  private drawHeatmap(
+    heatmap: Float32Array,
+    vx: number,
+    vw: number,
+    color = '#ff3200',
+    maxAlpha = 0.5
+  ): void {
     // Only ever drawn on the un-offset pass: it is a full-column wash rather
     // than a sprite, so it has nothing hanging over the seam to duplicate.
     if (this.drawOffset !== 0) return
@@ -906,8 +914,8 @@ export class Renderer {
         for (let y = 0; y < WORLD_H; y++) {
           const v = heatmap[y * WORLD_W + x]
           if (v < 0.5) continue
-          ctx.globalAlpha = Math.min(0.5, v / peak)
-          ctx.fillStyle = '#ff3200'
+          ctx.globalAlpha = Math.min(maxAlpha, (v / peak) * maxAlpha)
+          ctx.fillStyle = color
           ctx.fillRect(x, y, 1, 1)
         }
       }

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -524,6 +524,12 @@ interface MicroLandState {
     totalLinks: number
   } | null
   setNetworkStats: (stats: { connected: number; isolated: number; clusterCount: number; totalLinks: number } | null) => void
+  /**
+   * Set of blueprint IDs identified as keystone species — those that 2+ other
+   * species depend on. Updated periodically by updateKeystoneSpecies(). Issue #3122.
+   */
+  keystoneSpeciesIds: ReadonlySet<string>
+  setKeystoneSpeciesIds: (ids: ReadonlySet<string>) => void
 
   /**
    * When set, the renderer draws each creature with a color overlay based on
@@ -554,6 +560,9 @@ interface MicroLandState {
   /** The species whose activity is shown as a heatmap overlay; null = off. */
   heatmapBlueprintId: string | null
   setHeatmapBlueprint: (id: string | null) => void
+  /** When true, render a temperature gradient overlay across the world. */
+  tempOverlayEnabled: boolean
+  setTempOverlayEnabled: (enabled: boolean) => void
   soundEnabled: boolean
   setSoundEnabled: (on: boolean) => void
 
@@ -721,6 +730,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   shelf: { worlds: [], activeId: null, busy: false, error: null },
   networkDegree: {},
   networkStats: null,
+  keystoneSpeciesIds: new Set<string>(),
   locateRequest: null,
   populationItems: [],
   invasionFront: {},
@@ -739,6 +749,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   replayIndex: 0,
   trailsEnabled: false,
   heatmapBlueprintId: null,
+  tempOverlayEnabled: false,
   soundEnabled: false,
 
   setTheme: themeId => set({ themeId }),
@@ -861,6 +872,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, sidebar: null }),
   setNetworkDegree: d => set({ networkDegree: d }),
   setNetworkStats: stats => set({ networkStats: stats }),
+  setKeystoneSpeciesIds: ids => set({ keystoneSpeciesIds: ids }),
   setPopulationItems: items => set({ populationItems: items }),
   setInvasionFront: data => set({ invasionFront: data }),
   setBiomeZones: zones => set({ biomeZones: zones }),
@@ -877,6 +889,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setFocusedSpeciesStats: stats => set({ focusedSpeciesStats: stats }),
   setTrailsEnabled: on => set({ trailsEnabled: on }),
   setHeatmapBlueprint: id => set({ heatmapBlueprintId: id }),
+  setTempOverlayEnabled: enabled => set({ tempOverlayEnabled: enabled }),
   setSoundEnabled: on => set({ soundEnabled: on }),
 
   enterReplay: snapshots =>


### PR DESCRIPTION
## Summary
- When a creature species is selected from the toolbar for placement, the Field Guide sidebar automatically opens and scrolls to that species' entry
- The selected species is highlighted with a mint-colored outline so it stands out in the guide list

## Changes
- `toolbar.tsx`: subscribe to `setSidebar`; call `setSidebar('guide')` alongside `setTool` when a creature chip is clicked (non-remove mode)
- `field-guide.tsx`: subscribe to `tool` state; `useEffect` scrolls the matching `[data-blueprint-id]` entry into view when `placingBlueprintId` changes; `GuideEntry` accepts `isPlacing` prop and renders a mint outline; also passes `keystoneSpeciesIds` to `GuideEntry` for keystone badge display (#3122)
- `store.ts`: adds `keystoneSpeciesIds` / `setKeystoneSpeciesIds` state (#3122); `tempOverlayEnabled` (#3380)
- `game-instance.ts`: pushes `keystoneSpeciesIds` to store on stats tick (#3122)
- `renderer.ts`: accepts optional `tempHeatmap` parameter for temperature overlay (#3380)

Closes #3104