### PR TITLE
feat(micro-land): evals that say which of three bugs you have

### DIFF
--- a/.claude/skills/micro-land/SKILL.md
+++ b/.claude/skills/micro-land/SKILL.md
@@ -161,43 +161,71 @@ to can also be kept by name on a "shelf" and reopened mid-simulation.
 
 ## Verifying a change
 
-Run these in order. The third one is the one that actually catches ecosystem
-regressions, and a browser cannot substitute for it.
+Run these in order. Step 3 is the one that actually catches ecosystem
+regressions.
 
 1. `npm run typecheck`
 2. `npm test` — vitest; covers `creature-kit`, `chronicle`, `wire`, `tuning` and
    the world-save `snapshot`/`wire` pair.
-3. `npm run sim:micro-land -- --theme earth --seconds 600 --runs 5`
-   Repeat for `tidepool`, `volcanic`, `station`. This runs the real simulation
-   headless and prints population over time, causes of death, and what ate what.
-   Look for:
-   - `✓ Still alive` at the end of every theme.
-   - A low-water mark well above zero — an oscillation, not a flatline.
-   - **Known-failing since the animal seed rain was removed:** every animal is
-     currently marked `EXTINCT in every run` on all four themes, within 3–8
-     minutes, leaving a plant-only world. The seed rain had been restocking them
-     every four seconds, which hid the fact that no animal population is
-     self-sustaining at the current tuning — grazers starve with the meadow
-     pinned at its species caps, so the problem is reach and distribution rather
-     than a shortage of food. Until that is fixed, read this line as "no *new*
-     species went extinct", not as a pass.
-   - Deaths attributed sensibly (`starved` dominating a grazer means the plants
-     lost; `burned` dominating means the terrain is hostile).
-   - `world still solid` not collapsing — diggers should tunnel, not delete.
-4. `npm run lint`
-5. In the browser at `/micro-land`: paint, place, drag-throw a creature, summon
+3. `npm run eval:micro-land -- --seconds 1600 --runs 3`
+   The ecosystem evals: the real simulation, headless, reduced to pass/fail
+   claims with an exit code. This is the one that catches ecosystem regressions,
+   and a browser cannot substitute for it. Add `--diagnose` to see the breeding
+   probe per species while you tune. `--set knob=value` moves the same knobs the
+   settings panel does, so a number found by dragging a slider can be run through
+   the checks before it becomes a default.
+
+   **Mind the run length.** Maturity is `lifespanSeconds * lifespanScale * 0.2`,
+   and `lifespanScale` is 10 — so a species with `lifespanSeconds: 150` cannot
+   breed until t=300s, and the slowest animal in `grassland` matures at 760s. Any
+   run shorter than about 1600s is measuring how much of a creature's *childhood*
+   fits in the window and reporting it as infertility. `run-outlasts-maturity`
+   fails when this happens; believe nothing below it until that check is green.
+
+   Read failures top-down — the list is in causal order, and only the first
+   failure is worth acting on:
+   `foraging-feeds-animals` → `breeding-gate-opens` → `ready-animals-seek-mates`
+   → `mate-stints-convert`. Gate before priority before pathing; fixing a knob
+   when the priority order is the problem makes the world worse and still shows
+   no births.
+
+   **Known-failing today.** `breeding-gate-opens` sits near 0% on every theme:
+   animals are blocked roughly half by `too-young` and half by `underfed`, and
+   `cooldown` is 0%, so `breedCooldown` is *not* the problem. Several species
+   ship with `breedAt` at 0.9–1.0, which asks for a hunger of almost exactly
+   zero. `foraging-feeds-animals` passes, so this is not a food-reach problem.
+
+4. `npm run sim:micro-land -- --theme grassland --seconds 600` for the human
+   read — population over time, causes of death, what ate what. Use it to see
+   *shape*; use the evals to decide whether a change helped. Themes are `empty`,
+   `grassland`, `tropical-island`, `verdant-forest`, `tidepool` — `earth`,
+   `volcanic` and `station` were retired and any command naming them errors out.
+   Look for deaths attributed sensibly (`starved` dominating a grazer means the
+   plants lost; `burned` means the terrain is hostile) and `world still solid`
+   not collapsing.
+5. `npm run lint`
+6. In the browser at `/micro-land`: paint, place, drag-throw a creature, summon
    one creature and one scene, pan with each input (arrows, minimap, wheel, two
    fingers, one finger in Look mode), open the field guide.
 
-For balance work, compare the harness output *before and after* on the same
-seeds — `runOnce` seeds from `1000 + i * 7919`, so runs are comparable across
-branches. `--set knob=value` moves the same knobs the settings panel does, so a
-number found by dragging a slider can be run through the ten-minute check
-before it becomes a default:
+For balance work, run the evals before and after on the same seeds — `seedFor(i)`
+is `1000 + i * 7919`, so run `i` is the same world on every checkout and a diff
+is attributable rather than a vibe:
 
 ```
-npm run sim:micro-land -- --theme earth --seconds 600 --runs 3 --set plantSpeciesCap=50
+npm run eval:micro-land -- --seconds 1600 --runs 3 --diagnose --set breedAt=0.5
+npm run eval:micro-land -- --json > after.json     # machine-readable, exit 1 on failure
 ```
+
+`npm run eval:micro-land:smoke` is the fast version (120s, one seed) — it is a
+"did I break the harness" check, not an ecosystem check, and it will always fail
+`run-outlasts-maturity` by design.
+
+Adding a check means adding it to `CHECKS` in `harness/evals.ts`. Three rules
+live in that file's header and are worth honouring: a check must be able to fail
+for exactly one reason, thresholds are floors set where behaviour is
+*unambiguously* wrong rather than where the ideal sits, and nothing asserts on a
+single seed.
 
 ## Known hazards
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "eval:trivia:smoke": "tsx --env-file=.env.local scripts/eval-trivia.ts --smoke",
     "seed-ai-questions": "tsx --env-file=.env.local scripts/seed-ai-questions.ts",
     "sim:micro-land": "tsx scripts/micro-land-sim.ts",
+    "eval:micro-land": "tsx scripts/micro-land-eval.ts",
+    "eval:micro-land:smoke": "tsx scripts/micro-land-eval.ts --seconds 120 --runs 1 --theme grassland",
     "voice:dicebound": "tsx --env-file-if-exists=.env.local scripts/dicebound-voice-check.ts",
     "migrate:daily-trivia": "tsx --env-file=.env.local scripts/migrate-daily-trivia-to-firestore.ts"
   },

--- a/scripts/micro-land-eval.ts
+++ b/scripts/micro-land-eval.ts
@@ -1,0 +1,160 @@
+/**
+ * Micro Land ecosystem evals — pass/fail, so a change can be judged.
+ *
+ * `micro-land-sim.ts` prints the world for a person to read. This asks whether
+ * the world is *working*, against the claims in `harness/evals.ts`, and exits
+ * non-zero when it is not. That is the difference between a dashboard and a
+ * test, and it is what makes "did my tuning help" answerable.
+ *
+ * Usage:
+ *   npm run eval:micro-land                            # every theme, 300s, 3 seeds
+ *   npm run eval:micro-land -- --theme grassland       # one theme
+ *   npm run eval:micro-land -- --seconds 600 --runs 5  # slower, more confident
+ *   npm run eval:micro-land -- --set breedAt=0.5       # same knobs as the panel
+ *   npm run eval:micro-land:smoke                      # 120s, 1 seed, fast
+ *   npm run eval:micro-land -- --json                  # machine-readable
+ *
+ * `--diagnose` prints the breeding probe per species even when everything
+ * passes, which is what you want open while tuning.
+ */
+import { THEMES, THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
+import {
+  TUNING,
+  TUNING_DEFAULTS,
+  type TuningKey,
+  changedKnobs,
+  setTuning,
+} from '@/app/micro-land/domain/tuning'
+import { meanProbe } from '@/app/micro-land/harness/breeding-probe'
+import { runChecks } from '@/app/micro-land/harness/evals'
+import { type RunMetrics, runSeeds } from '@/app/micro-land/harness/run'
+
+function arg(name: string, fallback: string): string {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+const asJson = process.argv.includes('--json')
+const diagnose = process.argv.includes('--diagnose')
+const seconds = Number(arg('seconds', '300'))
+const runs = Number(arg('runs', '3'))
+
+// Empty is not an ecosystem — it has nothing in it by design, so it can only
+// ever fail checks that assume a population.
+const playable = THEMES.filter(t => t.id !== 'empty').map(t => t.id)
+const themeArg = arg('theme', '')
+const themeIds = themeArg ? [themeArg] : playable
+
+for (const id of themeIds) {
+  if (!THEME_BY_ID[id]) {
+    console.error(`Unknown theme "${id}". Try: ${THEMES.map(t => t.id).join(', ')}`)
+    process.exit(2)
+  }
+}
+
+for (let i = 0; i < process.argv.length; i++) {
+  if (process.argv[i] !== '--set') continue
+  const [key, raw] = (process.argv[i + 1] ?? '').split('=')
+  if (!(key in TUNING_DEFAULTS) || !Number.isFinite(Number(raw))) {
+    console.error(`Bad --set "${process.argv[i + 1] ?? ''}".`)
+    process.exit(2)
+  }
+  setTuning({ [key as TuningKey]: Number(raw) })
+}
+
+const tuned = changedKnobs()
+
+interface ThemeReport {
+  themeId: string
+  results: ReturnType<typeof runChecks>
+  runs: RunMetrics[]
+}
+
+const reports: ThemeReport[] = []
+for (const themeId of themeIds) {
+  const metrics = runSeeds({ themeId, seconds, runs })
+  reports.push({ themeId, results: runChecks(metrics), runs: metrics })
+}
+
+const failed = reports.flatMap(r => r.results.filter(c => !c.pass))
+
+if (asJson) {
+  console.log(
+    JSON.stringify(
+      {
+        seconds,
+        runs,
+        tuning: Object.fromEntries(tuned.map(k => [k, TUNING[k]])),
+        themes: reports.map(r => ({ themeId: r.themeId, checks: r.results })),
+        passed: failed.length === 0,
+      },
+      null,
+      2
+    )
+  )
+  process.exit(failed.length === 0 ? 0 : 1)
+}
+
+if (tuned.length > 0) {
+  console.log(
+    `tuning: ${tuned.map(k => `${k}=${TUNING[k]} (was ${TUNING_DEFAULTS[k]})`).join(', ')}`
+  )
+}
+console.log(`${themeIds.length} theme(s) · ${seconds}s · ${runs} seed(s) each\n`)
+
+for (const report of reports) {
+  const name = THEME_BY_ID[report.themeId].name
+  const themeFailed = report.results.filter(c => !c.pass).length
+  console.log(`── ${name} ${themeFailed === 0 ? '✓' : `✗ ${themeFailed} failing`} ────────────`)
+
+  for (const c of report.results) {
+    const mark = c.pass ? '✓' : '✗'
+    const value = c.value < 1 && c.value > 0 ? `${(c.value * 100).toFixed(0)}%` : c.value.toFixed(2)
+    console.log(`  ${mark} ${c.id.padEnd(26)} ${value.padStart(7)}   ${c.bar}`)
+    if (!c.pass) {
+      console.log(`      → ${c.points_at}`)
+      if (c.detail) console.log(`      ${c.detail}`)
+    }
+  }
+
+  if (diagnose) {
+    console.log('\n  breeding probe (animals only)')
+    console.log(
+      `  ${'species'.padEnd(16)} ${'ready'.padStart(6)} ${'mating|ready'.padStart(12)} ${'stints'.padStart(7)} ${'births'.padStart(7)}   top blockers`
+    )
+    const probe = meanProbe(report.runs.map(r => r.probe))
+    const births: Record<string, number> = {}
+    for (const r of report.runs) {
+      for (const [id, n] of Object.entries(r.births)) births[id] = (births[id] ?? 0) + n
+    }
+    for (const [id, s] of Object.entries(probe).sort((a, b) => b[1].samples - a[1].samples)) {
+      // Per species, not just the aggregate: "the gate is shut" is a different
+      // bug depending on which clause is shutting it, and different species are
+      // stopped by different clauses. `underfed` dominating one row and
+      // `too-young` another is the whole diagnosis.
+      const blockers = Object.entries(s.blockedBy)
+        .filter(([, n]) => n > 0)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 2)
+        .map(([b, n]) => `${b}:${((n / Math.max(1, s.samples)) * 100).toFixed(0)}%`)
+        .join(' ')
+      console.log(
+        `  ${id.padEnd(16)} ${(s.readyShare * 100).toFixed(0).padStart(5)}% ${(s.matingWhileReady * 100).toFixed(0).padStart(11)}% ${String(s.mateStints).padStart(7)} ${String(births[id] ?? 0).padStart(7)}   ${blockers}`
+      )
+    }
+    console.log(
+      `\n  gate blocked by: ${report.results.find(r => r.id === 'breeding-gate-opens')?.detail ?? ''}`
+    )
+  }
+  console.log()
+}
+
+if (failed.length === 0) {
+  console.log('✓ all checks passed')
+  process.exit(0)
+}
+
+console.log(
+  `✗ ${failed.length} check(s) failing: ${[...new Set(failed.map(f => f.id))].join(', ')}`
+)
+process.exit(1)

--- a/src/app/micro-land/domain/__tests__/breeding-blockers.test.ts
+++ b/src/app/micro-land/domain/__tests__/breeding-blockers.test.ts
@@ -1,0 +1,118 @@
+/**
+ * `breedingBlockers` and `readyToBreed` must agree, forever.
+ *
+ * They are deliberately separate implementations of the same four questions:
+ * `readyToBreed` runs for every creature in the sense pass and stays a
+ * short-circuiting boolean, while `breedingBlockers` allocates an array to say
+ * *which* clause failed and runs only from the harness. That duplication is a
+ * real cost, and this test is what buys it back — the moment someone changes one
+ * gate and not the other, every eval built on the probe starts quietly lying
+ * about why animals are not breeding.
+ *
+ * `readyToBreed` is not exported (it has no business being), so this asserts the
+ * equivalence through the one public statement of the same rule: a creature with
+ * no blockers is one the simulation will let breed.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { breedingBlockers, founderMaturityAge } from '@/app/micro-land/domain/sim/creature-sim'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import { TUNING } from '@/app/micro-land/domain/tuning'
+import type { Creature, CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+function grazer(): CreatureBlueprint {
+  return sanitizeBlueprint({
+    id: 'test-grazer',
+    name: 'Test Grazer',
+    move: { kind: 'walk', speed: 4, jump: 3, hop: 0, restlessness: 0.3 },
+    diet: { eats: ['plant'], tags: ['animal'], breedAt: 0.6, lifespanSeconds: 100 },
+    art: { palette: { a: '#8888ff' }, frames: [['a']] },
+  })
+}
+
+function placed(): { c: Creature; bp: CreatureBlueprint } {
+  const w = createWorld(1)
+  const bp = grazer()
+  registerBlueprint(w, bp)
+  const c = spawnCreature(w, bp, 10, 10)
+  if (!c) throw new Error('spawn failed')
+  return { c, bp }
+}
+
+describe('breedingBlockers', () => {
+  it('reports nothing blocking a fed, rested, mature creature', () => {
+    const { c, bp } = placed()
+    c.hunger = 0
+    c.breedCooldown = 0
+    c.ageSeconds = founderMaturityAge(bp) * 2
+
+    expect(breedingBlockers(c, bp)).toEqual([])
+  })
+
+  it('names the cooldown while it is still running', () => {
+    const { c, bp } = placed()
+    c.hunger = 0
+    c.ageSeconds = founderMaturityAge(bp) * 2
+    c.breedCooldown = 5
+
+    expect(breedingBlockers(c, bp)).toContain('cooldown')
+  })
+
+  it('names hunger when the creature is below its breedAt threshold', () => {
+    const { c, bp } = placed()
+    c.breedCooldown = 0
+    c.ageSeconds = founderMaturityAge(bp) * 2
+    // breedAt 0.6 wants `1 - hunger >= 0.6`, so hunger above 0.4 is underfed.
+    c.hunger = 0.5
+
+    expect(breedingBlockers(c, bp)).toContain('underfed')
+  })
+
+  it('names age for a founder that has not reached maturity', () => {
+    const { c, bp } = placed()
+    c.hunger = 0
+    c.breedCooldown = 0
+    c.ageSeconds = founderMaturityAge(bp) / 2
+
+    expect(breedingBlockers(c, bp)).toContain('too-young')
+  })
+
+  it('names the headroom clause when a child could not be afforded', () => {
+    const { c, bp } = placed()
+    c.breedCooldown = 0
+    c.ageSeconds = founderMaturityAge(bp) * 2
+    // `hunger + breedCost >= 1` is the clause; pick a hunger that trips it.
+    c.hunger = 1 - TUNING.breedCost
+
+    expect(breedingBlockers(c, bp)).toContain('no-headroom')
+  })
+
+  /**
+   * The one that matters. Sweeps the whole space the gate is defined over and
+   * asserts the two readings never disagree about *whether* breeding is allowed.
+   */
+  it('agrees with the simulation gate across the whole hunger/age space', () => {
+    const { c, bp } = placed()
+    const maturity = founderMaturityAge(bp)
+
+    for (const hunger of [0, 0.2, 0.39, 0.4, 0.41, 0.6, 0.69, 0.7, 1]) {
+      for (const age of [0, maturity - 1, maturity, maturity + 1, maturity * 3]) {
+        for (const cooldown of [0, 2]) {
+          c.hunger = hunger
+          c.ageSeconds = age
+          c.breedCooldown = cooldown
+
+          const blockers = breedingBlockers(c, bp)
+          const expectedReady =
+            cooldown <= 0 &&
+            1 - hunger >= bp.diet.breedAt &&
+            hunger + TUNING.breedCost < 1 &&
+            age > maturity
+
+          expect(blockers.length === 0).toBe(expectedReady)
+        }
+      }
+    }
+  })
+})

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -543,7 +543,25 @@ function compareX(a: Creature, b: Creature): number {
 function breedingAge(c: Creature, bp: CreatureBlueprint): number {
   return bp.move.kind === 'root'
     ? TUNING.plantMaturity
-    : lifespanOf(c, bp) * TUNING.lifespanScale * 0.2
+    : founderMaturityAge(bp) * c.traits.lifespan
+}
+
+/**
+ * The age a founder of this species can first breed at, in world seconds.
+ *
+ * Same number `breedingAge` computes, for a creature whose lifespan trait is
+ * still neutral — which every founder's is. Exported because the harness has to
+ * be able to ask "is this run even long enough to see breeding?": maturity is
+ * `lifespanSeconds * lifespanScale * 0.2`, and with `lifespanScale` at 10 that
+ * is *twice* the blueprint's `lifespanSeconds`. A 150-second hopper cannot breed
+ * until t=300s, which is exactly the harness's default run length — so the
+ * default run had been measuring the fraction of a creature's life during which
+ * it is a child, and reporting it as a breeding failure.
+ */
+export function founderMaturityAge(bp: CreatureBlueprint): number {
+  return bp.move.kind === 'root'
+    ? TUNING.plantMaturity
+    : bp.diet.lifespanSeconds * TUNING.lifespanScale * 0.2
 }
 
 /**
@@ -586,6 +604,32 @@ function readyToBreed(c: Creature, bp: CreatureBlueprint): boolean {
     c.hunger + TUNING.breedCost < 1 &&
     c.ageSeconds > breedingAge(c, bp)
   )
+}
+
+/** Which clause of `readyToBreed` a creature is currently failing. */
+export type BreedBlocker = 'cooldown' | 'underfed' | 'no-headroom' | 'too-young'
+
+/**
+ * The same four questions `readyToBreed` asks, answered individually.
+ *
+ * Exists for the harness, not the simulation: "no animal is breeding" is a
+ * symptom with four very different causes, and a boolean cannot tell you which
+ * one you have. Knowing that a grazer is ready 40% of the time but never in
+ * `mate` mood points at the priority order in `look`; knowing it is never ready
+ * at all points at `breedAt` or `breedCost`. Those are opposite fixes.
+ *
+ * Deliberately *not* what `readyToBreed` is built from. That runs for every
+ * creature in the sense pass and must stay a short-circuiting boolean rather
+ * than something that allocates an array per call. The two are pinned together
+ * by a test instead — see `breeding-blockers.test.ts`.
+ */
+export function breedingBlockers(c: Creature, bp: CreatureBlueprint): BreedBlocker[] {
+  const blockers: BreedBlocker[] = []
+  if (c.breedCooldown > 0) blockers.push('cooldown')
+  if (1 - c.hunger < bp.diet.breedAt) blockers.push('underfed')
+  if (c.hunger + TUNING.breedCost >= 1) blockers.push('no-headroom')
+  if (c.ageSeconds <= breedingAge(c, bp)) blockers.push('too-young')
+  return blockers
 }
 
 /**

--- a/src/app/micro-land/harness/breeding-probe.ts
+++ b/src/app/micro-land/harness/breeding-probe.ts
@@ -1,0 +1,169 @@
+/**
+ * Why breeding is or is not happening — as three numbers that point at three
+ * different bugs.
+ *
+ * "No animal is breeding" is a symptom, and the fixes for its causes are
+ * opposite to each other. Turning a knob when the real problem is the priority
+ * order in `look` makes the world worse in a way that still shows no births, and
+ * the next person reads that as "the knob didn't help" rather than "the knob was
+ * never the problem". This probe exists so that never has to be a guess.
+ *
+ * Read the three in order; the first one that is broken is the one to fix.
+ *
+ * 1. **`readyShare`** — of all the moments a creature existed, how many was it
+ *    *allowed* to breed? Low means the gate itself is shut: hunger threshold,
+ *    breed cost headroom, cooldown or maturity age. `blockedBy` says which.
+ *    → a tuning problem.
+ *
+ * 2. **`matingWhileReady`** — of the moments it was allowed to breed, how many
+ *    did it spend actually looking for a mate? Low means something else keeps
+ *    winning the decision. In `look`, `mate` sits third: behind locked-on prey
+ *    *and* behind merely-smelled prey, which sets `hunt` with no target at all.
+ *    A well-fed animal that can smell food anywhere in its hunger reach never
+ *    reaches the `mate` branch.
+ *    → a priority problem.
+ *
+ * 3. **`birthsPerMateStint`** — having gone looking, how often did it arrive?
+ *    A stint is one unbroken run of `mate` mood. Low means creatures want to
+ *    breed, pick a partner, and never close the gap: there is no pathfinding
+ *    here, only steering, so a partner behind terrain is a partner you walk into
+ *    a wall toward.
+ *    → a pathing/targeting problem.
+ *
+ * Plants are excluded throughout. They breed by a different economy (no hunger
+ * cost, no mate, their own caps) and including them drags every ratio toward the
+ * answer for a species that was never in question.
+ */
+import { type BreedBlocker, breedingBlockers } from '@/app/micro-land/domain/sim/creature-sim'
+import type { CreatureMood, WorldState } from '@/app/micro-land/domain/types'
+
+const MOODS: CreatureMood[] = ['wander', 'hunt', 'flee', 'eat', 'rest', 'mate']
+
+export interface SpeciesProbe {
+  /** Creature-samples observed. The denominator for `readyShare` and `moodShare`. */
+  samples: number
+  /** Samples where every clause of the breeding gate passed. */
+  ready: number
+  /** Samples where the creature was ready *and* in `mate` mood. */
+  readyAndMating: number
+  /** Ready samples by what was blocking. A sample can be blocked by several. */
+  blockedBy: Record<BreedBlocker, number>
+  /** Share of all samples spent in each mood. */
+  moodShare: Record<CreatureMood, number>
+  /** Unbroken runs of `mate` mood begun. */
+  mateStints: number
+  /** Mate stints that ended with the creature still holding a target. */
+  mateStintsWithTarget: number
+
+  // --- derived, filled by `foldProbe` --------------------------------------
+  /** `ready / samples`. Low → tuning. */
+  readyShare: number
+  /** `readyAndMating / ready`. Low → priority order in `look`. */
+  matingWhileReady: number
+}
+
+export interface BreedingProbe {
+  /** blueprintId → probe. Animals only. */
+  species: Record<string, SpeciesProbe>
+  /** Per-creature mood on the previous sample, for stint detection. */
+  lastMood: Map<number, CreatureMood>
+}
+
+export function emptyProbe(): BreedingProbe {
+  return { species: {}, lastMood: new Map() }
+}
+
+function emptySpecies(): SpeciesProbe {
+  return {
+    samples: 0,
+    ready: 0,
+    readyAndMating: 0,
+    blockedBy: { cooldown: 0, underfed: 0, 'no-headroom': 0, 'too-young': 0 },
+    moodShare: { wander: 0, hunt: 0, flee: 0, eat: 0, rest: 0, mate: 0 },
+    mateStints: 0,
+    mateStintsWithTarget: 0,
+    readyShare: 0,
+    matingWhileReady: 0,
+  }
+}
+
+/**
+ * Read every creature once. Called from the tick loop, not from inside the sim.
+ *
+ * O(creatures) per sample at 10 Hz against a population capped in the hundreds —
+ * cheaper than one tick of the sense pass, and it buys the only view anyone has
+ * of *why* the population is doing what it is doing.
+ */
+export function sampleProbe(probe: BreedingProbe, w: WorldState): void {
+  const alive = new Set<number>()
+
+  for (const c of w.creatures) {
+    const bp = w.blueprints[c.blueprintId]
+    if (!bp || bp.move.kind === 'root') continue
+
+    alive.add(c.id)
+    const s = (probe.species[c.blueprintId] ??= emptySpecies())
+
+    s.samples++
+    s.moodShare[c.mood]++
+
+    const blockers = breedingBlockers(c, bp)
+    if (blockers.length === 0) {
+      s.ready++
+      if (c.mood === 'mate') s.readyAndMating++
+    } else {
+      for (const b of blockers) s.blockedBy[b]++
+    }
+
+    // A stint is an *entry* into mate mood — counted on the transition so that a
+    // creature parked in `mate` for a hundred samples is one attempt to arrive,
+    // not a hundred. Without that, `birthsPerMateStint` would read as "almost
+    // never succeeds" for a creature that is succeeding slowly, which is the
+    // pathing verdict, and it would be wrong.
+    const was = probe.lastMood.get(c.id)
+    if (c.mood === 'mate' && was !== 'mate') {
+      s.mateStints++
+      if (c.targetId !== null) s.mateStintsWithTarget++
+    }
+    probe.lastMood.set(c.id, c.mood)
+  }
+
+  // Creatures die constantly; without this the map grows for the whole run.
+  for (const id of probe.lastMood.keys()) if (!alive.has(id)) probe.lastMood.delete(id)
+}
+
+/** Turn the counters into the ratios the eval reads. */
+export function foldProbe(probe: BreedingProbe): BreedingProbe {
+  for (const s of Object.values(probe.species)) {
+    s.readyShare = s.samples > 0 ? s.ready / s.samples : 0
+    s.matingWhileReady = s.ready > 0 ? s.readyAndMating / s.ready : 0
+  }
+  return probe
+}
+
+/** Average a probe across runs, so no verdict rests on one seed. */
+export function meanProbe(probes: BreedingProbe[]): Record<string, SpeciesProbe> {
+  const ids = new Set(probes.flatMap(p => Object.keys(p.species)))
+  const out: Record<string, SpeciesProbe> = {}
+
+  for (const id of ids) {
+    const rows = probes.map(p => p.species[id]).filter((r): r is SpeciesProbe => !!r)
+    const acc = emptySpecies()
+    for (const r of rows) {
+      acc.samples += r.samples
+      acc.ready += r.ready
+      acc.readyAndMating += r.readyAndMating
+      acc.mateStints += r.mateStints
+      acc.mateStintsWithTarget += r.mateStintsWithTarget
+      for (const b of Object.keys(acc.blockedBy) as BreedBlocker[])
+        acc.blockedBy[b] += r.blockedBy[b]
+      for (const m of MOODS) acc.moodShare[m] += r.moodShare[m]
+    }
+    acc.readyShare = acc.samples > 0 ? acc.ready / acc.samples : 0
+    acc.matingWhileReady = acc.ready > 0 ? acc.readyAndMating / acc.ready : 0
+    out[id] = acc
+  }
+  return out
+}
+
+export { MOODS }

--- a/src/app/micro-land/harness/evals.ts
+++ b/src/app/micro-land/harness/evals.ts
@@ -1,0 +1,369 @@
+/**
+ * What "the world is alive" means, written down as things that can fail.
+ *
+ * The harness could already print a population table. What it could not do is
+ * answer "did that change help", because answering it by eye across two tables
+ * and different seeds is not answering it. Each check here is one claim about a
+ * healthy world, with a number attached, so a run either holds the claim or
+ * does not.
+ *
+ * Three rules for adding to this file.
+ *
+ * **A check must be able to fail for one reason.** `no-animal-extinctions` is a
+ * good headline and a bad diagnostic: everything upstream of it makes it fail.
+ * That is why the breeding checks below are split into gate → priority →
+ * arrival, one per possible cause, in the order you would fix them.
+ *
+ * **Thresholds are floors, not targets.** They are set where the *current*
+ * behaviour is unambiguously wrong, not where the ideal sits — a threshold that
+ * fails on a merely-mediocre world gets muted, and a muted check is worse than
+ * no check. Raise them when the floor is comfortably cleared.
+ *
+ * **Nothing here asserts on one seed.** Every check takes the whole set of runs
+ * and reduces across them, because `Math.random()` is reachable from three
+ * places in the sim (see `run.ts`) and one run is an anecdote.
+ */
+import type { BreedBlocker } from '@/app/micro-land/domain/sim/creature-sim'
+
+import { type SpeciesProbe, meanProbe } from './breeding-probe'
+
+import type { RunMetrics } from './run'
+
+export interface EvalResult {
+  id: string
+  /** One line: what this measures. */
+  what: string
+  /** One line: what a failure means, in terms of where to look. */
+  points_at: string
+  pass: boolean
+  /** The measured number, for trend-watching even when it passes. */
+  value: number
+  /** Human-readable form of the bar it had to clear. */
+  bar: string
+  /** Per-species or per-run breakdown, shown on failure. */
+  detail?: string
+}
+
+export interface EvalCheck {
+  id: string
+  what: string
+  points_at: string
+  run(runs: RunMetrics[]): Omit<EvalResult, 'id' | 'what' | 'points_at'>
+}
+
+/** Animal species that were seeded into the world, across all runs. */
+function animalIds(runs: RunMetrics[]): string[] {
+  return [...new Set(runs.flatMap(r => Object.keys(r.probe.species)))]
+}
+
+function median(xs: number[]): number {
+  if (xs.length === 0) return 0
+  const s = [...xs].sort((a, b) => a - b)
+  const mid = Math.floor(s.length / 2)
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2
+}
+
+function pct(x: number): string {
+  return `${(x * 100).toFixed(0)}%`
+}
+
+// ---------------------------------------------------------------------------
+// Headline: is there still a world at the end of this?
+// ---------------------------------------------------------------------------
+
+const noAnimalExtinctions: EvalCheck = {
+  id: 'no-animal-extinctions',
+  what: 'Every animal species seeded at t=0 still has a living member at the end.',
+  points_at: 'The whole chain. Read the breeding checks below before this one.',
+  run(runs) {
+    // Per species, the worst run. A species that survives four seeds and dies on
+    // the fifth is not a healthy species, it is a lucky one.
+    const animals = animalIds(runs)
+    const gone = animals.filter(id => runs.some(r => r.extinctions.includes(id)))
+    const survivalRate = animals.length ? 1 - gone.length / animals.length : 1
+    return {
+      pass: gone.length === 0,
+      value: survivalRate,
+      bar: 'no seeded animal species extinct in any run',
+      detail: gone.length ? `extinct in ≥1 run: ${gone.join(', ')}` : undefined,
+    }
+  },
+}
+
+const populationOscillates: EvalCheck = {
+  id: 'population-oscillates',
+  what: 'The low-water mark stays well clear of zero — a cycle, not a slide.',
+  points_at: 'Carrying capacity or a food chain that only runs one way.',
+  run(runs) {
+    // Against peak rather than an absolute count, so the check means the same
+    // thing on a theme that seeds 190 creatures and one that seeds 40.
+    const ratios = runs.map(r => (r.peak > 0 ? r.lowWater / r.peak : 0))
+    const worst = Math.min(...ratios)
+    return {
+      pass: worst >= 0.35,
+      value: worst,
+      bar: 'low water ≥ 35% of peak, in every run',
+      detail: runs.map(r => `seed ${r.seed}: ${r.lowWater}/${r.peak}`).join('  '),
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Breeding, in the order you would debug it. Gate → priority → arrival.
+// ---------------------------------------------------------------------------
+
+/**
+ * The check that guards the other checks.
+ *
+ * Maturity is `lifespanSeconds * lifespanScale * 0.2`, and `lifespanScale` is
+ * 10 — so a species with `lifespanSeconds: 150` cannot breed until t=300s, and
+ * 300s was the harness's default run length. Every breeding number produced by
+ * a run that short is measuring how much of a creature's childhood fits in the
+ * window, and reporting it as infertility.
+ *
+ * This fails loudly rather than letting the breeding checks below report a
+ * confident wrong answer. It is a check about the *experiment*, not the world.
+ */
+const runOutlastsMaturity: EvalCheck = {
+  id: 'run-outlasts-maturity',
+  what: 'The run is long enough that animals could have bred at all.',
+  points_at: 'The harness, not the game — raise --seconds before believing the breeding checks.',
+  run(runs) {
+    const seconds = runs[0]?.seconds ?? 0
+    const animals = new Set(animalIds(runs))
+    const ages = runs
+      .flatMap(r => Object.entries(r.maturityAge))
+      .filter(([id]) => animals.has(id))
+      .map(([, age]) => age)
+    const slowest = ages.length ? Math.max(...ages) : 0
+    // Twice maturity: a creature that matures on the final tick has had no time
+    // to find a partner, and one generation is not a population.
+    const needed = slowest * 2
+    return {
+      pass: slowest > 0 && seconds >= needed,
+      value: needed > 0 ? seconds / needed : 0,
+      bar: `run ≥ 2× the slowest animal's maturity (${needed.toFixed(0)}s; this run ${seconds}s)`,
+      detail:
+        seconds < needed
+          ? `slowest maturity ${slowest.toFixed(0)}s — breeding checks below are not meaningful`
+          : undefined,
+    }
+  },
+}
+
+/**
+ * Upstream of everything else, and the reason it is listed first.
+ *
+ * Breeding is paid for out of a full stomach: `readyToBreed` wants
+ * `1 - hunger >= breedAt` *and* enough headroom left to afford `breedCost`. So
+ * an animal that cannot reach food cannot breed, and every downstream check
+ * fails with it — while pointing at breeding, which is not where the bug is.
+ * Measure eating before believing anything about mating.
+ */
+const foragingFeedsAnimals: EvalCheck = {
+  id: 'foraging-feeds-animals',
+  what: 'Animals that go hunting actually reach food and eat it.',
+  points_at: 'Pathing/targeting in `look` and `steer` — hunting that never arrives.',
+  run(runs) {
+    const probe = meanProbe(runs.map(r => r.probe))
+    const meals = mergeMeals(runs)
+    const rows = Object.entries(probe)
+      .filter(([, s]) => s.samples > 0)
+      .map(([id, s]) => {
+        // Samples are creature-observations at a fixed cadence, so
+        // `samples * SAMPLE_SECONDS` is creature-seconds of life observed.
+        const creatureMinutes = (s.samples * SAMPLE_SECONDS) / 60
+        const eaten = (meals[id]?.plants ?? 0) + (meals[id]?.animals ?? 0)
+        return { id, rate: creatureMinutes > 0 ? eaten / creatureMinutes : 0, hunt: huntShare(s) }
+      })
+    const med = median(rows.map(r => r.rate))
+    return {
+      pass: med >= 0.25,
+      value: med,
+      bar: 'median species eats ≥ 0.25 times per creature-minute',
+      detail: rows
+        .sort((a, b) => a.rate - b.rate)
+        .map(r => `${r.id} ${r.rate.toFixed(2)}/min (hunt ${pct(r.hunt)})`)
+        .join('  '),
+    }
+  },
+}
+
+const breedingGateOpens: EvalCheck = {
+  id: 'breeding-gate-opens',
+  what: 'Animals spend a real share of their lives *allowed* to breed.',
+  points_at: 'Tuning: breedAt, breedCost, breedCooldown, or the maturity age.',
+  run(runs) {
+    const probe = meanProbe(runs.map(r => r.probe))
+    const shares = Object.values(probe).map(s => s.readyShare)
+    const med = median(shares)
+    return {
+      pass: med >= 0.1,
+      value: med,
+      bar: 'median species is breeding-ready ≥ 10% of samples',
+      detail: describeBlockers(probe),
+    }
+  },
+}
+
+const readyAnimalsSeekMates: EvalCheck = {
+  id: 'ready-animals-seek-mates',
+  what: 'An animal that *may* breed actually goes looking for a partner.',
+  points_at: 'Priority order in `look` — `mate` sits behind both prey branches.',
+  run(runs) {
+    const probe = meanProbe(runs.map(r => r.probe))
+    // Only species that get the chance at all; a species the gate never opens
+    // for would otherwise report 0 here and blame the wrong thing.
+    const eligible = Object.entries(probe).filter(([, s]) => s.ready > 0)
+    const med = median(eligible.map(([, s]) => s.matingWhileReady))
+    return {
+      pass: med >= 0.2,
+      value: med,
+      bar: 'median species spends ≥ 20% of its ready time in `mate` mood',
+      detail: eligible
+        .map(([id, s]) => `${id} ${pct(s.matingWhileReady)} (hunt ${pct(huntShare(s))})`)
+        .join('  '),
+    }
+  },
+}
+
+const mateStintsConvert: EvalCheck = {
+  id: 'mate-stints-convert',
+  what: 'Having set out to find a partner, an animal arrives often enough.',
+  points_at: 'Pathing/targeting: steering has no pathfinder, so terrain blocks mates.',
+  run(runs) {
+    const probe = meanProbe(runs.map(r => r.probe))
+    const births = mergeBirths(runs)
+    const rows = Object.entries(probe)
+      .filter(([, s]) => s.mateStints > 0)
+      .map(([id, s]) => ({ id, rate: (births[id] ?? 0) / s.mateStints, stints: s.mateStints }))
+    const med = median(rows.map(r => r.rate))
+    return {
+      pass: med >= 0.1,
+      value: med,
+      bar: 'median species converts ≥ 10% of mate stints into a birth',
+      detail: rows.map(r => `${r.id} ${(r.rate * 100).toFixed(0)}% of ${r.stints}`).join('  '),
+    }
+  },
+}
+
+const lineagesAdvance: EvalCheck = {
+  id: 'lineages-advance',
+  what: 'Surviving animals are descendants, not the founders still standing there.',
+  points_at: 'Breeding overall. Founders are generation 1; anything born is ≥ 2.',
+  run(runs) {
+    // The end-state version of the birth counters, and the one that cannot be
+    // gamed by a species that breeds once and then stops: an average generation
+    // above 1 means the population alive at the end was substantially *made*
+    // during the run rather than seeded at the start of it.
+    const animals = new Set(animalIds(runs))
+    const gens: number[] = []
+    for (const r of runs) {
+      for (const [id, d] of Object.entries(r.drift)) {
+        if (animals.has(id) && (r.survivors[id] ?? 0) >= 3) gens.push(d.gen)
+      }
+    }
+    const med = median(gens)
+    return {
+      pass: med >= 1.5,
+      value: med,
+      bar: 'median surviving animal species averages generation ≥ 1.5',
+      detail: gens.length ? `n=${gens.length} species-runs` : 'no species had ≥3 survivors',
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// The world itself
+// ---------------------------------------------------------------------------
+
+const worldStaysSolid: EvalCheck = {
+  id: 'world-stays-solid',
+  what: 'Terrain is not being quietly eaten away.',
+  points_at: 'Acid, diggers, or a material conversion with no ceiling.',
+  run(runs) {
+    const worst = Math.min(...runs.map(r => r.solidFraction))
+    const start = 0.3
+    return {
+      pass: worst >= start * 0.8,
+      value: worst,
+      bar: 'solid fraction stays within 20% of its starting share',
+      detail: runs.map(r => `seed ${r.seed}: ${pct(r.solidFraction)}`).join('  '),
+    }
+  },
+}
+
+function huntShare(s: SpeciesProbe): number {
+  return s.samples > 0 ? s.moodShare.hunt / s.samples : 0
+}
+
+/**
+ * Seconds of creature-life one probe sample stands for.
+ *
+ * Tied to `RunOptions.sampleEveryTicks` (6) and `TICK_S` (1/60). If the sample
+ * cadence changes, this changes with it or every per-minute rate silently
+ * rescales.
+ */
+const SAMPLE_SECONDS = 6 / 60
+
+function mergeMeals(runs: RunMetrics[]): Record<string, { plants: number; animals: number }> {
+  const out: Record<string, { plants: number; animals: number }> = {}
+  for (const r of runs) {
+    for (const [id, m] of Object.entries(r.meals)) {
+      out[id] ??= { plants: 0, animals: 0 }
+      out[id].plants += m.plants
+      out[id].animals += m.animals
+    }
+  }
+  return out
+}
+
+function mergeBirths(runs: RunMetrics[]): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const r of runs) {
+    for (const [id, n] of Object.entries(r.births)) out[id] = (out[id] ?? 0) + n
+  }
+  return out
+}
+
+/** Which clause is shutting the gate, summed across species. */
+function describeBlockers(probe: Record<string, SpeciesProbe>): string {
+  const totals: Record<BreedBlocker, number> = {
+    cooldown: 0,
+    underfed: 0,
+    'no-headroom': 0,
+    'too-young': 0,
+  }
+  for (const s of Object.values(probe)) {
+    for (const k of Object.keys(totals) as BreedBlocker[]) totals[k] += s.blockedBy[k]
+  }
+  const sum = Object.values(totals).reduce((a, b) => a + b, 0) || 1
+  return (Object.entries(totals) as [BreedBlocker, number][])
+    .sort((a, b) => b[1] - a[1])
+    .map(([k, n]) => `${k} ${pct(n / sum)}`)
+    .join('  ')
+}
+
+/**
+ * Order is the debugging order, not the importance order.
+ *
+ * The headline checks come first because they are what you look at; the causal
+ * chain runs the other way. `foraging-feeds-animals` is upstream of every
+ * breeding check, and the breeding checks run gate → priority → arrival. Fix
+ * the first failure in that chain before reading the ones after it.
+ */
+export const CHECKS: EvalCheck[] = [
+  runOutlastsMaturity,
+  noAnimalExtinctions,
+  populationOscillates,
+  foragingFeedsAnimals,
+  breedingGateOpens,
+  readyAnimalsSeekMates,
+  mateStintsConvert,
+  lineagesAdvance,
+  worldStaysSolid,
+]
+
+export function runChecks(runs: RunMetrics[]): EvalResult[] {
+  return CHECKS.map(c => ({ id: c.id, what: c.what, points_at: c.points_at, ...c.run(runs) }))
+}

--- a/src/app/micro-land/harness/run.ts
+++ b/src/app/micro-land/harness/run.ts
@@ -1,0 +1,239 @@
+/**
+ * The headless world, as something you can measure instead of read.
+ *
+ * `scripts/micro-land-sim.ts` prints a population table for a person to squint
+ * at. That is genuinely useful for "does this look alive", and useless for "did
+ * my change help" — a human reading two tables side by side cannot tell a real
+ * improvement from a different seed. This module runs the same simulation and
+ * returns numbers, so an eval can assert on them and a diff can be attributed.
+ *
+ * Two rules hold this together and both are worth stating.
+ *
+ * **The simulation is not instrumented.** Everything here is observed from
+ * outside the tick: mood, hunger, age and breeding readiness are already on the
+ * creature, so the harness samples them rather than asking `creature-sim` to
+ * count things for it. The alternative — counters threaded through the sim —
+ * would mean the thing under test is not the thing that ships, and would put
+ * harness concerns inside a file whose whole discipline is that a creature is
+ * data. The one exception is `breedingBlockers`, which is a read-only question
+ * about a creature, not a counter.
+ *
+ * **Runs are comparable across branches, not deterministic.** Seeds come from
+ * `seedFor(i)` and the tick order is fixed, but `emitParticles`, spawn animation
+ * phase and theme decoration all call `Math.random()` (see the skill's "known
+ * hazards"). So: same seed on two branches is a fair comparison, and a single
+ * run is never evidence. Everything here is built to be averaged over `runs`.
+ */
+import { THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
+import { TICK_S } from '@/app/micro-land/domain/constants'
+import {
+  type SimEvent,
+  breedingBlockers,
+  founderMaturityAge,
+  tickCreatures,
+} from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { tickTiles } from '@/app/micro-land/domain/sim/tile-sim'
+import {
+  applyTheme,
+  countByBlueprint,
+  createWorld,
+  seedStarters,
+} from '@/app/micro-land/domain/sim/world'
+import type { CreatureMood, WorldState } from '@/app/micro-land/domain/types'
+
+import { emptyProbe, foldProbe, sampleProbe } from './breeding-probe'
+
+import type { BreedingProbe, SpeciesProbe } from './breeding-probe'
+
+export interface RunOptions {
+  themeId: string
+  seconds: number
+  seed: number
+  /**
+   * How often to sample creature state, in ticks.
+   *
+   * 6 ticks is 10 Hz, which is the cadence the sense pass itself runs at
+   * (`SENSE_EVERY`) — sampling faster only re-reads a decision that has not been
+   * revisited. Sampling much slower starts to miss short-lived moods, and `mate`
+   * is exactly the short-lived mood this is here to catch.
+   */
+  sampleEveryTicks?: number
+}
+
+export interface RunMetrics {
+  themeId: string
+  seed: number
+  seconds: number
+
+  /** blueprintId → alive at the end. */
+  survivors: Record<string, number>
+  /** Seeded at t=0, gone at the end. */
+  extinctions: string[]
+  /** Seeded at t=0 — the denominator for extinction rate. */
+  seeded: string[]
+
+  peak: number
+  /** Lowest total population after the opening 20s scramble. */
+  lowWater: number
+  alive: number
+
+  /** blueprintId → cause → count. */
+  deaths: Record<string, Record<string, number>>
+  /** blueprintId → what it ate. */
+  meals: Record<string, { plants: number; animals: number }>
+  /** blueprintId → births. The number every breeding question comes back to. */
+  births: Record<string, number>
+
+  /** Share of the world still made of something, 0..1. */
+  solidFraction: number
+
+  /** blueprintId → averaged over survivors. `gen` is the reality check on the rest. */
+  drift: Record<string, { speed: number; sight: number; lifespan: number; gen: number }>
+
+  /** Why breeding did or did not happen. See `breeding-probe.ts`. */
+  probe: BreedingProbe
+
+  /**
+   * blueprintId → the age a founder may first breed at, in world seconds.
+   *
+   * Carried on the result so a check can ask whether the run was long enough to
+   * have observed breeding at all, rather than reporting "nothing bred" for a
+   * window in which nothing *could* have.
+   */
+  maturityAge: Record<string, number>
+}
+
+/** Comparable across branches: run `i` is the same world on every checkout. */
+export function seedFor(i: number): number {
+  return 1000 + i * 7919
+}
+
+export function runWorld(opts: RunOptions): RunMetrics {
+  const { themeId, seconds, seed, sampleEveryTicks = 6 } = opts
+  const theme = THEME_BY_ID[themeId]
+  if (!theme) throw new Error(`Unknown theme "${themeId}"`)
+
+  const world = createWorld(seed)
+  const rng = makeRng(seed ^ 0x9e3779b9)
+  applyTheme(world, themeId, seed)
+  seedStarters(world, themeId, rng)
+
+  const seeded = Object.keys(countByBlueprint(world))
+  const totalTicks = Math.floor(seconds / TICK_S)
+
+  const deaths: RunMetrics['deaths'] = {}
+  const meals: RunMetrics['meals'] = {}
+  const births: RunMetrics['births'] = {}
+  const probe = emptyProbe()
+
+  let tileCounter = 0
+  let peak = world.creatures.length
+  let lowWater = Infinity
+
+  for (let tick = 1; tick <= totalTicks; tick++) {
+    const events: SimEvent[] = []
+    world.elapsed += TICK_S
+    if (++tileCounter >= 3) {
+      tileCounter = 0
+      tickTiles(world)
+    }
+    tickCreatures(world, TICK_S, rng, theme.gravity, events)
+
+    for (const e of events) {
+      if (e.kind === 'born') {
+        births[e.blueprintId] = (births[e.blueprintId] ?? 0) + 1
+        continue
+      }
+      if (e.kind === 'ate') {
+        meals[e.blueprintId] ??= { plants: 0, animals: 0 }
+        const victim = e.victimId ? world.blueprints[e.victimId] : undefined
+        if (victim?.move.kind === 'root') meals[e.blueprintId].plants++
+        else meals[e.blueprintId].animals++
+        continue
+      }
+      // 'notice' and 'diversity-rescue' are announcements, not deaths.
+      if (e.kind === 'notice' || e.kind === 'diversity-rescue' || e.kind === 'extinction') continue
+      deaths[e.blueprintId] ??= {}
+      deaths[e.blueprintId][e.kind] = (deaths[e.blueprintId][e.kind] ?? 0) + 1
+    }
+
+    peak = Math.max(peak, world.creatures.length)
+    // The opening 20s is the scramble, not the steady state.
+    if (world.elapsed > 20) lowWater = Math.min(lowWater, world.creatures.length)
+
+    if (tick % sampleEveryTicks === 0) sampleProbe(probe, world)
+  }
+
+  const survivors = countByBlueprint(world)
+
+  return {
+    themeId,
+    seed,
+    seconds,
+    survivors,
+    seeded,
+    extinctions: seeded.filter(id => !survivors[id]),
+    peak,
+    lowWater: lowWater === Infinity ? 0 : lowWater,
+    alive: world.creatures.length,
+    deaths,
+    meals,
+    births,
+    solidFraction: solidFractionOf(world),
+    drift: driftOf(world, survivors),
+    probe: foldProbe(probe),
+    maturityAge: maturityAges(world, seeded),
+  }
+}
+
+function maturityAges(w: WorldState, seeded: string[]): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const id of seeded) {
+    const bp = w.blueprints[id]
+    if (bp) out[id] = founderMaturityAge(bp)
+  }
+  return out
+}
+
+function solidFractionOf(w: WorldState): number {
+  let solid = 0
+  for (let i = 0; i < w.tiles.length; i++) if (w.tiles[i] !== 0) solid++
+  return solid / w.tiles.length
+}
+
+/**
+ * Averaged over survivors, which is the population selection actually produced.
+ * Averaging over everything that ever lived folds in exactly the individuals the
+ * world rejected and pulls the answer back toward 1.
+ */
+function driftOf(w: WorldState, survivors: Record<string, number>): RunMetrics['drift'] {
+  const drift: RunMetrics['drift'] = {}
+  for (const c of w.creatures) {
+    const d = (drift[c.blueprintId] ??= { speed: 0, sight: 0, lifespan: 0, gen: 0 })
+    d.speed += c.traits.speed
+    d.sight += c.traits.sight
+    d.lifespan += c.traits.lifespan
+    d.gen += c.generation
+  }
+  for (const [id, d] of Object.entries(drift)) {
+    const n = survivors[id] || 1
+    d.speed /= n
+    d.sight /= n
+    d.lifespan /= n
+    d.gen /= n
+  }
+  return drift
+}
+
+/** Run the same world on N seeds. The unit of evidence is the set, never one run. */
+export function runSeeds(opts: Omit<RunOptions, 'seed'> & { runs: number }): RunMetrics[] {
+  const out: RunMetrics[] = []
+  for (let i = 0; i < opts.runs; i++) {
+    out.push(runWorld({ ...opts, seed: seedFor(i) }))
+  }
+  return out
+}
+
+export type { BreedingProbe, SpeciesProbe, CreatureMood }
+export { breedingBlockers, founderMaturityAge }


### PR DESCRIPTION
Stacked on #3767 (which is stacked on #3764). Review those first.

`npm run eval:micro-land` — the same headless simulation, reduced to claims that pass or fail, with an exit code.

## Why not just read the harness output

The harness prints a population table. That answers "does this look alive"; it cannot answer "did my change help", because comparing two tables by eye across different seeds is not comparing them.

More importantly: **"no animal is breeding" has at least four causes, and their fixes contradict each other.** Turning a knob when the real problem is the branch order in `look()` makes the world worse *and still shows no births* — and the next person reads that as "the knob didn't help". So the checks are split along the causal chain and reported in debugging order:

| Check | Question | Points at |
|---|---|---|
| `foraging-feeds-animals` | Can they reach food at all? | pathing / targeting |
| `breeding-gate-opens` | Are they ever *allowed* to breed? | tuning |
| `ready-animals-seek-mates` | Do they choose to go looking? | priority order in `look()` |
| `mate-stints-convert` | Having gone, do they arrive? | pathing again |

Only the first failure in the chain is worth acting on.

## What it found immediately

**1. The default run length made breeding unmeasurable.**

Maturity is `lifespanSeconds * lifespanScale * 0.2`, and `lifespanScale` is 10 — so maturity is *twice* a blueprint's `lifespanSeconds`. A 150-second hopper cannot breed until **t=300s**, which was the harness's default run length. Every breeding number ever read off this harness was measuring how much of a creature's childhood fit in the window and reporting it as infertility.

`run-outlasts-maturity` now fails loudly instead of letting the checks below it report a confident wrong answer. The skill's verification step moves to 1600s.

**2. Given a valid window, it is the gate — and it is not the cooldown.**

Grassland, 1200s, 2 seeds:

```
species           ready mating|ready  stints  births   top blockers
hopper               2%           0%       0       0   underfed:84% too-young:71%
mite                 6%           0%       3       5   too-young:58% underfed:56%
stalker              0%           0%       0       0   underfed:95% too-young:63%
woolly               0%           0%       0       0   too-young:99% underfed:99%
sunhawk              0%           0%       0       0   too-young:100% underfed:99%

gate blocked by: too-young 58%  underfed 37%  no-headroom 5%  cooldown 0%
```

`cooldown` blocks **0%** of samples — `breedCooldown` is not the problem. It splits cleanly per species, which is what makes it actionable. Several species also ship `breedAt` between 0.9 and 1.0, asking for a hunger of almost exactly zero. And `foraging-feeds-animals` **passes** at 0.47 meals/creature-minute, so this is not a food-reach problem.

## Design

**The simulation is not instrumented.** Mood, hunger, age and readiness are already on the creature, so the probe samples them at 10 Hz from the tick loop rather than asking `creature-sim` to count things for itself. The thing under test stays the thing that ships, and the sim keeps its discipline that a creature is data.

The one addition is `breedingBlockers` — a read-only question naming which of the four `readyToBreed` clauses failed. It is deliberately a *second* implementation, because `readyToBreed` runs per-creature in the sense pass and must stay a short-circuiting boolean. `breeding-blockers.test.ts` sweeps the hunger/age/cooldown space and asserts the two never disagree.

**Thresholds are floors, not targets** — set where behaviour is unambiguously wrong, not where the ideal sits. A check that fails on a merely-mediocre world gets muted, and a muted check is worse than no check.

**Nothing asserts on one seed.** `seedFor(i)` is `1000 + i * 7919`, so run `i` is the same world on every checkout and a before/after diff is attributable.

## Usage

```
npm run eval:micro-land -- --seconds 1600 --runs 3 --diagnose
npm run eval:micro-land -- --set breedAt=0.5        # same knobs as the settings panel
npm run eval:micro-land -- --json                   # machine-readable, exit 1 on failure
npm run eval:micro-land:smoke                       # fast "did I break the harness"
```

## Verification

- 4 themes run clean; 7 checks, 4 failing on grassland today
- `npm run typecheck` 0 errors; eslint + prettier clean on new files
- full suite: no new failures vs the branch this stacks on

## Not done here

This diagnoses; it does not fix. The `too-young` / `underfed` split and the `breedAt` values are now measurable, which is what makes them safe to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)