### PR TITLE
chore(micro-land): clear the type backlog and let the compiler stop the next one

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,19 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  // TODO: Remove once all TypeScript strict-mode errors are resolved.
-  // See issue #2719 for tracking.
-  typescript: {
-    ignoreBuildErrors: true,
-  },
+  // `typescript.ignoreBuildErrors` used to be set here, with a TODO pointing at
+  // issue #2719. It is gone, and it should stay gone.
+  //
+  // What it cost: `tsc` had correctly reported
+  // "Block-scoped variable 'isPlant' used before its declaration" and two
+  // "Cannot find name" errors in the micro-land simulation. All three were
+  // guaranteed runtime ReferenceErrors, all three built cleanly because of this
+  // flag, and all three shipped — freezing /micro-land for every visitor the
+  // moment their world grew its first plant. The compiler had the answer the
+  // whole time and was told not to interrupt.
+  //
+  // The backlog it was covering for is cleared. `npm run typecheck` is clean;
+  // a new type error now fails the build instead of becoming a bug report.
   images: {
     remotePatterns: [
       {

--- a/scripts/micro-land-sim.ts
+++ b/scripts/micro-land-sim.ts
@@ -84,8 +84,6 @@ interface RunResult {
   meals: Record<string, { plants: number; animals: number }>
   /** Share of the world still made of something, 0..1. */
   solidFraction: number
-  /** Tiles tunnelled through by creatures still alive at the end. */
-  dug: number
   /**
    * blueprintId → what its survivors inherited, averaged.
    *
@@ -161,11 +159,13 @@ function runOnce(seed: number): RunResult {
     }
   }
 
-  // How much of the map got eaten by diggers? A tunnel network is the point;
-  // a world with no walls left is a bug.
+  // How much of the map is still standing? A world with no walls left is a bug.
+  //
+  // The companion "tunnelled" figure is gone: it summed `creature.tilesDug`,
+  // which stopped existing when digging was removed, so the harness had been
+  // printing `NaN tiles` on every run since.
   let solidLeft = 0
   for (let i = 0; i < world.tiles.length; i++) if (world.tiles[i] !== 0) solidLeft++
-  const dug = world.creatures.reduce((a, c) => a + c.tilesDug, 0)
 
   const survivors = countByBlueprint(world)
   const extinctions = [...seeded].filter(id => !survivors[id])
@@ -197,7 +197,6 @@ function runOnce(seed: number): RunResult {
     deaths,
     meals,
     solidFraction: solidLeft / world.tiles.length,
-    dug,
     drift,
   }
 }
@@ -286,9 +285,6 @@ console.log(`  low water mark    ${avgMin.toFixed(0)}`)
 console.log(`  alive at the end  ${(totalAlive / runs).toFixed(0)}`)
 console.log(
   `  world still solid ${((results.reduce((a, r) => a + r.solidFraction, 0) / runs) * 100).toFixed(0)}%`
-)
-console.log(
-  `  tunnelled (live)  ${(results.reduce((a, r) => a + r.dug, 0) / runs).toFixed(0)} tiles`
 )
 console.log(
   totalAlive === 0

--- a/src/app/micro-land/components/blueprint-workshop.tsx
+++ b/src/app/micro-land/components/blueprint-workshop.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useMicroLand } from '@/app/micro-land/store'
+import { neutralTraits } from '@/app/micro-land/domain/traits'
 import type { CreatureBlueprint, Traits } from '@/app/micro-land/domain/types'
 
 const TRAIT_DEFS: Array<{ key: keyof Traits; label: string; min: number; max: number; step: number; neutral: number }> = [
@@ -31,13 +32,10 @@ function traitColor(hue: number, shade: number): string {
   return `hsl(${Math.round(hue)}, 60%, ${lightness}%)`
 }
 
-function defaultTraits(): Traits {
-  return {
-    speed: 1, sight: 1, lifespan: 1, hue: 0, shade: 1,
-    roam: 1, territorial: 0.5, size: 1, camouflage: 0.2,
-    toxicity: 0, cooperation: 0.3, immunity: 0.2,
-  }
-}
+// Was a hand-written copy of the neutral set, and had already fallen two traits
+// behind it. There is exactly one definition of "neutral" and it lives in
+// `traits.ts`.
+const defaultTraits = neutralTraits
 
 /**
  * Build a creature out of one already here: pick a base, then move its numbers.

--- a/src/app/micro-land/domain/__tests__/competitive-exclusion.test.ts
+++ b/src/app/micro-land/domain/__tests__/competitive-exclusion.test.ts
@@ -17,9 +17,10 @@ import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
 import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
 import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import type { SimEvent } from '@/app/micro-land/domain/sim/creature-sim'
 import { makeRng } from '@/app/micro-land/domain/sim/prng'
 import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
-import type { CreatureBlueprint, SimEvent, WorldState } from '@/app/micro-land/domain/types'
+import type { CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
 
 function mudWorld(): WorldState {
   const w = createWorld(5)

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -483,6 +483,7 @@ export function sanitizeBlueprint(
   const move = (b.move ?? {}) as Record<string, unknown>
   const diet = (b.diet ?? {}) as Record<string, unknown>
   const senses = (b.senses ?? {}) as Record<string, unknown>
+  const phenology = (b.phenology ?? {}) as Record<string, unknown>
   const habitat = (b.habitat ?? {}) as Record<string, unknown>
   const death = (b.death ?? {}) as Record<string, unknown>
 
@@ -714,9 +715,14 @@ export function sanitizeBlueprint(
     canLearnFoodWashing: !!b.canLearnFoodWashing,
     canInnovateTechniques: b.canInnovateTechniques !== undefined ? !!b.canInnovateTechniques : undefined,
     elderWisdom: !!b.elderWisdom,
-    phenology: b.phenology?.breedingGdd !== undefined
-      ? { breedingGdd: Math.max(0, Math.min(1000, b.phenology.breedingGdd)) }
-      : undefined,
+    // Narrowed by `typeof` rather than tested against `undefined`: `raw` is
+    // hostile input, and a `breedingGdd` of "soon" passes an !== undefined check
+    // and then comes out of Math.min as NaN — which, on a gate that decides
+    // whether a species may breed at all, is a species that never breeds again.
+    phenology:
+      typeof phenology.breedingGdd === 'number' && Number.isFinite(phenology.breedingGdd)
+        ? { breedingGdd: Math.max(0, Math.min(1000, phenology.breedingGdd)) }
+        : undefined,
     brainSize:
       typeof b.brainSize === 'number' && b.brainSize >= 0 && b.brainSize <= 1
         ? b.brainSize
@@ -765,10 +771,9 @@ export function sanitizeBlueprint(
         : undefined,
     toxic: b.toxic !== undefined ? !!b.toxic : undefined,
     toxicMimic: b.toxicMimic !== undefined ? !!b.toxicMimic : undefined,
-    otterOligarchy: typeof b.otterOligarchy === 'boolean' ? b.otterOligarchy : undefined,
-    squirrelSocialism: typeof b.squirrelSocialism === 'boolean' ? b.squirrelSocialism : undefined,
-    voleVoting: typeof b.voleVoting === 'boolean' ? b.voleVoting : undefined,
-    weaselTribunal: typeof b.weaselTribunal === 'boolean' ? b.weaselTribunal : undefined,
+    // The four polity flags are set once, above. They were duplicated here
+    // verbatim — harmless, since both copies computed the same value, but the
+    // second silently shadowed the first.
   }
 }
 

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1338,7 +1338,10 @@ export function tickCreatures(
     }
 
     // Quicksand: walkers progressively slow and die after 12 s if they can't escape.
-    if (bp.body.locomotion === 'walk') {
+    // `move.kind`, not the `body.locomotion` this used to read — that field went
+    // away with the digging feature, so this whole quicksand branch had been
+    // dead since. Walkers sink again.
+    if (bp.move.kind === 'walk') {
       const qs_fx = Math.floor(c.x + body.dx + body.w / 2)
       const qs_fy = Math.floor(c.y + body.dy + body.h)
       if (MATERIAL_BY_INDEX[tileAt(w, qs_fx, qs_fy)]?.id === 'quicksand') {

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -1040,11 +1040,18 @@ export function tickLight(w: WorldState, tickCount: number): void {
       if (IS_SOLID[tileIdx] === 1) {
         light *= 0.25
       } else {
-        // Semi-solid tiles (plants, water) attenuate light partially. Issue #3170.
+        // Semi-solid tiles attenuate light partially. Issue #3170.
+        //
+        // Only `moss` and `grass` are checked because they are the only growth
+        // materials in the table. This originally also tested 'plant',
+        // 'leaves', 'fern' and 'flower', none of which are materials — plants
+        // are *creatures* here, not tiles, so a plant can never appear in the
+        // grid. Those branches were unreachable and are gone; shading from
+        // standing vegetation would have to read `w.creatures` instead.
         const matId = MATERIAL_BY_INDEX[tileIdx]?.id
-        if (matId === 'plant' || matId === 'leaves' || matId === 'moss' || matId === 'fern' || matId === 'grass' || matId === 'flower') {
+        if (matId === 'moss' || matId === 'grass') {
           light *= 0.6  // canopy plants reduce light by 40%
-        } else if (matId === 'water' || matId === 'salt-water') {
+        } else if (matId === 'water') {
           light *= 0.85  // water reduces light by 15%
         }
       }
@@ -1484,7 +1491,9 @@ export function tickAcidRain(w: WorldState, tickCount: number, _rng: () => numbe
   for (let i = 0; i < w.tiles.length; i++) {
     const matId = MATERIAL_BY_INDEX[w.tiles[i]]?.id
     if (matId === 'lava') sulfurEmitted += 0.0004
-    if (matId === 'marble' || matId === 'limestone') limestoneCount++
+    // `marble` is the only carbonate in the material table — the 'limestone'
+    // this used to also test is not a material and never matched.
+    if (matId === 'marble') limestoneCount++
   }
 
   // --- Step 2: Update atmospheric sulfur (decays naturally, buffered by limestone) ---
@@ -1500,7 +1509,8 @@ export function tickAcidRain(w: WorldState, tickCount: number, _rng: () => numbe
 
   for (let i = 0; i < w.tiles.length; i++) {
     const matId = MATERIAL_BY_INDEX[w.tiles[i]]?.id
-    const isWater = matId === 'water' || matId === 'salt-water'
+    // 'salt-water' is not a material; `water` is the only liquid water here.
+    const isWater = matId === 'water'
     const isMoist = (w.moisture?.[i] ?? 0) > 0.5
 
     if (!isWater && !isMoist) continue
@@ -1515,7 +1525,7 @@ export function tickAcidRain(w: WorldState, tickCount: number, _rng: () => numbe
       const ni = (y + dy) * w.width + (x + dx)
       if (ni >= 0 && ni < w.tiles.length) {
         const nMat = MATERIAL_BY_INDEX[w.tiles[ni]]?.id
-        if (nMat === 'marble' || nMat === 'limestone') {
+        if (nMat === 'marble') {
           w.tilePH[i] = Math.min(7.0, w.tilePH[i] + 0.3)
           break
         }

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -91,6 +91,34 @@ export function neutralTraits(): Traits {
   return { ...NEUTRAL_TRAITS }
 }
 
+/**
+ * The range each trait is allowed to occupy.
+ *
+ * One table rather than bounds written out at each site. `inherit` clamps a
+ * newborn into these, and the save loader clamps a stored one back into them on
+ * the way in; the two quietly disagreeing is exactly how a world starts
+ * changing its own creatures a little every time it is reopened.
+ *
+ * `hue` is absent on purpose — it is an angle and wraps, so it has no bounds to
+ * clamp to. See `wrapHue`.
+ */
+export const TRAIT_BOUNDS: Record<Exclude<keyof Traits, 'hue'>, { min: number; max: number }> = {
+  speed: { min: TRAIT_MIN, max: TRAIT_MAX },
+  sight: { min: TRAIT_MIN, max: TRAIT_MAX },
+  lifespan: { min: TRAIT_MIN, max: TRAIT_MAX },
+  shade: { min: SHADE_MIN, max: SHADE_MAX },
+  roam: { min: TRAIT_MIN, max: TRAIT_MAX },
+  territorial: { min: 0.1, max: 1.4 },
+  size: { min: 0.8, max: 1.2 },
+  camouflage: { min: 0, max: 0.8 },
+  toxicity: { min: 0, max: 1 },
+  cooperation: { min: 0, max: 1 },
+  diurnal: { min: -1, max: 1 },
+  immunity: { min: 0, max: 1 },
+  reproductionCooldown: { min: TRAIT_MIN, max: TRAIT_MAX },
+  chronotype: { min: -1, max: 1 },
+}
+
 function clamp(v: number, lo: number, hi: number): number {
   return v < lo ? lo : v > hi ? hi : v
 }
@@ -134,22 +162,26 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity' | 'reproductionCooldown' | 'chronotype') =>
     b ? ((a[key] ?? 0) + (b[key] ?? 0)) / 2 : (a[key] ?? 0)
 
+  /** Blend, nudge, and clamp back into the trait's own range. */
+  const drifted = (key: Exclude<keyof Traits, 'hue'>) =>
+    clamp(mix(key) + nudge(rng, drift), TRAIT_BOUNDS[key].min, TRAIT_BOUNDS[key].max)
+
   return {
-    speed: clamp(mix('speed') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
-    sight: clamp(mix('sight') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
-    lifespan: clamp(mix('lifespan') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
+    speed: drifted('speed'),
+    sight: drifted('sight'),
+    lifespan: drifted('lifespan'),
     hue: wrapHue((b ? blendHue(a.hue, b.hue) : a.hue) + nudge(rng, hueDrift)),
-    shade: clamp(mix('shade') + nudge(rng, drift), SHADE_MIN, SHADE_MAX),
-    roam: clamp(mix('roam') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
-    territorial: clamp(mix('territorial') + nudge(rng, drift), 0.1, 1.4),
-    size: clamp(mix('size') + nudge(rng, drift), 0.8, 1.2),
-    camouflage: clamp(mix('camouflage') + nudge(rng, drift), 0, 0.8),
-    toxicity: clamp(mix('toxicity') + nudge(rng, drift), 0, 1),
-    cooperation: clamp(mix('cooperation') + nudge(rng, drift), 0, 1),
-    diurnal: clamp(mix('diurnal') + nudge(rng, drift), -1, 1),
-    immunity: clamp(mix('immunity') + nudge(rng, drift), 0, 1),
-    reproductionCooldown: clamp(mix('reproductionCooldown') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
-    chronotype: clamp(mix('chronotype') + nudge(rng, drift), -1, 1),
+    shade: drifted('shade'),
+    roam: drifted('roam'),
+    territorial: drifted('territorial'),
+    size: drifted('size'),
+    camouflage: drifted('camouflage'),
+    toxicity: drifted('toxicity'),
+    cooperation: drifted('cooperation'),
+    diurnal: drifted('diurnal'),
+    immunity: drifted('immunity'),
+    reproductionCooldown: drifted('reproductionCooldown'),
+    chronotype: drifted('chronotype'),
   }
 }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1103,6 +1103,11 @@ export interface CreatureBlueprint {
  * `biomeZoneAt(w, y)` returns one of these based on the tile's y-row.
  * Zones map the world's height into rough latitudinal bands: the sky rows
  * are the warmest (tropical), the deep underground rows are the coldest (ice-cap).
+ *
+ * This is also the Whittaker classification assigned per horizontal region
+ * band (issue #3377) — that landed as a second, byte-identical copy of this
+ * union further down the file, which is a redeclaration rather than a new
+ * type. One declaration, two readings of it.
  */
 export type BiomeZoneType =
   | 'tropical-rainforest'
@@ -1762,21 +1767,6 @@ export interface WorldGeneratorEntry {
    */
   nextSeed: number
 }
-
-/**
- * Whittaker biome classification — one of eight climate zones.
- * Assigned per horizontal region band (8 bands from sky to bedrock).
- * Issue #3377.
- */
-export type BiomeZoneType =
-  | 'tropical-rainforest'
-  | 'tropical-savanna'
-  | 'desert'
-  | 'temperate-grassland'
-  | 'temperate-forest'
-  | 'boreal'
-  | 'tundra'
-  | 'ice-cap'
 
 /** One classified biome band — a full-width horizontal slice of the world. */
 export interface BiomeZone {

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -1233,7 +1233,10 @@ export class Renderer {
       }
 
       if (traitKey) {
-        const delta = ((c.traits as Record<string, number>)[traitKey] ?? 1) - 1.0
+        // Double cast because `Traits` has no index signature — the heatmap
+        // picks its trait by string key at runtime, so this is a genuine
+        // dynamic read rather than a mistake.
+        const delta = ((c.traits as unknown as Record<string, number>)[traitKey] ?? 1) - 1.0
         if (Math.abs(delta) >= 0.08) {
           const alpha = Math.min(0.6, Math.abs(delta) * 1.2).toFixed(2)
           ctx.globalAlpha = parseFloat(alpha)
@@ -1270,10 +1273,13 @@ export class Renderer {
       if (!this.onScreen(c.x - 8, 16)) continue
 
       const dots: string[] = []
-      if ((c as { sick?: number }).sick) dots.push('#a855f7')
+      // These three are required on `Creature`; the widening casts that used to
+      // be here dated from when they were not, and re-introduced the very
+      // `undefined` they were meant to guard against.
+      if (c.sick) dots.push('#a855f7')
       if (c.starving > 0) dots.push('#f97316')
-      if ((c as { poisoned?: number }).poisoned > 0) dots.push('#84cc16')
-      if ((c as { stunTimer?: number }).stunTimer > 0) dots.push('#facc15')
+      if (c.poisoned > 0) dots.push('#84cc16')
+      if (c.stunTimer > 0) dots.push('#facc15')
       if (c.distress > 1) dots.push('#60a5fa')
       if (dots.length === 0) continue
 

--- a/src/app/micro-land/worlds/__tests__/snapshot.test.ts
+++ b/src/app/micro-land/worlds/__tests__/snapshot.test.ts
@@ -4,6 +4,7 @@ import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
 import { MATERIAL_IDS, MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
 import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import { neutralTraits } from '@/app/micro-land/domain/traits'
 import {
   decodeTiles,
   encodeTiles,
@@ -118,7 +119,20 @@ describe('freezing and thawing a world', () => {
    */
   it('brings back what each creature inherited', () => {
     const { w } = populatedWorld()
-    w.creatures[0].traits = { speed: 1.37, sight: 0.72, lifespan: 1.15, hue: 214, shade: 0.9 }
+    // Spread over neutral rather than written out: the trait set has grown from
+    // five to fourteen, and a hand-written literal here is what stopped this
+    // test noticing that the save format had been silently dropping nine of
+    // them. `toxicity` and `camouflage` are asserted below for that reason.
+    w.creatures[0].traits = {
+      ...neutralTraits(),
+      speed: 1.37,
+      sight: 0.72,
+      lifespan: 1.15,
+      hue: 214,
+      shade: 0.9,
+      toxicity: 0.61,
+      camouflage: 0.44,
+    }
 
     const fresh = createWorld(1)
     restoreSnapshot(fresh, snapshotWorld(w))
@@ -129,15 +143,13 @@ describe('freezing and thawing a world', () => {
     expect(first.traits.lifespan).toBeCloseTo(1.15, 2)
     expect(first.traits.hue).toBeCloseTo(214, 0)
     expect(first.traits.shade).toBeCloseTo(0.9, 2)
+    // The two that were being dropped. Not decoration: these fail against the
+    // old five-field save format and pass against the current one.
+    expect(first.traits.toxicity).toBeCloseTo(0.61, 2)
+    expect(first.traits.camouflage).toBeCloseTo(0.44, 2)
     // Untouched creatures stay exactly their species, which is what makes a
     // placed creature and a born one different things.
-    expect(fresh.creatures[1].traits).toEqual({
-      speed: 1,
-      sight: 1,
-      lifespan: 1,
-      hue: 0,
-      shade: 1,
-    })
+    expect(fresh.creatures[1].traits).toEqual(neutralTraits())
   })
 
   it('thaws a world saved before creatures inherited anything into neutral ones', () => {

--- a/src/app/micro-land/worlds/snapshot.ts
+++ b/src/app/micro-land/worlds/snapshot.ts
@@ -24,7 +24,8 @@ import { MATERIAL_IDS } from '@/app/micro-land/domain/config/materials'
 import { makeRng } from '@/app/micro-land/domain/sim/prng'
 import { registerBlueprint } from '@/app/micro-land/domain/sim/world'
 import { neutralTraits } from '@/app/micro-land/domain/traits'
-import type { Creature, CreatureMood, WorldState } from '@/app/micro-land/domain/types'
+import type { Creature, CreatureMood, Traits, WorldState } from '@/app/micro-land/domain/types'
+import { wrapCol } from '@/app/micro-land/domain/wrap'
 
 import type { SavedCreature, SavedGenerator, SavedSpawner, WorldSnapshot } from './types'
 
@@ -33,6 +34,23 @@ const MOODS: CreatureMood[] = ['wander', 'hunt', 'flee', 'eat', 'rest', 'mate']
 /** Two decimals is a hundredth of a tile — far finer than a pixel can show. */
 function round(n: number): number {
   return Math.round(n * 100) / 100
+}
+
+/**
+ * Round every trait for storage, whatever the trait set currently is.
+ *
+ * Driven off the object's own keys rather than a written-out list, so that a
+ * trait added to `Traits` is saved without anyone having to remember this file.
+ * `hue` is a whole number of degrees; everything else is a multiplier where two
+ * decimals is already finer than the simulation can act on.
+ */
+function roundTraits(traits: Traits): Partial<Traits> {
+  const out: Record<string, number> = {}
+  for (const [key, value] of Object.entries(traits)) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) continue
+    out[key] = key === 'hue' ? Math.round(value) : round(value)
+  }
+  return out as Partial<Traits>
 }
 
 /**
@@ -157,13 +175,14 @@ export function snapshotWorld(w: WorldState): WorldSnapshot {
       // their blueprints would quietly delete every line the player had grown —
       // and it would look like nothing had happened, because the animals would
       // all still be there.
-      traits: {
-        speed: round(c.traits.speed),
-        sight: round(c.traits.sight),
-        lifespan: round(c.traits.lifespan),
-        hue: Math.round(c.traits.hue),
-        shade: round(c.traits.shade),
-      },
+      //
+      // Every trait, not the five this listed by hand until the set grew to
+      // fourteen. The hand-written list did not fail loudly when a trait was
+      // added — it just stopped saving it, and the thaw handed back neutral, so
+      // a shelved world quietly lost its camouflage, toxicity, cooperation and
+      // six others every time it was reopened. Spreading the object means a
+      // trait added later is persisted the day it exists.
+      traits: roundTraits(c.traits),
       name: c.name,
     })),
     blueprints,
@@ -210,9 +229,39 @@ function thaw(saved: SavedCreature): Creature {
     mealsEaten: saved.mealsEaten,
     children: saved.children,
     generation: saved.generation,
-    traits: saved.traits ? { ...saved.traits } : neutralTraits(),
+    // Merged over neutral rather than spread alone: a save written before a
+    // trait existed has no key for it, and `undefined` on a multiplier that
+    // gets multiplied is NaN, not "no effect".
+    traits: { ...neutralTraits(), ...saved.traits },
     name: saved.name,
     huntPassCount: 0,
+
+    // Transient state, rebuilt rather than stored.
+    //
+    // These are all required on `Creature` and none of them were being set
+    // here, so a thawed creature carried `undefined` where the simulation
+    // expects a number — and `undefined - dt` is NaN, which spreads to the
+    // creature's position on the next tick and never comes back. The type
+    // error that would have said so was masked by the trait mismatch directly
+    // above it, which is the whole argument for not having a `tsc` backlog.
+    //
+    // Zero is the honest value for every timer: a world reopens with nobody
+    // mid-stun, mid-migration or mid-symbiosis, and each one refills within a
+    // tick or two of play. `homeX`/`homeY` are the exception — a creature's
+    // home is where it is standing when the world comes back, matching what
+    // `spawnCreature` does for anything placed rather than born.
+    huntBlockedId: null,
+    poisoned: 0,
+    homeX: wrapCol(Math.round(saved.x)),
+    homeY: Math.round(saved.y),
+    migrateTimer: 0,
+    packTimer: 0,
+    sinking: 0,
+    stunTimer: 0,
+    symbiosisTimer: 0,
+    sick: 0,
+    carryingSeed: null,
+    seedTimer: 0,
   }
 }
 

--- a/src/app/micro-land/worlds/types.ts
+++ b/src/app/micro-land/worlds/types.ts
@@ -24,7 +24,7 @@
  * out rather than handed over as-is.
  */
 import type { SanitizedTerrain } from '@/app/micro-land/domain/terrain'
-import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import type { CreatureBlueprint, Traits } from '@/app/micro-land/domain/types'
 
 /**
  * Bump when an old save would be *misread* rather than merely come up short.
@@ -74,8 +74,16 @@ export interface SavedCreature {
    * creatures, which is exactly what the sanitizer does with a missing value —
    * and neutral is the right answer, not a lossy one: a world written before the
    * mechanic existed genuinely had no drift in it.
+   *
+   * `Partial` rather than the full `Traits` for the same reason it is optional:
+   * every save written before a given trait existed is missing it, and there
+   * have been three such waves now. The thaw merges whatever is present over
+   * `neutralTraits()`, so an absent field is neutral rather than undefined.
+   * Spelling the five original traits out here — as this did until the set grew
+   * to fourteen — silently dropped every trait added since on save *and* on
+   * load, which reset nine of them to neutral on every reopen.
    */
-  traits?: { speed: number; sight: number; lifespan: number; hue: number; shade: number }
+  traits?: Partial<Traits>
   name: string | null
 }
 

--- a/src/app/micro-land/worlds/wire.ts
+++ b/src/app/micro-land/worlds/wire.ts
@@ -20,8 +20,8 @@
 import { MATERIAL_IDS } from '@/app/micro-land/domain/config/materials'
 import { PLANT_SEED_INTERVAL, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import { sanitizeTerrain } from '@/app/micro-land/domain/terrain'
-import { SHADE_MAX, SHADE_MIN, TRAIT_MAX, TRAIT_MIN } from '@/app/micro-land/domain/traits'
-import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import { NEUTRAL_TRAITS, TRAIT_BOUNDS } from '@/app/micro-land/domain/traits'
+import type { CreatureBlueprint, Traits } from '@/app/micro-land/domain/types'
 
 import {
   type SavedCreature,
@@ -145,16 +145,25 @@ function validRuns(runs: unknown, tileCount: number): number[] | null {
  */
 function cleanTraits(raw: unknown): SavedCreature['traits'] {
   if (!isPlainObject(raw)) return undefined
-  return {
-    speed: clamp(raw.speed, TRAIT_MIN, TRAIT_MAX, 1),
-    sight: clamp(raw.sight, TRAIT_MIN, TRAIT_MAX, 1),
-    lifespan: clamp(raw.lifespan, TRAIT_MIN, TRAIT_MAX, 1),
-    // Wrapped rather than clamped — hue is an angle, and 370° is 10°, not 360°.
-    hue: ((clamp(raw.hue, -1e6, 1e6, 0) % 360) + 360) % 360,
-    shade: clamp(raw.shade, SHADE_MIN, SHADE_MAX, 1),
-    // roam was added after the first save format; absent in old saves → defaults to 1.
-    roam: clamp(raw.roam, TRAIT_MIN, TRAIT_MAX, 1),
+
+  const out: Partial<Traits> = {}
+
+  // Wrapped rather than clamped — hue is an angle, and 370° is 10°, not 360°.
+  if (raw.hue !== undefined) out.hue = ((clamp(raw.hue, -1e6, 1e6, 0) % 360) + 360) % 360
+
+  // Driven off `TRAIT_BOUNDS` rather than a written-out list, so a trait added
+  // to the set is validated here the day it exists rather than the day someone
+  // notices it is being dropped. A key absent from the save stays absent — the
+  // thaw merges over `neutralTraits()`, which is the one place the default for
+  // a missing trait is decided.
+  for (const key of Object.keys(TRAIT_BOUNDS) as Exclude<keyof Traits, 'hue'>[]) {
+    const value = raw[key]
+    if (value === undefined) continue
+    const { min, max } = TRAIT_BOUNDS[key]
+    out[key] = clamp(value, min, max, NEUTRAL_TRAITS[key] ?? 1)
   }
+
+  return out
 }
 
 function cleanCreature(raw: unknown, index: number): SavedCreature | null {

--- a/src/lib/trivia/__tests__/dailyQuestionsDb.test.ts
+++ b/src/lib/trivia/__tests__/dailyQuestionsDb.test.ts
@@ -131,7 +131,10 @@ describe('setDailyQuestions', () => {
   })
 
   it('calls set with data merged with createdAt', async () => {
-    const setFn = vi.fn(() => Promise.resolve())
+    // Declared with its argument: `vi.fn(() => …)` infers a zero-arg signature,
+    // which types `mock.calls[0]` as the empty tuple and makes reading the
+    // document that was written a type error rather than an assertion.
+    const setFn = vi.fn<(doc: Record<string, unknown>) => Promise<void>>(() => Promise.resolve())
     const { db } = buildMockDb({ docSet: setFn })
     mockGetFirestoreDb.mockReturnValue(db as unknown as ReturnType<typeof getFirestoreDb>)
 


### PR DESCRIPTION
Stacked on #3764 — review that one first.

Removes `typescript: { ignoreBuildErrors: true }` from `next.config.ts` and clears the 39-error backlog it was covering for. Three of those errors were the ReferenceErrors that froze `/micro-land` in production.

## The ones that were actually costing something

**Saved worlds were losing 9 of 14 traits.** `SavedCreature['traits']` spelled out the five traits that existed when the shelf format was written. The set has grown to fourteen. The hand-written list never failed when a trait was added — it just stopped saving it, and the thaw handed back neutral. Every reopen silently reset camouflage, toxicity, cooperation, diurnal, immunity, size, territorial, roam and reproductionCooldown.

Now: encode spreads the whole object, `cleanTraits` validates off a shared `TRAIT_BOUNDS` table that `inherit` also clamps against (so the two can't drift apart), and the thaw merges over `neutralTraits()`. `snapshot.test.ts` gained assertions on `toxicity` and `camouflage` — they fail against the old format and pass against this one.

**Thawed creatures were missing 12 required fields.** `homeX`, `homeY`, `stunTimer`, `sinking`, `sick`, `poisoned` and six more were never set by `thaw`, so a reopened world ran on `undefined` timers — and `undefined - dt` is NaN, which spreads to position and never recovers. The type error saying so was masked by the trait mismatch directly above it.

**Two features were silently dead.**
- Quicksand tested `bp.body.locomotion`, which went away with the digging feature. Walkers had stopped sinking entirely.
- Canopy shade tested for `'plant'`, `'leaves'`, `'fern'`, `'flower'` materials — none of which exist, because plants are *creatures* here, not tiles. Same for `'salt-water'` and `'limestone'`. Unreachable branches removed, reachable ones documented.

## The rest

- Duplicated four-key block in `sanitizeBlueprint` (second copy shadowed the first)
- Byte-identical second declaration of `BiomeZoneType`
- `phenology.breedingGdd` accepted without a `typeof` check — a non-numeric value reached `Math.min` and came out NaN, on the gate deciding whether a species may breed at all
- `defaultTraits()` in the workshop had drifted two traits behind neutral; now aliases `neutralTraits`
- Harness `tilesDug` stat removed — it had been printing `NaN tiles` on every run since digging was removed

## Verification

| Check | Before | After |
|---|---|---|
| `npm run typecheck` | 39 errors | **0** |
| `npm run build` | passed by ignoring errors | passes **with typechecking enforced** |
| tests (vs `origin/main`) | 133 failing | 77 failing, **zero new** |
| harness | crashed in 30s | 2×300s, `✓ Still alive` |
| eslint | — | parity with baseline on every touched file |

The remaining 77 test failures are pre-existing and almost entirely comet-cards; none are in files this touches.

## Note

This does not fix the ecosystem balance. Animals still sit at `gen 1.0` after five minutes — they essentially never breed while plants stay pinned at their caps. Separate, older problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)