### PR TITLE
feat(dicebound): severity on roll_check, and damage lands from the band

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -42,6 +42,17 @@ import {
   skillsOf,
 } from '@/app/dicebound/domain/attributes'
 import {
+  type Body,
+  CONDITION_LABEL,
+  CONDITION_PHRASE,
+  DAMAGE_TABLE,
+  DEFAULT_DANGER,
+  SEVERITY_ORDER,
+  type Severity,
+  applyDamage,
+  validateSeverity,
+} from '@/app/dicebound/domain/body'
+import {
   CONDENSE_AT,
   type Campaign,
   type CheckEntry,
@@ -104,6 +115,14 @@ import {
   shouldNameClass,
 } from '@/app/dicebound/domain/klass'
 import {
+  PROVENANCES,
+  type Provenance,
+  describeQuality,
+  rollQuality,
+  traitsFor,
+  worthOf,
+} from '@/app/dicebound/domain/loot'
+import {
   GRANT_ITEM_TOOL,
   GRANT_POWER_TOOL,
   NARRATE_TOOL,
@@ -116,14 +135,6 @@ import {
   partitionTurnCalls,
 } from '@/app/dicebound/domain/turn'
 import { bool, boundedInt, isPlainObject, oneOf, slug, str } from '@/app/dicebound/domain/validate'
-import {
-  PROVENANCES,
-  type Provenance,
-  describeQuality,
-  rollQuality,
-  traitsFor,
-  worthOf,
-} from '@/app/dicebound/domain/loot'
 import {
   EDGE_KINDS,
   ENTITY_KINDS,
@@ -220,6 +231,23 @@ const MOVE_LINES = BAND_ORDER.map(band => `  ${BAND_LABEL[band]} — ${BAND_MOVE
 
 const HARD_MOVE_LINES = HARD_MOVES.map(move => `  - ${move}`).join('\n')
 
+/**
+ * The severity table, rendered from the same rows the tool enum is built from.
+ *
+ * The examples are not decoration and this is the only place the model ever
+ * reads them. The failure they exist to prevent is a DM reaching for `lethal`
+ * because the sentence was dramatic — the player writes "I climb down into the
+ * ravine" and a forty-turn character is gone. Nothing downstream can fix that,
+ * because by the time the roll resolves the row has already been chosen. So the
+ * rows are anchored in things a reader can picture, exactly the way `DC_LINES`
+ * anchors difficulty.
+ *
+ * What is deliberately *not* rendered is `DamageRow.fatal` or anything about
+ * how many rungs a row costs. The DM picks a row and is told the result; a
+ * model shown the mapping starts tuning it.
+ */
+const SEVERITY_LINES = DAMAGE_TABLE.map(row => `  ${row.label} — ${row.example}`).join('\n')
+
 const SKILL_LINES = ATTRIBUTE_IDS.map(
   id =>
     `  ${ATTRIBUTES[id].name} — ${skillsOf(id)
@@ -255,6 +283,14 @@ Pick the row that honestly fits the attempt. Do not soften a DC because you like
 
 SITUATIONAL MODIFIERS
 Add small bonuses and penalties for what is true in the scene right now: the floor is wet (−2), you have rope (+2), you just mentioned his daughter (−3), you spent the last scene earning her trust (+2). Each is at most ±${MAX_SITUATIONAL}. Name them plainly — the player sees every one on the die card, and this is where they learn that the fiction affects the odds.
+
+WHEN A CHECK CAN HURT THEM
+Most cannot, and leaving severity off is the ordinary case. Picking a lock badly costs time, not blood. Losing an argument costs the argument. A DM that stamps a severity on every check has turned a story into a war of attrition, and the player will feel it long before they can say why.
+Fill it in only when the scene itself contains something that could physically hurt them — a drop, an edge, a fire, a blade already in the air. Then pick the row that matches what is actually there, not the row that matches how exciting the moment feels:
+${SEVERITY_LINES}
+You are choosing this BEFORE the dice are thrown, and that is the entire point of putting it here: you do not yet know whether it lands. A success costs them nothing at all, whatever row you named.
+Never pick lethal for something the player could not have seen coming. If the fiction did not already tell them this could kill them, it is not that row — and if you are reaching for it because the scene needs weight, use a hard move instead.
+The game decides what a hit costs. You are told afterwards what state they are in, and you narrate that and nothing heavier. Do not decide how badly they are hurt, do not describe a wound the roll did not give them, and do not soften one it did.
 
 ATTRIBUTES AND SKILLS
 Every check names one attribute. It may also name one sub-skill, and you should whenever a specific one genuinely applies:
@@ -335,6 +371,12 @@ const RollCheckSchema = z.object({
       'Ids of things the character is carrying that genuinely bear on THIS attempt. Name them and the game decides what they are worth — most are worth nothing, and are named on the card anyway because the reason is real even when the number is not.'
     ),
   dc: z.number().int().min(0).max(30).describe('The difficulty, from the table. Be honest.'),
+  severity: z
+    .enum(SEVERITY_ORDER as unknown as [Severity, ...Severity[]])
+    .optional()
+    .describe(
+      'Only when failing this could physically hurt them, which is not most checks. The row from the table matching what is actually in the scene. Omit it entirely when nothing here can draw blood — that is the ordinary case. A success costs nothing whatever you name here.'
+    ),
   situational: z
     .array(
       z.object({
@@ -490,7 +532,9 @@ const ProvenanceEnum = z.enum(['underfoot', 'given', 'bought', 'taken', 'hoard']
 const GrantItemSchema = z.object({
   name: z
     .string()
-    .describe('What the player would call it. The game slugs this into a stable id — reuse the same name for the same thing.'),
+    .describe(
+      'What the player would call it. The game slugs this into a stable id — reuse the same name for the same thing.'
+    ),
   note: z
     .string()
     .optional()
@@ -501,7 +545,9 @@ const GrantItemSchema = z.object({
   from: z
     .string()
     .optional()
-    .describe('The id of the world entity it came from, if any. Looked up — if it does not exist in the graph, the item is still granted.'),
+    .describe(
+      'The id of the world entity it came from, if any. Looked up — if it does not exist in the graph, the item is still granted.'
+    ),
   consumable: z.boolean().optional().describe('True if using it uses it up.'),
   uses: z.number().int().min(1).max(9).optional().describe('For a consumable: how many times.'),
   traits: z
@@ -509,14 +555,18 @@ const GrantItemSchema = z.object({
       z.object({
         label: z
           .string()
-          .describe('What is true because they have it, as the player would say it: "you have rope". The game assigns the number.'),
+          .describe(
+            'What is true because they have it, as the player would say it: "you have rope". The game assigns the number.'
+          ),
         applies: z
           .object({
             attributes: z.array(AttributeEnum).optional(),
             skills: z.array(SkillEnum).optional(),
           })
           .optional()
-          .describe('Leave empty when it applies everywhere. Name attributes or skills to narrow it.'),
+          .describe(
+            'Leave empty when it applies everywhere. Name attributes or skills to narrow it.'
+          ),
       })
     )
     .max(2)
@@ -525,7 +575,9 @@ const GrantItemSchema = z.object({
   replace: z
     .string()
     .optional()
-    .describe('Id of an item already in the pack to swap out. Use this when the pack is full and the player chose what to put down.'),
+    .describe(
+      'Id of an item already in the pack to swap out. Use this when the pack is full and the player chose what to put down.'
+    ),
 })
 
 const GRANT_ITEM: ToolDef = {
@@ -895,6 +947,10 @@ Resolve it, then call narrate with what happens.`,
   // reopening it, and a turn that never stops is a turn that never comes back.
   let fuseAnswered = false
   let kit = campaign.kit
+  // Carried through the turn the way `kit` and `world` are, rather than being
+  // written back to the campaign at each roll. A turn can roll three times, and
+  // the third blow has to land on the body the first two left behind.
+  let body = campaign.body
   // Both fixed for the whole turn, on purpose.
   //
   // `level` is read once so a skill that ranks up mid-turn cannot also unlock a
@@ -1043,8 +1099,9 @@ Resolve it, then call narrate with what happens.`,
       results.push({ type: 'tool_result', tool_use_id: call.id, content: note })
     }
     for (const call of rolls) {
-      const { entry, brief } = rollFor(campaign, kit, powers, call.input)
+      const { entry, brief, body: afterBlow } = rollFor(campaign, kit, body, powers, call.input)
       entries.push(entry)
+      body = afterBlow
 
       // Spend one charge per named item that bore on this check.
       const rawInput = (call.input ?? {}) as { items?: unknown }
@@ -1145,7 +1202,7 @@ Resolve it, then call narrate with what happens.`,
     })
   }
 
-  return { entries, synopsis, dropped, world, chapters, kit }
+  return { entries, synopsis, dropped, world, chapters, kit, body }
 }
 
 /**
@@ -1220,11 +1277,7 @@ function recallFor(world: World, input: unknown): string {
  * nothing on the die, it describes a sword. That is the same loop `roll_check`
  * runs — commit first, then narrate around a number you did not choose.
  */
-function grantFor(
-  kit: Kit,
-  world: World,
-  input: unknown
-): { kit: Kit; note: string } {
+function grantFor(kit: Kit, world: World, input: unknown): { kit: Kit; note: string } {
   const now = world.clock.elapsed
   const raw = isPlainObject(input) ? input : {}
 
@@ -1462,9 +1515,10 @@ function grantPowerFor(
 function rollFor(
   campaign: Campaign,
   kit: Kit,
+  body: Body,
   powers: TurnPowers,
   input: unknown
-): { entry: CheckEntry; brief: string } {
+): { entry: CheckEntry; brief: string; body: Body } {
   const raw = (input ?? {}) as {
     attempt?: unknown
     attribute?: unknown
@@ -1472,6 +1526,7 @@ function rollFor(
     dc?: unknown
     situational?: unknown
     items?: unknown
+    severity?: unknown
   }
 
   const attribute: AttributeId = isAttributeId(raw.attribute) ? raw.attribute : 'wisdom'
@@ -1520,6 +1575,17 @@ function rollFor(
 
   const outcome = resolveCheck({ dc, modifiers, advantage: claimed.map(entry => entry.source) })
 
+  // Read *before* `validateSeverity`, not through it. That function repairs an
+  // unrecognised row to the mildest one, which is right for a garbled field and
+  // catastrophic for a missing one: passing `undefined` straight through would
+  // stamp `bruising` on every check in the game and turn the ordinary case —
+  // no severity at all — into a slow bleed nobody chose.
+  const severity = typeof raw.severity === 'string' ? validateSeverity(raw.severity) : null
+  // `DEFAULT_DANGER` until the dial exists (#3777). It is passed rather than
+  // defaulted inside `applyDamage` so that the day `Campaign.danger` lands, the
+  // only edit is this argument.
+  const change = severity ? applyDamage(body, severity, outcome.band, DEFAULT_DANGER) : null
+
   const entry: CheckEntry = {
     kind: 'check',
     attempt: typeof raw.attempt === 'string' ? raw.attempt.slice(0, 300) : 'the attempt',
@@ -1549,12 +1615,43 @@ function rollFor(
     // top of a long prompt loses to whatever the model feels like doing by the
     // time a roll comes back; the move quoted next to the number does not.
     `YOUR MOVE: ${BAND_MOVE[outcome.band]}`,
+    // What the model is told about a number changes how it narrates
+    // (invariant 19), and nowhere more sharply than here. A DM told a blow
+    // landed but not how hard writes a maiming, because a maiming is the more
+    // interesting sentence — and then the prose and the sheet describe two
+    // different injuries, which is a bug no test can see.
+    woundBrief(change, outcome.succeeded),
     'Narrate this outcome. Do not restate the numbers — the player can already see them.',
   ]
     .filter(Boolean)
     .join(' ')
 
-  return { entry, brief }
+  return { entry, brief, body: change ? change.body : body }
+}
+
+/**
+ * What the DM is told a wound actually cost, in words.
+ *
+ * The rung is reported and the arithmetic is not. The model named a row and is
+ * handed a state; it never learns how many steps a row is worth, because a
+ * model that can see the mapping can aim at it, and aiming at it is how a DM
+ * that likes the protagonist arranges for them to sit one rung above dead
+ * forever.
+ *
+ * A check the DM flagged as dangerous and then *passed* says nothing at all.
+ * The character is fine, that is what passing means, and a line reading "it did
+ * not hurt them" invites a paragraph about the wound they nearly took.
+ */
+function woundBrief(change: ReturnType<typeof applyDamage> | null, succeeded: boolean): string {
+  if (!change || succeeded) return ''
+  if (change.steps > 0) {
+    return `THAT HURT THEM. They are now ${CONDITION_LABEL[change.to].toLowerCase()}: ${CONDITION_PHRASE[change.to]} Narrate the injury at exactly that weight — not heavier because the moment deserved it, and not lighter because you would rather they were fine.`
+  }
+  // The blow landed on a body the table could not move: a failure whose row
+  // cost nothing at this danger, or `bruising` on someone already dying, where
+  // the floor holds. Said out loud because silence here reads as a success.
+  if (change.from === 'unhurt') return 'It did not mark them. Do not narrate a wound.'
+  return `It cost them nothing further — they are still ${CONDITION_LABEL[change.to].toLowerCase()}. Do not narrate a new wound.`
 }
 
 /**
@@ -1638,7 +1735,35 @@ function sheetBlock(campaign: Campaign): string {
   return `THE CHARACTER
 ${c.name} — ${c.concept}
 Attributes: ${attributes}
-Earned skills: ${skills}${windowBlock(campaign)}${powersBlock(campaign.kit)}${packBlock(campaign.kit)}`
+Earned skills: ${skills}${bodyBlock(campaign.body)}${windowBlock(campaign)}${powersBlock(campaign.kit)}${packBlock(campaign.kit)}`
+}
+
+/**
+ * What is wrong with them, when anything is.
+ *
+ * Absent entirely for an unhurt character, and that is not just tidiness. A
+ * standing line reading "Condition: unhurt" puts the track in front of the DM
+ * on every one of the many turns where nobody is in any danger, and a model
+ * shown a health bar starts looking for reasons to move it. A character who has
+ * never been hurt should not be able to tell this system is here.
+ *
+ * The harder question is whether to show it at all, because the DM both reads
+ * this and picks the severity — which is the exact pairing #3769 warns about: a
+ * model that can see the rung and choose the damage will keep the protagonist
+ * one step above dead. It is shown anyway, for a failure that is worse and
+ * certain rather than gradual and possible. Without it the DM has no memory of
+ * injury across turns, so a character bleeding out gets narrated as fine on the
+ * very next line, and the track becomes a number on a sheet that the story
+ * never once acknowledges — which is a longer way of saying it does not exist.
+ *
+ * What keeps the pairing safe is that seeing the rung buys the model no
+ * arithmetic. It can pick a milder row, and that is a real risk; it cannot pick
+ * a smaller number, cannot see the mapping, and cannot know the die when it
+ * chooses. #3779 is what measures whether the mild-row drift actually happens.
+ */
+function bodyBlock(body: Body): string {
+  if (body.condition === 'unhurt') return ''
+  return `\nCondition: ${CONDITION_LABEL[body.condition].toLowerCase()} — ${CONDITION_PHRASE[body.condition]} Let this show in how they move and what they can face. Do not heal it, and do not forget it.`
 }
 
 /**

--- a/src/app/dicebound/domain/__tests__/body-turn.test.ts
+++ b/src/app/dicebound/domain/__tests__/body-turn.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The body's trip through a finished turn.
+ *
+ * `rollFor` — where severity actually becomes damage — lives in the route and
+ * has no test harness; the epic's answer to that is a real turn, not a mock.
+ * What is testable here is the rule that makes the wound stick, and it is the
+ * one that has already been got wrong twice for `world` and `kit`: a field the
+ * turn did not set must read as *unchanged*, never as reset.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { newCampaign } from '@/app/dicebound/domain/campaign'
+import { blankAttributes } from '@/app/dicebound/domain/character'
+import { applyTurn } from '@/app/dicebound/domain/turn'
+
+function campaign() {
+  return newCampaign(
+    'a lighthouse that has started walking',
+    {
+      name: 'Pell',
+      concept: 'a very small person with a very large hammer',
+      reading: '',
+      attributes: blankAttributes(),
+      skills: {},
+    },
+    1000,
+    null
+  )
+}
+
+describe('the body across a turn', () => {
+  it('keeps the wound the turn inflicted', () => {
+    const after = applyTurn(campaign(), { entries: [], body: { condition: 'bloodied' } }, 2000)
+    expect(after.body.condition).toBe('bloodied')
+  })
+
+  it('leaves the body alone on a turn that never touched it — absent means unchanged, not healed', () => {
+    // A missing field read as an undamaged body would make every quiet turn a
+    // free heal. The player would never see it happen; they would only notice
+    // that nothing that is done to them ever seems to stay done.
+    const hurt = { ...campaign(), body: { condition: 'broken' as const } }
+    expect(applyTurn(hurt, { entries: [] }, 2000).body.condition).toBe('broken')
+  })
+
+  it('does not let a turn that ended without narrating undo a wound it already landed', () => {
+    // Three rolls in one turn land on each other, so the body is carried
+    // through the loop rather than written back per roll — and the fallback
+    // paths out of the loop have to carry it too.
+    const hurt = { ...campaign(), body: { condition: 'hurt' as const } }
+    const after = applyTurn(hurt, { entries: [], body: { condition: 'dying' } }, 2000)
+    expect(after.body.condition).toBe('dying')
+  })
+})

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -8,6 +8,7 @@
  */
 import { type Character, recordSkillUse } from './character'
 
+import type { Body } from './body'
 import type { Campaign, CampaignStats, CheckEntry, TranscriptEntry } from './campaign'
 import type { Kit } from './kit'
 import type { World } from './world'
@@ -131,6 +132,17 @@ export interface TurnResult {
   /** The pack after anything the turn handed over. */
   kit?: Kit
   /**
+   * The body after anything the turn did to it.
+   *
+   * Absent on the opening turn and on any path that never reached a roll, and
+   * absent means *unchanged* rather than restored — the same rule `world` and
+   * `kit` follow. A missing field that read as an undamaged body would make
+   * every failed turn a free heal, which is a subtler bug than it sounds: the
+   * player would never see it happen, they would only notice that nothing they
+   * take ever seems to stay taken.
+   */
+  body?: Body
+  /**
    * The chapter counter after an archive. Set only on a turn that condensed and
    * successfully wrote what it dropped — a failed archive leaves the counter
    * alone, so the next condense reuses the index and overwrites rather than
@@ -208,6 +220,7 @@ export function applyTurn(campaign: Campaign, result: TurnResult, now: number): 
     synopsis: result.synopsis ?? campaign.synopsis,
     world: result.world ?? campaign.world,
     kit: result.kit ?? campaign.kit,
+    body: result.body ?? campaign.body,
     chapters: result.chapters ?? campaign.chapters,
     character,
     transcript: [...kept, ...entries],


### PR DESCRIPTION
Closes #3772. Turn lane.

The condition track shipped in #3789 and nothing could move it — a player asked the DM to hurt them and got a heron explaining that there is no damage tool. This is the wire between the two.

## The shape

`roll_check` gets an optional `severity`. Code turns severity × outcome band × danger into steps down the track, applies them, and tells the DM what state the character is now in.

Severity rides on `roll_check` and nowhere else, because `roll_check` is already the tool that makes the model commit before it learns the die. Put it on `narrate`, or in a second call after the roll, and the failure stops being possible and becomes certain: a model that can see the player's rung *and* choose the damage will leave them one step above dead forever. Not out of malice — it is agreeable, the story is going well, and killing the protagonist is inconvenient.

## The decisions worth arguing with

**`validateSeverity` is called only after the field is confirmed present.** It repairs an unrecognised row to the mildest one, which is right for a garbled field and catastrophic for a missing one — `validateSeverity(undefined)` returns `bruising`, so passing the raw field straight through would have stamped a severity on every check in the game and turned the ordinary case into a slow bleed nobody chose. This is the bug this PR most easily could have shipped.

**The tool result reports the rung, never the arithmetic.** The DM is told "they are now bloodied" plus the rung's phrase, and is never told how many steps a row is worth. What the model is told about a number changes how it narrates (invariant 19) — a DM told a blow landed but not how hard writes a maiming, because a maiming is the better sentence, and then the prose and the sheet describe two different injuries. A model shown the mapping, meanwhile, starts aiming at it.

**A passed check says nothing at all.** `woundBrief` returns empty on a success even when severity was named. "It did not hurt them" is an invitation to write a paragraph about the wound they nearly took.

**The standing prompt shows the condition — but only when they are hurt.** This is the one deliberate concession to the risk above, and it is a real one: a DM that can see the rung can pick milder rows. I took it because the alternative is worse and *certain* rather than gradual and possible — without it the DM has no memory of injury across turns, so a character bleeding out is narrated as fine on the very next line and the track becomes a number the story never once acknowledges. Seeing the rung buys the model no arithmetic: it cannot see the mapping, cannot choose a magnitude, and does not know the die when it picks. #3779 is what measures whether the mild-row drift is real. An unhurt character produces no line at all, so a player who has never been hurt cannot tell this system is here.

**Danger is `DEFAULT_DANGER`,** passed explicitly rather than defaulted inside `applyDamage`, so when #3777 lands the only edit is that argument.

**`TurnResult.body` absent means unchanged, not restored** — the same rule `world` and `kit` follow. A missing field read as an undamaged body would make every quiet turn a free heal, which the player would never see happen; they would only notice that nothing done to them ever stays done. There is a test for exactly that.

## What happens at `dead`, in the interim

Per the issue, death is #3776's job. Today a character who reaches `dead` has it recorded on `Campaign.body` and **play continues** — the DM would be handed the `dead` phrase ("the story does not continue from here") and would narrate an ending, while the composer still accepts input. That is incoherent and it is reachable: `lethal` on a natural 1 from full health, or any fatal row on someone already `dying`. **#3776 should land next, not after the other Body-lane issues.**

## Verification

```
$ npm run typecheck            (clean)
$ npx tsc --noEmit | grep dicebound     (empty)
$ npx vitest run src/app/dicebound
 Test Files  1 failed | 17 passed (18)
      Tests  3 failed | 384 passed (387)
```

The 3 failures are the pre-existing `localStorage` ones in `components/__tests__/suggestions.test.tsx`, unrelated and untouched.

```
$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
4 problems — all pre-existing, all in files this diff does not touch
  api/v1/dicebound/character/route.ts  28:3, 38:3  sort-imports
  components/__tests__/suggestions.test.tsx  11:1  import/order
  domain/__tests__/loot.test.ts  8:3  sort-imports

$ npm run lint:routes    check-route-slugs: ok
$ npx prettier --check <touched>   clean
```

### A real campaign, instrumented

This touches the prompt, a tool schema and the turn loop, so all three triggers fire. I ran a throwaway harness that drives the real `POST` route (same approach as `dicebound-voice-check.ts`), with a temporary `console.error` inside `rollFor` printing the raw `severity` field and the resulting change — because narration that reads correctly is not evidence a tool worked. The instrumentation was removed before commit.

Scenario: *"a pirate ship at the moment the crew decides to mutiny, blades already out."*

```
opening: "Blades Already Out"  body=unhurt

turn 1: 0 check(s) []  body=unhurt
[dmg] raw.severity="bloody"    band=strong-failure    {from:unhurt,   to:grazed,   steps:1}
turn 2: body=grazed     unhurt -> grazed
[dmg] raw.severity="bloody"    band=critical-failure  {from:grazed,   to:bloodied, steps:2}
turn 3: body=bloodied   grazed -> bloodied
[dmg] raw.severity="bloody"    band=success           {from:bloodied, to:bloodied, steps:0}
turn 4: body=bloodied
[dmg] raw.severity="grievous"  band=strong-failure    {from:bloodied, to:dying,    steps:2}
turn 5: FAILED — AbortError (turn timed out; nothing applied)
[dmg] raw.severity=undefined   band=strong-success    change=null
turn 6: body=bloodied
```

Every step matches `STEPS`. The success cost nothing. The prose tracked the rung without being told the number — at `grazed`, *"one of them opening a shallow red line from wrist to elbow"*; at `bloodied`, *"the blood coming through it faster than a fist ought to leak"*; and the turn after, unprompted, *"your right hand will not close now."* That last one is `bodyBlock` doing its job across a turn boundary.

**Two honest caveats about this run.**

One turn of six died to an `AbortError`. Its damage (`bloodied → dying`) was correctly discarded along with the rest of the turn, which is the right behaviour, but a run that loses turns is a run that cannot be reasoned about as a sample — flagging it because the epic's own hazard note is about exactly this.

And **this run cannot measure the base rate of severity use.** Four of five checks carried one, but every action I wrote was some version of "swing a blade at someone in a knife fight". That is the scenario doing the work, not the prompt. Whether the DM reaches for severity on ordinary turns is #3779's question, and it is the number to watch — the failure mode here is gradual and invisible to the suite.

The other thing that run shows is pace: reckless play took a character from `unhurt` to `dying` in four turns at `ordinary` danger. That may be correct for a mutiny, and it may mean `ordinary` is tuned hot. It is a measurement question, not a feel question, so I have not touched the table.