### PR TITLE
feat(dicebound): the condition track

### DIFF
--- a/src/app/dicebound/domain/__tests__/body.test.ts
+++ b/src/app/dicebound/domain/__tests__/body.test.ts
@@ -1,0 +1,282 @@
+/**
+ * The condition track.
+ *
+ * Nearly every test here is a property asserted exhaustively rather than a
+ * hand-picked case, because `STEPS` is thirty-six numbers written out by hand
+ * and the interesting failure is a typo in one of them — `grievous` costing less
+ * than `bloody` at one danger setting and one band would never show up in a
+ * spot check, and would quietly make a whole row of the table meaningless.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  CONDITION_LABEL,
+  CONDITION_ORDER,
+  CONDITION_PHRASE,
+  type Condition,
+  DAMAGE_TABLE,
+  DANGER_ORDER,
+  DEFAULT_DANGER,
+  SEVERITY_ORDER,
+  TRACK_LENGTH,
+  applyDamage,
+  conditionIndex,
+  damageFor,
+  damageRow,
+  isDead,
+  undamagedBody,
+  validateBody,
+  validateDanger,
+  validateSeverity,
+  worsen,
+} from '@/app/dicebound/domain/body'
+import { BAND_ORDER } from '@/app/dicebound/domain/dice'
+import type { OutcomeBand } from '@/app/dicebound/domain/dice'
+
+const SUCCESSES: readonly OutcomeBand[] = ['critical-success', 'strong-success', 'success']
+const FAILURES: readonly OutcomeBand[] = ['failure', 'strong-failure', 'critical-failure']
+
+describe('the track', () => {
+  it('runs best to worst and ends in death', () => {
+    expect(CONDITION_ORDER[0]).toBe('unhurt')
+    expect(CONDITION_ORDER[CONDITION_ORDER.length - 1]).toBe('dead')
+    expect(TRACK_LENGTH).toBe(CONDITION_ORDER.length - 1)
+  })
+
+  it('gives every rung a word for the sheet and a phrase for the dungeon master', () => {
+    // A rung with no phrase is a rung the DM narrates from nothing, which is how
+    // the prose starts disagreeing with the sheet.
+    for (const condition of CONDITION_ORDER) {
+      expect(CONDITION_LABEL[condition]).toBeTruthy()
+      expect(CONDITION_PHRASE[condition].length).toBeGreaterThan(20)
+    }
+  })
+
+  it('indexes rungs in order, and reads an unknown one as unhurt', () => {
+    CONDITION_ORDER.forEach((condition, index) => {
+      expect(conditionIndex(condition)).toBe(index)
+    })
+    expect(conditionIndex('sprained' as Condition)).toBe(0)
+  })
+
+  it('starts a character unhurt and not dead', () => {
+    expect(undamagedBody().condition).toBe('unhurt')
+    expect(isDead(undamagedBody())).toBe(false)
+    expect(isDead({ condition: 'dying' })).toBe(false)
+    expect(isDead({ condition: 'dead' })).toBe(true)
+  })
+})
+
+describe('the severity table', () => {
+  it('anchors every row with a concrete example, because that is the safety mechanism', () => {
+    // The risk this table exists to manage is the DM assigning `lethal` to
+    // something the fiction never signalled was lethal. An unanchored row is a
+    // row the model picks on vibes.
+    for (const severity of SEVERITY_ORDER) {
+      const row = damageRow(severity)
+      expect(row.severity).toBe(severity)
+      expect(row.example.length).toBeGreaterThan(30)
+    }
+    expect(DAMAGE_TABLE).toHaveLength(SEVERITY_ORDER.length)
+  })
+
+  it('warns in the lethal row itself that the player must have been able to see it coming', () => {
+    expect(damageRow('lethal').example).toMatch(/could not have known|already told them/)
+  })
+
+  it('reads an unrecognised severity off a tool call as the mildest one', () => {
+    // The model writes this field. Repairing upward would let a typo kill
+    // someone; repairing downward costs at worst a wound that did not land.
+    expect(validateSeverity('devastating')).toBe('bruising')
+    expect(validateSeverity(undefined)).toBe('bruising')
+    expect(validateSeverity('grievous')).toBe('grievous')
+  })
+})
+
+describe('damageFor', () => {
+  it('costs nothing on a success, at every severity and every danger', () => {
+    // You made the check. Charging for it would punish people for winning and
+    // make refusing to roll the safest play.
+    for (const danger of DANGER_ORDER) {
+      for (const severity of SEVERITY_ORDER) {
+        for (const band of SUCCESSES) {
+          expect(damageFor(severity, band, danger)).toBe(0)
+        }
+      }
+    }
+  })
+
+  it('never costs less for a worse band', () => {
+    for (const danger of DANGER_ORDER) {
+      for (const severity of SEVERITY_ORDER) {
+        const steps = FAILURES.map(band => damageFor(severity, band, danger))
+        expect(steps).toEqual([...steps].sort((a, b) => a - b))
+      }
+    }
+  })
+
+  it('never costs less for a worse severity', () => {
+    for (const danger of DANGER_ORDER) {
+      for (const band of FAILURES) {
+        const steps = SEVERITY_ORDER.map(severity => damageFor(severity, band, danger))
+        expect(steps).toEqual([...steps].sort((a, b) => a - b))
+      }
+    }
+  })
+
+  it('never costs less in a more dangerous world — perilous ≥ ordinary ≥ gentle', () => {
+    // The dial is the reason this parameter exists (#3777). Three rows that do
+    // not actually differ in the right direction are three rows of nothing.
+    for (const severity of SEVERITY_ORDER) {
+      for (const band of FAILURES) {
+        const steps = DANGER_ORDER.map(danger => damageFor(severity, band, danger))
+        expect(steps).toEqual([...steps].sort((a, b) => a - b))
+      }
+    }
+  })
+
+  it('defaults to the middle setting, so a caller with no dial gets the tuned table', () => {
+    for (const severity of SEVERITY_ORDER) {
+      for (const band of BAND_ORDER) {
+        expect(damageFor(severity, band)).toBe(damageFor(severity, band, DEFAULT_DANGER))
+      }
+    }
+    expect(DEFAULT_DANGER).toBe('ordinary')
+  })
+
+  it('lets an ordinary near miss with nothing sharp in it cost nothing at all', () => {
+    // Most failed checks are not injuries. A track that ticked on every miss
+    // would walk a talkative character to death through a series of arguments.
+    expect(damageFor('bruising', 'failure', 'ordinary')).toBe(0)
+  })
+})
+
+describe('what bruising can never do', () => {
+  it('cannot kill, from any rung, on any band, at any danger setting', () => {
+    // This is the difference between a tense game and one where people stop
+    // playing: a character on the ground finished by a scraped elbow reads as
+    // an accident rather than an ending.
+    for (const danger of DANGER_ORDER) {
+      for (const band of BAND_ORDER) {
+        for (const from of CONDITION_ORDER) {
+          if (from === 'dead') continue
+          expect(applyDamage({ condition: from }, 'bruising', band, danger).to).not.toBe('dead')
+        }
+      }
+    }
+  })
+
+  it('still cannot kill at perilous, where every other row got worse', () => {
+    expect(applyDamage({ condition: 'dying' }, 'bruising', 'critical-failure', 'perilous').to).toBe(
+      'dying'
+    )
+  })
+
+  it('carries the rule on the row rather than somewhere the next severity would miss it', () => {
+    expect(damageRow('bruising').fatal).toBe(false)
+    expect(SEVERITY_ORDER.filter(s => !damageRow(s).fatal)).toEqual(['bruising'])
+  })
+})
+
+describe('lethal', () => {
+  it('ends a healthy character on a natural 1 — and that is intended', () => {
+    // It needs two things at once: a scene the fiction already flagged as
+    // deadly, and a critical failure. If that could not kill, nothing in this
+    // game could ever kill you on the day it happened.
+    const change = applyDamage(undamagedBody(), 'lethal', 'critical-failure', 'ordinary')
+    expect(change.to).toBe('dead')
+    expect(change.died).toBe(true)
+    expect(change.steps).toBe(TRACK_LENGTH)
+  })
+
+  it('leaves a healthy character alive at gentle, where death has to be walked into', () => {
+    const change = applyDamage(undamagedBody(), 'lethal', 'critical-failure', 'gentle')
+    expect(change.to).not.toBe('dead')
+    expect(change.to).toBe('broken')
+  })
+
+  it('does not spare a character who was already dying', () => {
+    expect(applyDamage({ condition: 'dying' }, 'lethal', 'failure', 'ordinary').to).toBe('dead')
+  })
+})
+
+describe('worsen', () => {
+  it('does nothing when the blow cost nothing', () => {
+    expect(worsen('hurt', 0, true)).toBe('hurt')
+    expect(worsen('hurt', -2, true)).toBe('hurt')
+  })
+
+  it('never moves a body back up the track', () => {
+    // A non-fatal blow floors at `dying`, and a body already there stays there
+    // rather than being pulled up to it.
+    expect(worsen('dying', 3, false)).toBe('dying')
+    expect(worsen('dead', 3, false)).toBe('dead')
+  })
+
+  it('leaves the dead where they are, whatever hits them next', () => {
+    expect(worsen('dead', 6, true)).toBe('dead')
+  })
+
+  it('stops at the end of the track rather than running off it', () => {
+    expect(worsen('broken', 99, true)).toBe('dead')
+    expect(worsen('broken', 99, false)).toBe('dying')
+  })
+
+  it('leaves dying reachable and survivable, so the last step is a moment not a switch', () => {
+    // `dying` is a rung. Nothing here marks it terminal, which is what lets a
+    // later healing pass climb back out of it.
+    expect(worsen('broken', 1, true)).toBe('dying')
+    expect(worsen('dying', 0, true)).toBe('dying')
+  })
+})
+
+describe('applyDamage', () => {
+  it('reports what actually happened, not what the table asked for', () => {
+    // The DM being told a wound cost three rungs when the floor let it cost one
+    // is how prose starts disagreeing with the sheet.
+    const change = applyDamage({ condition: 'broken' }, 'bruising', 'critical-failure', 'perilous')
+    expect(damageFor('bruising', 'critical-failure', 'perilous')).toBe(2)
+    expect(change.from).toBe('broken')
+    expect(change.to).toBe('dying')
+    expect(change.steps).toBe(1)
+    expect(change.died).toBe(false)
+  })
+
+  it('leaves the body object untouched when nothing moved', () => {
+    const body = undamagedBody()
+    const change = applyDamage(body, 'bruising', 'success')
+    expect(change.body).toBe(body)
+    expect(change.steps).toBe(0)
+  })
+
+  it('does not report a second death for a body that was already dead', () => {
+    const change = applyDamage({ condition: 'dead' }, 'lethal', 'critical-failure')
+    expect(change.died).toBe(false)
+    expect(change.steps).toBe(0)
+  })
+})
+
+describe('reading a body off the wire', () => {
+  it('reads a body full of garbage as undamaged rather than throwing', () => {
+    // Losing the index must never cost the player the story, and it must
+    // certainly never cost them a character.
+    expect(validateBody(undefined).condition).toBe('unhurt')
+    expect(validateBody(null).condition).toBe('unhurt')
+    expect(validateBody('dead').condition).toBe('unhurt')
+    expect(validateBody([]).condition).toBe('unhurt')
+    expect(validateBody({ condition: 42 }).condition).toBe('unhurt')
+    expect(validateBody({ condition: 'sprained' }).condition).toBe('unhurt')
+  })
+
+  it('keeps a condition it recognises', () => {
+    for (const condition of CONDITION_ORDER) {
+      expect(validateBody({ condition }).condition).toBe(condition)
+    }
+  })
+
+  it('reads a missing danger dial as ordinary', () => {
+    expect(validateDanger(undefined)).toBe(DEFAULT_DANGER)
+    expect(validateDanger('reckless')).toBe(DEFAULT_DANGER)
+    expect(validateDanger('gentle')).toBe('gentle')
+  })
+})

--- a/src/app/dicebound/domain/__tests__/migration.test.ts
+++ b/src/app/dicebound/domain/__tests__/migration.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, it } from 'vitest'
 
+import { undamagedBody } from '@/app/dicebound/domain/body'
 import {
   CAMPAIGN_VERSION,
   emptyStats,
@@ -64,6 +65,10 @@ describe('version 1 campaigns', () => {
     expect(campaign?.chapters).toBe(0)
   })
 
+  it('arrive with an undamaged body, because injury did not exist when they were saved', () => {
+    expect(validateCampaign(v1())?.body).toEqual(undamagedBody())
+  })
+
   it('ignore any version 2 fields that somehow came along', () => {
     const campaign = validateCampaign(v1({ kit: { className: 'Cat Burglar' }, chapters: 4 }))
     expect(campaign?.kit.className).toBeNull()
@@ -88,6 +93,31 @@ describe('version 2 campaigns', () => {
     expect(campaign?.world.entities.kell?.name).toBe('Bosun Kell')
     expect(campaign?.kit.className).toBe('Cat Burglar')
     expect(campaign?.chapters).toBe(2)
+  })
+
+  it('load with an undamaged body — the whole of the version 2 to 3 migration', () => {
+    // The stakes here are a step above the last bump. Refusing a version 2
+    // campaign would delete every story in existence; repairing its missing body
+    // toward the middle of the track would kill characters over an absent field.
+    const campaign = validateCampaign({ ...v1(), version: 2 })
+    expect(campaign?.body).toEqual(undamagedBody())
+    expect(campaign?.version).toBe(CAMPAIGN_VERSION)
+  })
+})
+
+describe('version 3 campaigns', () => {
+  it('keep the rung the character was actually on', () => {
+    const campaign = validateCampaign({ ...v1(), version: 3, body: { condition: 'bloodied' } })
+    expect(campaign?.body.condition).toBe('bloodied')
+  })
+
+  it('read a body full of garbage from the wire as undamaged rather than throwing', () => {
+    // A body is the one field where a parse failure could cost the player a
+    // character rather than an index, so it repairs in the survivable direction.
+    expect(validateCampaign({ ...v1(), version: 3, body: 'dead' })?.body).toEqual(undamagedBody())
+    expect(
+      validateCampaign({ ...v1(), version: 3, body: { condition: 'exploded' } })?.body
+    ).toEqual(undamagedBody())
   })
 })
 

--- a/src/app/dicebound/domain/body.ts
+++ b/src/app/dicebound/domain/body.ts
@@ -1,0 +1,438 @@
+/**
+ * The body — how much a character has left, and the last step off the end of it.
+ *
+ * Until this file existed a Dicebound character could not end. There was no hit
+ * point, no wound and no death anywhere in the game, which is why "danger" was
+ * an adjective in a prompt rather than a thing that could happen to anyone.
+ *
+ * Three decisions shape everything here, and all three were settled before a
+ * line of it was written (#3769):
+ *
+ * **It is a track, not a pool.** A visible number of hit points turns a
+ * storytelling game into a combat game — it hands the player a quantity to
+ * optimise, and quantities get optimised. The track is a short ordered list of
+ * states the fiction can describe and the sheet can name, and the bottom of it
+ * is death.
+ *
+ * **The track never touches the die.** Nothing in this file returns a modifier,
+ * and nothing that reads it may turn a rung into one. This is the opposite of
+ * most systems and it is deliberate: a penalty on a track that only moves
+ * downward is a death spiral, and permadeath makes a death spiral terminal —
+ * two bad rolls and the game is decided while the player watches the rest of it
+ * happen. The track counts down toward an ending; it does not make the ending
+ * arrive faster.
+ *
+ * **The model says how much it hurt, before it knows whether it landed.** This
+ * is the one place damage touches the invariant the whole game rests on, so it
+ * borrows the split `roll_check` already uses. A fall from a roof and a barked
+ * shin are genuinely not the same and no formula knows which is which — only
+ * the fiction does. So the dungeon master picks a `Severity` from a fixed table
+ * *in the same breath as it names the DC*, before the die exists, and every
+ * number after that comes from here.
+ *
+ * The failure that split prevents is specific and would otherwise be certain: a
+ * model that can see the player's current rung *and* choose the damage will
+ * leave them one step above dead, forever. Not out of malice — it is agreeable
+ * and the story is going well. That is permadeath quietly becoming something
+ * else without anyone deciding it should.
+ *
+ * Pure, like everything else in `domain/`. No clock, no `Math.random`, nothing
+ * read from ambient state — the danger setting arrives as an argument for the
+ * same reason the rng does elsewhere.
+ */
+import { isPlainObject, oneOf } from './validate'
+
+import type { OutcomeBand } from './dice'
+
+// ------------------------------------------------------------------ the track
+
+/**
+ * Every state a body can be in, and the one it cannot come back from.
+ *
+ * Seven rungs, six steps end to end. The count is a design number and the thing
+ * it buys is *room*: a character has to be hurt several distinguishable times
+ * before dying is on the table, so the fiction gets to describe a decline rather
+ * than announce a result. Fewer rungs and the middle of the track stops meaning
+ * anything; more and the names stop being distinguishable in prose, which is the
+ * only place the player meets them.
+ *
+ * **`dying` is a rung, not a synonym for `dead`.** It is the entire reason the
+ * last step is something the story can spend a moment on instead of a light
+ * switch — someone is on the ground and going, and what happens in the next
+ * turn matters. It is deliberately climbable: nothing here marks it terminal,
+ * and `worsen` will happily leave a body sitting there. Only `dead` is an
+ * ending, and the only thing that cannot reach it is `bruising` — everything the
+ * fiction called a real injury still finishes someone who is already down.
+ */
+export type Condition = 'unhurt' | 'grazed' | 'hurt' | 'bloodied' | 'broken' | 'dying' | 'dead'
+
+/**
+ * Best to worst, and the only ordering there is.
+ *
+ * The type is a union and unions have no order, so this array is what "one step
+ * worse" means. Following `BAND_ORDER` in `domain/dice.ts`: a `readonly` array
+ * plus `Record<Condition, …>` lookups, so adding a rung is a type error at every
+ * table rather than a row that silently goes missing from one of them.
+ */
+export const CONDITION_ORDER: readonly Condition[] = [
+  'unhurt',
+  'grazed',
+  'hurt',
+  'bloodied',
+  'broken',
+  'dying',
+  'dead',
+]
+
+/** How many steps there are from perfect health to the end. */
+export const TRACK_LENGTH = CONDITION_ORDER.length - 1
+
+/** The word on the sheet. One of these, never a number. */
+export const CONDITION_LABEL: Record<Condition, string> = {
+  unhurt: 'Unhurt',
+  grazed: 'Grazed',
+  hurt: 'Hurt',
+  bloodied: 'Bloodied',
+  broken: 'Broken',
+  dying: 'Dying',
+  dead: 'Dead',
+}
+
+/**
+ * What the rung feels like, for the dungeon master to narrate from.
+ *
+ * A second string rather than reusing the label, for the reason `BAND_BRIEF`
+ * sits beside `BAND_LABEL` in `dice.ts`: they answer different questions. The
+ * sheet wants a word the player can read at a glance; the DM wants to be told
+ * what state the character is actually in, because a model handed only the word
+ * "Broken" will invent its own severity for it and the prose will drift away
+ * from the track underneath.
+ *
+ * Written in the game's voice. These are player-facing text — the DM quotes
+ * their sense back in narration — not debug labels.
+ */
+export const CONDITION_PHRASE: Record<Condition, string> = {
+  unhurt: 'Whole. Whatever the day has cost so far, it has not cost them this.',
+  grazed:
+    'Scrapes and a shallow cut or two. Nothing that slows them; everything that reminds them.',
+  hurt: 'It is going to be a bad night. They favour one side, and they know they are doing it.',
+  bloodied:
+    'Bleeding in a way that is not going to simply stop. Whatever comes next comes through it.',
+  broken: 'Something in them has given out. They are upright by decision rather than by strength.',
+  dying: 'On the ground and going. Minutes, if nothing changes — and something has to change.',
+  dead: 'Gone. The story does not continue from here.',
+}
+
+/** Where a rung sits on the track. `unhurt` is 0; `dead` is `TRACK_LENGTH`. */
+export function conditionIndex(condition: Condition): number {
+  const index = CONDITION_ORDER.indexOf(condition)
+  // An unrecognised rung reads as unhurt rather than throwing. Nothing should
+  // be able to hand this an off-track value — `validateBody` is the wire and it
+  // clamps — but a body is the one thing in this game a parse error must never
+  // be allowed to cost the player.
+  return index === -1 ? 0 : index
+}
+
+export function isDead(body: Body): boolean {
+  return body.condition === 'dead'
+}
+
+// -------------------------------------------------------------- the body
+
+/**
+ * Everything the game knows about the character's physical state.
+ *
+ * One field today. It is an object rather than a bare `Condition` because the
+ * next two issues in this epic hang things off it — statuses (#3774) and
+ * whatever healing turns out to need — and a field added to an object is a
+ * migration nobody notices, while widening a stored string is not.
+ */
+export interface Body {
+  condition: Condition
+}
+
+export function undamagedBody(): Body {
+  return { condition: 'unhurt' }
+}
+
+/**
+ * Read a body off the wire.
+ *
+ * Follows `validateWorld` rather than `validateCampaign`: it never refuses,
+ * because there is no such thing as a campaign that is unreadable *only* in its
+ * body. An unreadable body is an undamaged body. That direction is not
+ * arbitrary — repairing toward `unhurt` can at worst hand a player back some
+ * health they had lost, while repairing toward the middle of the track could
+ * kill a character over a dropped key, and one of those failures is recoverable.
+ *
+ * A campaign saved before this file existed has no `body` at all, which lands in
+ * exactly the same place. That is the whole of the version 2 → 3 migration.
+ */
+export function validateBody(value: unknown): Body {
+  if (!isPlainObject(value)) return undamagedBody()
+  return { condition: oneOf(value.condition, CONDITION_ORDER, 'unhurt') }
+}
+
+// ----------------------------------------------------------- the severity table
+
+/**
+ * How badly a thing hurts, independent of whether it landed.
+ *
+ * Four rows, deliberately few. The DM picks one when it proposes a check, and a
+ * table it has to choose from is the mechanism that keeps this from becoming a
+ * free-text number — there is no row for "8".
+ */
+export type Severity = 'bruising' | 'bloody' | 'grievous' | 'lethal'
+
+export const SEVERITY_ORDER: readonly Severity[] = ['bruising', 'bloody', 'grievous', 'lethal']
+
+export interface DamageRow {
+  severity: Severity
+  label: string
+  /**
+   * Concrete things that hurt this much. Not decoration — see the table.
+   */
+  example: string
+  /**
+   * Whether this row is allowed to take the last step onto `dead`.
+   *
+   * Kept on the row rather than in a list somewhere else, because it is a fact
+   * about the row and the two would drift apart the first time anyone added a
+   * severity.
+   */
+  fatal: boolean
+}
+
+/**
+ * The dungeon master's own table, the way `DC_TABLE` is.
+ *
+ * **The examples are the whole safety mechanism here, and they are the reason
+ * this table has prose in it at all.** The risk it exists to manage is precise:
+ * a model assigning `lethal` to something the fiction never signalled was
+ * lethal. The player writes "I climb down into the ravine", the DM reaches for
+ * the most dramatic row, and a character forty turns old is gone over a sentence
+ * that read like ordinary movement. No amount of clamping downstream fixes that,
+ * because by then the severity has already been chosen.
+ *
+ * So each row is anchored the way `DC_TABLE` anchors difficulty — with things a
+ * reader can picture — and the `lethal` row carries its own guard in its text.
+ * A row the model has to match against a concrete example is a row it reaches
+ * for less freely than one labelled only "lethal".
+ */
+export const DAMAGE_TABLE: readonly DamageRow[] = [
+  {
+    severity: 'bruising',
+    label: 'bruising',
+    example:
+      'a bad landing, a thrown fist, a door caught on the way through — it hurts and they will feel it tomorrow',
+    fatal: false,
+  },
+  {
+    severity: 'bloody',
+    label: 'bloody',
+    example:
+      'a knife that got through, a fall down a short flight of stairs, a dog that meant it — real injury, nothing that ends anyone today',
+    fatal: true,
+  },
+  {
+    severity: 'grievous',
+    label: 'grievous',
+    example:
+      'a spear, a fall from a roof, fire they had to walk through — the kind of wound the rest of the scene is spent dealing with',
+    fatal: true,
+  },
+  {
+    severity: 'lethal',
+    label: 'lethal',
+    example:
+      'the scene already told them this could kill them: the ravine, the flooded shaft, the thing in the dark that has killed someone before. If the player could not have known, this is not the row.',
+    fatal: true,
+  },
+]
+
+/** The row for a severity, for anything rendering the table or one line of it. */
+export function damageRow(severity: Severity): DamageRow {
+  return DAMAGE_TABLE.find(row => row.severity === severity) ?? DAMAGE_TABLE[0]
+}
+
+/** A severity read off a model's tool call. Anything unrecognised is the mildest. */
+export function validateSeverity(value: unknown): Severity {
+  return oneOf(value, SEVERITY_ORDER, 'bruising')
+}
+
+// ------------------------------------------------------------- the danger dial
+
+/**
+ * How lethal this player wants their world to be.
+ *
+ * Same fiction, different arithmetic. It is a parameter to `damageFor` rather
+ * than anything ambient, so the mapping stays a pure function of things that
+ * were written down — and so this file could land before the dial that sets it
+ * (#3777) exists.
+ *
+ * It governs lethality and nothing else. It is emphatically **not** a content
+ * setting: the all-ages line in the turn prompt is a baseline constraint of this
+ * app and is not on a slider.
+ */
+export type Danger = 'gentle' | 'ordinary' | 'perilous'
+
+export const DANGER_ORDER: readonly Danger[] = ['gentle', 'ordinary', 'perilous']
+
+/** What `damageFor` was tuned against, and what a campaign with no dial reads as. */
+export const DEFAULT_DANGER: Danger = 'ordinary'
+
+export function validateDanger(value: unknown): Danger {
+  return oneOf(value, DANGER_ORDER, DEFAULT_DANGER)
+}
+
+// ---------------------------------------------------------------- the mapping
+
+/** The half of the band union that can cost anything. */
+type FailureBand = Extract<OutcomeBand, 'failure' | 'strong-failure' | 'critical-failure'>
+
+const FAILURE_BANDS: readonly FailureBand[] = ['failure', 'strong-failure', 'critical-failure']
+
+function isFailureBand(band: OutcomeBand): band is FailureBand {
+  return (FAILURE_BANDS as readonly OutcomeBand[]).includes(band)
+}
+
+/**
+ * Steps down the track, by severity and by how badly the check went.
+ *
+ * Written out in full rather than derived from a base row plus a shift, because
+ * these thirty-six numbers *are* the design and a formula would hide which of
+ * them were chosen and which fell out. The properties they have to hold — worse
+ * band costs at least as much, worse severity costs at least as much, higher
+ * danger costs at least as much — are asserted exhaustively in the tests rather
+ * than guaranteed by construction, so a typo here fails a run instead of quietly
+ * making `grievous` cheaper than `bloody`.
+ *
+ * Two numbers in the table are worth pointing at:
+ *
+ * `lethal` on a `critical-failure` is the full length of the track — a healthy
+ * character dies. That is intended and it is the point of the row. It needs two
+ * things to line up at once: a scene the fiction already flagged as deadly, and
+ * a natural 1. Making it survivable would mean nothing in this game can ever
+ * kill you on the day it happens, which is a different game.
+ *
+ * `bruising` on an ordinary `failure` costs nothing at all. Most failed checks
+ * are not injuries, and a track that ticked on every miss would walk a talkative
+ * character to death through a series of arguments.
+ */
+const STEPS: Record<Danger, Record<Severity, Record<FailureBand, number>>> = {
+  gentle: {
+    bruising: { failure: 0, 'strong-failure': 0, 'critical-failure': 1 },
+    bloody: { failure: 0, 'strong-failure': 1, 'critical-failure': 1 },
+    grievous: { failure: 1, 'strong-failure': 1, 'critical-failure': 2 },
+    lethal: { failure: 1, 'strong-failure': 2, 'critical-failure': 4 },
+  },
+  ordinary: {
+    bruising: { failure: 0, 'strong-failure': 1, 'critical-failure': 1 },
+    bloody: { failure: 1, 'strong-failure': 1, 'critical-failure': 2 },
+    grievous: { failure: 1, 'strong-failure': 2, 'critical-failure': 3 },
+    lethal: { failure: 2, 'strong-failure': 3, 'critical-failure': TRACK_LENGTH },
+  },
+  perilous: {
+    bruising: { failure: 0, 'strong-failure': 1, 'critical-failure': 2 },
+    bloody: { failure: 1, 'strong-failure': 2, 'critical-failure': 3 },
+    grievous: { failure: 2, 'strong-failure': 3, 'critical-failure': 4 },
+    lethal: { failure: 3, 'strong-failure': 4, 'critical-failure': TRACK_LENGTH },
+  },
+}
+
+/**
+ * How many rungs a blow costs.
+ *
+ * **A success costs nothing, at every severity.** The check was made; the thing
+ * the severity described did not happen to them. Charging for a success would
+ * punish people for winning and would make the safest play refusing to roll,
+ * which is the opposite of what the game is asking for.
+ */
+export function damageFor(
+  severity: Severity,
+  band: OutcomeBand,
+  danger: Danger = DEFAULT_DANGER
+): number {
+  if (!isFailureBand(band)) return 0
+  return STEPS[danger][severity][band]
+}
+
+// ------------------------------------------------------------ moving the track
+
+/**
+ * What happened to a body, in the shape the DM has to be told it.
+ *
+ * `from` and `to` are both here because "what is wrong with you" and "what just
+ * changed" are different sentences, and a model given only the destination
+ * narrates the state rather than the moment. `steps` is the count *after* the
+ * floor below, so it is what actually happened rather than what the table asked
+ * for — the DM being told a wound cost three rungs when it cost one is exactly
+ * the kind of quiet disagreement between prose and sheet this codebase keeps
+ * running into.
+ */
+export interface BodyChange {
+  body: Body
+  from: Condition
+  to: Condition
+  /** Rungs actually descended. Zero when the blow did nothing. */
+  steps: number
+  /** True only on the step that ends the run. */
+  died: boolean
+}
+
+/**
+ * Walk a body down the track.
+ *
+ * `fatal` is whether this particular source of damage is allowed to take the
+ * last step. It is not a safety valve bolted on afterwards — it is what makes
+ * `bruising` mean something. A row that can kill from any rung is just a smaller
+ * `lethal`, and without this a character on `dying` could be finished by a
+ * scraped elbow, which reads as an accident rather than an ending.
+ *
+ * A non-fatal blow floors at `dying` instead. That leaves `dying` genuinely
+ * dangerous — anything the fiction called a real injury still finishes it — while
+ * keeping the last step something the story had to earn.
+ *
+ * Healing, when it arrives, is this function with the sign flipped and one extra
+ * rule: `dead` does not move. It is deliberately not here. How a character gets
+ * better — rest, a check, time off the clock, an item — is a real design question
+ * and answering it badly makes the whole track meaningless, so it gets its own
+ * decision once death has actually been played.
+ */
+export function worsen(condition: Condition, steps: number, fatal: boolean): Condition {
+  if (steps <= 0) return condition
+  if (condition === 'dead') return 'dead'
+
+  const ceiling = fatal ? TRACK_LENGTH : TRACK_LENGTH - 1
+  const next = Math.min(ceiling, conditionIndex(condition) + Math.round(steps))
+  // A non-fatal blow that lands on someone already past its ceiling leaves them
+  // where they are rather than pulling them back up the track.
+  return CONDITION_ORDER[Math.max(conditionIndex(condition), next)]
+}
+
+/**
+ * The whole of taking a hit: table, floor, and the record of what moved.
+ *
+ * This is the function routes and tools should call. `damageFor` and `worsen`
+ * are exported beside it because they are separately testable and separately
+ * meaningful, not because anything upstream should be assembling them by hand —
+ * a caller that forgets to pass `fatal` from the row has silently deleted the
+ * rule that `bruising` cannot kill.
+ */
+export function applyDamage(
+  body: Body,
+  severity: Severity,
+  band: OutcomeBand,
+  danger: Danger = DEFAULT_DANGER
+): BodyChange {
+  const from = body.condition
+  const to = worsen(from, damageFor(severity, band, danger), damageRow(severity).fatal)
+
+  return {
+    body: to === from ? body : { ...body, condition: to },
+    from,
+    to,
+    steps: conditionIndex(to) - conditionIndex(from),
+    died: to === 'dead' && from !== 'dead',
+  }
+}

--- a/src/app/dicebound/domain/campaign.ts
+++ b/src/app/dicebound/domain/campaign.ts
@@ -2,7 +2,7 @@
  * A campaign — everything Dicebound remembers between visits.
  *
  * One campaign per player at a time: a premise, a character, the transcript of
- * everything that has happened, and — since version 2 — a world.
+ * everything that has happened, a world (version 2) and a body (version 3).
  *
  * The transcript is still the story and still authoritative. What `world` adds
  * is an *index* over it: the handful of facts that have to be checkable rather
@@ -20,6 +20,7 @@
  * Set, a Date or a class.
  */
 import { ATTRIBUTE_IDS, isAttributeId, isSkillId } from './attributes'
+import { type Body, undamagedBody, validateBody } from './body'
 import { MAX_SKILL_RANK, blankAttributes, normalizeAttributes } from './character'
 import { type Kit, emptyKit, validateKit } from './kit'
 import { boundedInt, int, isPlainObject, str } from './validate'
@@ -39,11 +40,16 @@ import type { Modifier, OutcomeBand, RolledTwice } from './dice'
  * transcript it already has. Refusing it instead — which is what this file used
  * to do on any mismatch — would silently delete every story in existence and
  * show the player an empty game.
+ *
+ * Version 3 added the body: a condition track that can reach death. Same rule,
+ * and the stakes of getting it wrong are now a step higher — a version 2
+ * campaign reads as a valid campaign with an undamaged body, because the only
+ * honest reading of "this save predates injury" is that nobody has been injured.
  */
-export const CAMPAIGN_VERSION = 2
+export const CAMPAIGN_VERSION = 3
 
 /** Versions this code can read. Anything else is genuinely not a campaign. */
-export const SUPPORTED_VERSIONS: readonly number[] = [1, 2]
+export const SUPPORTED_VERSIONS: readonly number[] = [1, 2, 3]
 
 export interface NarrationEntry {
   kind: 'narration'
@@ -106,6 +112,8 @@ export interface Campaign {
   /** The DM's title for the story, set on the opening turn. */
   title: string
   character: Character
+  /** Where the character is on the condition track. Added in version 3. */
+  body: Body
   /** Places, people, things and threads, plus the clock. Added in version 2. */
   world: World
   /** Carried items, powers, species and the discovered class. Added in version 2. */
@@ -177,6 +185,7 @@ export function newCampaign(
     premise,
     title: 'An Untitled Story',
     character,
+    body: undamagedBody(),
     world: emptyWorld(),
     kit: emptyKit(),
     transcript: [],
@@ -248,6 +257,12 @@ export function validateCampaign(value: unknown): Campaign | null {
     premise: str(value.premise, MAX_PREMISE),
     title: str(value.title, 120, 'An Untitled Story'),
     character,
+    // No `migrating` guard, unlike the two below it. `validateBody` already
+    // reads an absent body as an undamaged one, so the version 2 → 3 migration
+    // is the ordinary path through it rather than a branch that has to be
+    // remembered — and a branch nobody has to remember is a branch that cannot
+    // be forgotten at the next bump.
+    body: validateBody(value.body),
     world: migrating ? emptyWorld() : validateWorld(value.world),
     kit: migrating ? emptyKit() : validateKit(value.kit),
     transcript: transcript.slice(-CONDENSE_AT * 2),


### PR DESCRIPTION
Closes #3771. First in #3769 — pure domain, no route, no tool, no UI.

## Why

A Dicebound character could not end. There is no hit point, wound or death anywhere in `src/app/dicebound` today; the only trace was a line in the phase 2 doc deferring the idea. That single absence is why there is no ceremony, no heirloom, and why "danger" is an adjective in a prompt. `domain/body.ts` is the thing everything else in the epic reads.

## The design decisions, and what they cost

**Seven rungs** — `unhurt → grazed → hurt → bloodied → broken → dying → dead`, six steps end to end. The count buys *room*: a character has to be hurt several distinguishable times before dying is on the table, so the fiction describes a decline rather than announcing a result. Fewer and the middle stops meaning anything; more and the names stop being distinguishable in prose, which is the only place the player meets them.

**`dying` is climbable.** The issue asked for a decision. Nothing in the file marks it terminal — only `dead` is an ending — which is what lets a later healing pass reach it. That is the whole reason it exists as a rung rather than as a spelling of "dead".

**`bruising` cannot take the last step, and the rule lives on the row.** `DamageRow.fatal` rather than a `CANNOT_KILL` list somewhere else, because it is a fact about the row and the two would drift the first time anyone added a severity. A non-fatal blow floors at `dying`. Without this a character on the ground could be finished by a scraped elbow — which reads as an accident, not an ending. Everything the fiction *did* call a real injury still finishes them, so `dying` stays genuinely dangerous.

**Lethal on a critical failure kills a healthy character, and that is intended.** `damageFor('lethal', 'critical-failure', 'ordinary')` is the full length of the track. It needs two things to line up: a scene the fiction already flagged as deadly, and a natural 1. Making it survivable would mean nothing in this game can kill you on the day it happens, which is a different game. At `gentle` the same blow lands on `broken` — death is reachable there but you have to walk into it.

**The severity table's examples are the safety mechanism, not decoration.** The failure it manages is a DM assigning `lethal` to something the fiction never signalled as lethal — the player writes "I climb down into the ravine" and a forty-turn character is gone. No downstream clamp fixes that, because the severity was already chosen. So each row is anchored the way `DC_TABLE` anchors difficulty, and the `lethal` row carries its own guard in its text: *"If the player could not have known, this is not the row."* A test asserts that sentence is still there.

**`STEPS` is written out, not derived.** Thirty-six numbers. A base row plus a danger shift would have been shorter and would have hidden which numbers were chosen and which fell out. The properties they have to hold are asserted exhaustively instead — worse band, worse severity and higher danger each cost at least as much, over every combination — so a typo fails a run rather than quietly making `grievous` cheaper than `bloody`.

**Danger is a parameter with a middle default**, so this landed without #3777. `Danger`, `DANGER_ORDER`, `DEFAULT_DANGER` and `validateDanger` are exported for it; `Campaign.danger` and the control are that issue's.

## What I deliberately did not do

**No healing.** The issue defers it and the deferral is right — answering it badly makes the track meaningless. What I left room for: `worsen` is the walker, and healing is the same function with the sign flipped plus one rule (`dead` does not move). `Body` is an object with one field rather than a bare `Condition`, so statuses (#3774) and whatever healing needs are field additions rather than a widened stored string.

**No penalty to the die.** Nothing in the file returns a modifier. Settled in #3769 and stated at the top of the module so the next person does not add a "wounded −1 just in case".

**No route, tool, prompt or UI.** Nothing calls `applyDamage` yet — #3772 is what wires it in. That is also why there is no real-turn verification below: there is no turn to run. The prompt, tool schemas and turn loop are untouched by this diff.

## Migration

`CAMPAIGN_VERSION` → 3, `SUPPORTED_VERSIONS` → `[1, 2, 3]`. `Campaign.body` is added through `newCampaign`, so every existing constructor picked it up.

`validateBody` follows `validateWorld` rather than `validateCampaign` — it never refuses, and it repairs toward `unhurt`. That direction is not arbitrary: repairing upward can at worst hand a player back health they had lost, while repairing toward the middle of the track could kill a character over a dropped key. Because an absent body already reads as undamaged, the v2 → v3 migration is the ordinary path through the function rather than a `migrating` branch someone has to remember at the next bump.

## Verification

```
$ npm run typecheck
> tsc --noEmit
(clean — the ~11 pre-existing errors the skill doc mentions are gone; that note is stale)

$ npx tsc --noEmit 2>&1 | grep dicebound
(empty)

$ npx vitest run src/app/dicebound
 Test Files  1 failed | 16 passed (17)
      Tests  3 failed | 381 passed (384)
```

The 3 failures are all in `components/__tests__/suggestions.test.tsx` (`window.localStorage.setItem is not a function`) and are **pre-existing** — confirmed by stashing this branch and rerunning that file alone on `main`: same 3 failures. Not touched by this diff.

New tests alone:

```
$ npx vitest run domain/__tests__/body.test.ts domain/__tests__/migration.test.ts
 ✓ body.test.ts (30 tests)
 ✓ migration.test.ts (16 tests)
      Tests  46 passed (46)
```

```
$ npx eslint src/app/dicebound src/lib/dicebound
2 problems — both pre-existing, in files this diff does not touch:
  components/__tests__/suggestions.test.tsx  11:1  import/order
  domain/__tests__/loot.test.ts               8:3  sort-imports

$ npm run lint:routes
check-route-slugs: ok

$ npx prettier --check <touched files>
All matched files use Prettier code style!
```

## Note for whoever picks up #3772

`applyDamage(body, severity, band, danger)` is the function to call, not `damageFor` + `worsen` by hand — a caller that assembles them itself and forgets to pass `fatal` from the row has silently deleted the rule that `bruising` cannot kill. `BodyChange` carries `from`, `to`, the steps *actually* taken after the floor, and `died`, because the DM needs to be told what changed rather than only where they ended up.