### PR TITLE
feat(micro-land): temperature heat-map overlay — shows thermal gradient across world (#3083)

### DIFF
--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -117,6 +117,8 @@ export function Hud({ onOpenHistory }: { onOpenHistory: () => void }) {
   const replaySnapshots = useMicroLand(s => s.replaySnapshots)
   const soundEnabled = useMicroLand(s => s.soundEnabled)
   const setSoundEnabled = useMicroLand(s => s.setSoundEnabled)
+  const tempOverlayEnabled = useMicroLand(s => s.tempOverlayEnabled)
+  const setTempOverlayEnabled = useMicroLand(s => s.setTempOverlayEnabled)
 
   const setSummonOpen = useMicroLand(s => s.setSummonOpen)
   const tool = useMicroLand(s => s.tool)
@@ -574,6 +576,23 @@ export function Hud({ onOpenHistory }: { onOpenHistory: () => void }) {
                 title="Toggle ambient sound"
               >
                 {soundEnabled ? 'Sound on' : 'Sound off'}
+              </button>
+
+              {/* Temperature overlay */}
+              <button
+                type="button"
+                className="cc-btn"
+                onClick={() => setTempOverlayEnabled(!tempOverlayEnabled)}
+                aria-pressed={tempOverlayEnabled}
+                title="Show a temperature gradient overlay across the world"
+                style={{
+                  ...overflowItem,
+                  ...(tempOverlayEnabled
+                    ? { borderColor: 'var(--cc-mint)', color: 'var(--cc-mint)', background: 'rgba(100,220,200,0.08)' }
+                    : {}),
+                }}
+              >
+                {tempOverlayEnabled ? 'Temp overlay on' : 'Temp overlay'}
               </button>
 
               {/* Settings */}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -223,6 +223,9 @@ export class GameInstance {
   private heatmapCurrentBpId: string | null = null
   private heatmapTickCounter = 0
 
+  // --- temperature overlay ---
+  private tempHeatmap: Float32Array | null = null
+
   // --- pointer state ---
   private pointerDown = false
   private grabbed: Creature | null = null
@@ -382,7 +385,7 @@ export class GameInstance {
       const replayWorld = { ...this.world, creatures: snap.creatures }
       this.renderer.render(replayWorld, theme, undefined, undefined, null)
     } else {
-      this.renderer.render(this.world, theme, this.inspectedId, this.elderId, this.heatmap)
+      this.renderer.render(this.world, theme, this.inspectedId, this.elderId, this.heatmap, this.tempHeatmap)
     }
   }
 
@@ -493,6 +496,44 @@ export class GameInstance {
           const ty = Math.max(0, Math.min(WORLD_H - 1, Math.round(c.y)))
           this.heatmap[ty * WORLD_W + tx] += 1
         }
+      }
+
+      // --- temperature overlay ---
+      const tempEnabled = useMicroLand.getState().tempOverlayEnabled
+      if (tempEnabled) {
+        if (!this.tempHeatmap) this.tempHeatmap = new Float32Array(WORLD_W * WORLD_H)
+        const seasonFactor = 1 + TUNING.seasonAmplitude * Math.sin(2 * Math.PI * w.elapsed / (TUNING.seasonPeriod * 60))
+        const lavaIdx = MATERIAL_INDEX['lava'] ?? -1
+        for (let y = 0; y < WORLD_H; y++) {
+          // Warmer at the bottom (higher y in tile coords = deeper underground = warmer)
+          const baseFraction = y / WORLD_H
+          const baseTemp = baseFraction * 0.8 * seasonFactor
+          for (let x = 0; x < WORLD_W; x++) {
+            this.tempHeatmap[y * WORLD_W + x] = Math.max(0, Math.min(1, baseTemp))
+          }
+        }
+        // Lava tiles add local heat plumes
+        if (lavaIdx >= 0 && w.tiles) {
+          for (let i = 0; i < w.tiles.length; i++) {
+            if (w.tiles[i] !== lavaIdx) continue
+            const lx = i % WORLD_W
+            const ly = Math.floor(i / WORLD_W)
+            for (let dy = -3; dy <= 3; dy++) {
+              for (let dx = -3; dx <= 3; dx++) {
+                const dist = Math.max(Math.abs(dx), Math.abs(dy))
+                const nx = (lx + dx + WORLD_W) % WORLD_W
+                const ny = ly + dy
+                if (ny < 0 || ny >= WORLD_H) continue
+                const boost = 1 - dist * 0.25
+                if (boost <= 0) continue
+                const idx = ny * WORLD_W + nx
+                this.tempHeatmap[idx] = Math.min(1, this.tempHeatmap[idx] + boost)
+              }
+            }
+          }
+        }
+      } else {
+        this.tempHeatmap = null
       }
     }
   }

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -551,7 +551,8 @@ export class Renderer {
     theme: Theme,
     highlightId: number | null = null,
     elderId: number | null = null,
-    heatmap: Float32Array | null = null
+    heatmap: Float32Array | null = null,
+    tempHeatmap: Float32Array | null = null
   ): void {
     const vx = this.viewLeft()
     const vw = Math.ceil(this.viewTiles)
@@ -597,6 +598,7 @@ export class Renderer {
       this.drawCarcasses(w)
       this.drawNests(w)
       this.drawTombstones(w)
+      if (tempHeatmap) this.drawHeatmap(tempHeatmap, vx, vw, '#ff6600', 0.35)
       if (heatmap) this.drawHeatmap(heatmap, vx, vw)
       this.drawEggs(w)
       this.drawSpawners(w)
@@ -883,7 +885,13 @@ export class Renderer {
     return top + (bottom - top) * ty
   }
 
-  private drawHeatmap(heatmap: Float32Array, vx: number, vw: number): void {
+  private drawHeatmap(
+    heatmap: Float32Array,
+    vx: number,
+    vw: number,
+    color = '#ff3200',
+    maxAlpha = 0.5
+  ): void {
     // Only ever drawn on the un-offset pass: it is a full-column wash rather
     // than a sprite, so it has nothing hanging over the seam to duplicate.
     if (this.drawOffset !== 0) return
@@ -906,8 +914,8 @@ export class Renderer {
         for (let y = 0; y < WORLD_H; y++) {
           const v = heatmap[y * WORLD_W + x]
           if (v < 0.5) continue
-          ctx.globalAlpha = Math.min(0.5, v / peak)
-          ctx.fillStyle = '#ff3200'
+          ctx.globalAlpha = Math.min(maxAlpha, (v / peak) * maxAlpha)
+          ctx.fillStyle = color
           ctx.fillRect(x, y, 1, 1)
         }
       }

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -554,6 +554,9 @@ interface MicroLandState {
   /** The species whose activity is shown as a heatmap overlay; null = off. */
   heatmapBlueprintId: string | null
   setHeatmapBlueprint: (id: string | null) => void
+  /** When true, render a temperature gradient overlay across the world. */
+  tempOverlayEnabled: boolean
+  setTempOverlayEnabled: (enabled: boolean) => void
   soundEnabled: boolean
   setSoundEnabled: (on: boolean) => void
 
@@ -739,6 +742,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   replayIndex: 0,
   trailsEnabled: false,
   heatmapBlueprintId: null,
+  tempOverlayEnabled: false,
   soundEnabled: false,
 
   setTheme: themeId => set({ themeId }),
@@ -877,6 +881,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setFocusedSpeciesStats: stats => set({ focusedSpeciesStats: stats }),
   setTrailsEnabled: on => set({ trailsEnabled: on }),
   setHeatmapBlueprint: id => set({ heatmapBlueprintId: id }),
+  setTempOverlayEnabled: enabled => set({ tempOverlayEnabled: enabled }),
   setSoundEnabled: on => set({ soundEnabled: on }),
 
   enterReplay: snapshots =>


### PR DESCRIPTION
## Summary
- Store: `tempOverlayEnabled` boolean state + `setTempOverlayEnabled` setter
- Game instance: builds temperature approximation from Y-position (altitude) + season factor + lava heat sources, every 5 ticks
- Renderer: new `tempHeatmap` parameter to `render()`; draws with orange (`#ff6600`) at 35% opacity via the existing `drawHeatmap` infrastructure (now accepts `color` and `maxAlpha` params)
- UI: "Temp overlay" toggle button in the overflow (···) menu in the HUD, follows existing Sound/Settings button patterns

## Temperature model
Until per-tile temperature physics is merged, the overlay uses a proxy model:
- Y-position determines base temperature (bottom=warm, top=cold), scaled 0–0.8
- Season factor modulates overall warmth (when `seasonAmplitude > 0`)
- Lava tiles create local heat plumes radiating 3 tiles out

## Test plan
- [ ] Open Micro Land, click ··· menu — "Temp overlay" button appears between Sound and Settings
- [ ] Toggle it on — warm lower portion of world gets a subtle orange tint
- [ ] Add lava tiles — bright orange spots appear around them
- [ ] Toggle it off — overlay disappears
- [ ] Verify creature activity heatmap (via Field Guide species heatmap) still works independently and remains red
- [ ] Verify replay mode shows no overlay (correct — replay passes null explicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)