### PR TITLE
feat(micro-land): tidal water level — coastal tiles flood and drain with lunar cycle (#3188)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -75,6 +75,7 @@ import {
   tickMoisture,
   tickMycorrhizalNetwork,
   tickSalinity,
+  tickTidal,
   tickTileTemp,
   tickFire,
   tickSoilAge,
@@ -905,6 +906,7 @@ export function tickCreatures(
   tickMoisture(w, tickCount, dt, rng)
   tickCaveNutrient(w, tickCount, dt)
   tickSalinity(w, tickCount)
+  tickTidal(w, tickCount)
   tickMarshDetritus(w, tickCount, dt)
   tickSoilNutrient(w, tickCount)
   w.eggs ??= []

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -2059,6 +2059,77 @@ export function tickWeather(w: WorldState, tickCount: number, rng: () => number)
  * Runs every 1200 ticks (every ~20 seconds of sim time at 60 ticks/s).
  * Uses a fixed random probe rather than a full scan.
  */
+/**
+ * Updates tidal water levels based on the lunar cycle.
+ *
+ * Scans each column for the baseline water surface (topmost water tile in
+ * tidalBaseline). At high tide, floods up to tidalRange rows above that
+ * surface with water. At low tide, exposes up to tidalRange rows of baseline
+ * water as sand. Only active when TUNING.lunarPeriod > 0. Issue #3188.
+ */
+export function tickTidal(w: WorldState, tickCount: number): void {
+  if (TUNING.lunarPeriod <= 0) return
+
+  // Initialize the baseline on first tidal tick — snapshot current terrain.
+  if (!w.tidalBaseline) {
+    w.tidalBaseline = new Uint8Array(w.tiles)
+  }
+
+  const lunarPhase = (w.elapsed % TUNING.lunarPeriod) / TUNING.lunarPeriod
+  w.tidalLevel = Math.sin(lunarPhase * 2 * Math.PI)
+
+  // Throttle tile updates to every 5 ticks for performance.
+  if (tickCount % 5 !== 0) return
+
+  const WATER = MATERIAL_INDEX.water
+  const SAND = MATERIAL_INDEX.sand
+  const tidalRange = Math.max(1, Math.round(TUNING.tidalRange))
+  // Positive offset = high tide (water covers terrain above baseline).
+  // Negative offset = low tide (baseline water exposed as sand).
+  const offset = Math.round(w.tidalLevel * tidalRange)
+
+  for (let x = 0; x < WORLD_W; x++) {
+    // Find the topmost water tile in the baseline for this column.
+    let baselineWaterTop = -1
+    for (let y = 0; y < WORLD_H; y++) {
+      if (w.tidalBaseline[y * WORLD_W + x] === WATER) {
+        baselineWaterTop = y
+        break
+      }
+    }
+    if (baselineWaterTop < 0) continue // no water in this column
+
+    // The intertidal zone spans tidalRange rows above and below the baseline.
+    const zoneTop = Math.max(0, baselineWaterTop - tidalRange)
+    const zoneBottom = Math.min(WORLD_H - 1, baselineWaterTop + tidalRange - 1)
+
+    for (let y = zoneTop; y <= zoneBottom; y++) {
+      const i = y * WORLD_W + x
+      const baseline = w.tidalBaseline[i]
+
+      if (y < baselineWaterTop) {
+        // Above baseline — terrain that floods at high tide.
+        // Flood if within the tide offset (tide is high enough to reach this row).
+        const flooded = y >= baselineWaterTop - offset
+        if (flooded && !IS_SOLID[baseline]) {
+          w.tiles[i] = WATER
+        } else {
+          w.tiles[i] = baseline
+        }
+      } else {
+        // At or below baseline water surface — water exposed at low tide.
+        const exposed = y < baselineWaterTop - offset
+        if (exposed && baseline === WATER) {
+          // Expose as sand (intertidal flat).
+          w.tiles[i] = SAND
+        } else {
+          w.tiles[i] = baseline
+        }
+      }
+    }
+  }
+}
+
 export function tickMineralVeins(w: WorldState, tickCount: number, rng: () => number): void {
   if (tickCount % 1200 !== 0) return
   const stoneIdx = MATERIAL_INDEX.stone

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -118,6 +118,16 @@ export const TUNING_DEFAULTS = {
    */
   dayLengthSeconds: 0,
   /**
+   * How long one lunar cycle lasts, in sim seconds.
+   * 0 = no tidal cycle (default). 600 = one cycle every ten real-world minutes at normal speed.
+   */
+  lunarPeriod: 0,
+  /**
+   * Maximum number of tile rows the tide floods or drains from the baseline water surface.
+   * Default 3 tiles.
+   */
+  tidalRange: 3,
+  /**
    * How long an egg takes to hatch, in sim seconds.
    */
   eggHatchSeconds: 15,
@@ -509,6 +519,26 @@ export const KNOBS: Knob[] = [
     min: 0,
     max: 0.5,
     step: 0.05,
+  },
+  {
+    key: 'lunarPeriod',
+    group: 'world',
+    label: 'Tidal cycle length',
+    help: 'How long one full lunar cycle takes in simulation time. 0 disables tides. 600 is one cycle every ten real-world minutes at normal speed. Coastal tiles flood at high tide and drain at low tide.',
+    min: 0,
+    max: 3000,
+    step: 30,
+    unit: 's',
+  },
+  {
+    key: 'tidalRange',
+    group: 'world',
+    label: 'Tidal range (tiles)',
+    help: 'How many tile rows the tide floods or drains from the shoreline. 3 is a gentle tide; 8 creates dramatic tidal flats.',
+    min: 1,
+    max: 12,
+    step: 1,
+    unit: 'tiles',
   },
   {
     key: 'eggHatchSeconds',

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -2381,6 +2381,19 @@ export interface WorldState {
   crabConstitutionRatified?: boolean
   /** World elapsed time of the last Duck Town Hall vote. Issue #3297. */
   duckTownHallTime?: number
+  /**
+   * Current tidal level, -1 (low tide) to +1 (high tide).
+   * Computed from lunarPhase = (elapsed % lunarPeriod) / lunarPeriod
+   * as sin(lunarPhase * 2π). Updated each tick when lunarPeriod > 0.
+   * Issue #3188.
+   */
+  tidalLevel?: number
+  /**
+   * Per-tile baseline terrain snapshot taken at world initialization (or first tidal tick).
+   * Used to restore exposed intertidal tiles when the tide retreats.
+   * Issue #3188.
+   */
+  tidalBaseline?: Uint8Array
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `lunarPeriod` (default 0 = disabled) and `tidalRange` (default 3 tiles) to the tuning system, exposed as player-facing sliders in the World knobs panel
- Adds `tidalLevel` (−1 to +1) and `tidalBaseline` (terrain snapshot) to `WorldState`
- `tickTidal()` in `world.ts` snapshots terrain on first run, then each cycle computes `lunarPhase = elapsed % lunarPeriod / lunarPeriod` → `tidalLevel = sin(phase × 2π)` and floods/drains intertidal columns accordingly — high tide covers up to `tidalRange` rows above the baseline shoreline with water; low tide exposes that many rows of baseline water as sand
- `tickTidal` is called from `tickCreatures` in `creature-sim.ts` after `tickSalinity`
- Tile updates throttled to every 5 ticks; column scan is O(WORLD_W × tidalRange), negligible

## Test plan
- [ ] TypeScript compiles without errors (CI)
- [ ] With `lunarPeriod = 0`, no tile changes occur (disabled by default)
- [ ] With `lunarPeriod = 120` on a Tidepool world, shoreline tiles visibly flood and drain twice per cycle
- [ ] At high tide (`tidalLevel ≈ +1`) intertidal tiles convert to water; at low tide (`tidalLevel ≈ −1`) baseline-water tiles expose as sand
- [ ] No tile changes occur in worlds with no surface water

Closes #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)