### PR TITLE
feat(dicebound): harm, for damage that is not a failed check

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -50,6 +50,7 @@ import {
   SEVERITY_ORDER,
   type Severity,
   applyDamage,
+  applyHarm,
   validateSeverity,
 } from '@/app/dicebound/domain/body'
 import {
@@ -125,6 +126,7 @@ import {
 import {
   GRANT_ITEM_TOOL,
   GRANT_POWER_TOOL,
+  HARM_TOOL,
   NARRATE_TOOL,
   RECALL_TOOL,
   ROLL_CHECK_TOOL,
@@ -291,6 +293,14 @@ ${SEVERITY_LINES}
 You are choosing this BEFORE the dice are thrown, and that is the entire point of putting it here: you do not yet know whether it lands. A success costs them nothing at all, whatever row you named.
 Never pick lethal for something the player could not have seen coming. If the fiction did not already tell them this could kill them, it is not that row — and if you are reaching for it because the scene needs weight, use a hard move instead.
 The game decides what a hit costs. You are told afterwards what state they are in, and you narrate that and nothing heavier. Do not decide how badly they are hurt, do not describe a wound the roll did not give them, and do not soften one it did.
+
+WHEN THE WORLD HURTS THEM ANYWAY
+Not all damage comes from a failed attempt. An ambush lands before anyone can react. A thread they have been ignoring catches up with them. Poison, fever, cold and hunger do what they were always going to do, whatever the player does that turn. When the fiction is already hurting them and no attempt of theirs is being tested, call harm — the same severity table as roll_check, plus a few words saying why.
+Call it BEFORE you narrate, exactly as you call roll_check before you narrate. You do not know what the injury cost until the game tells you, and a wound you describe first is a wound you invented.
+The line between the two tools is not a matter of taste and nothing sits in the middle:
+- They tried something and it could have gone wrong -> roll_check with a severity. ALWAYS, even when you are certain it fails.
+- Nothing they did is being tested -> harm.
+Do not use harm to avoid setting a DC. At most one in a turn.
 
 ATTRIBUTES AND SKILLS
 Every check names one attribute. It may also name one sub-skill, and you should whenever a specific one genuinely applies:
@@ -483,6 +493,46 @@ const ROLL_CHECK: ToolDef = {
   description:
     'Roll the dice for an uncertain attempt. Returns the roll, the total, and how far above or below the DC it landed. Call this BEFORE narrating an uncertain outcome — you do not know whether it works until you do.',
   input_schema: toolSchema(RollCheckSchema),
+}
+
+/**
+ * Damage with no check behind it.
+ *
+ * `roll_check` covers exactly one case: the player attempted something and the
+ * die went against them. It covers none of the others — a fuse fires and the
+ * thing they have been ignoring catches up, an ambush starts, a fever does what
+ * it promised five turns ago, the cold finally gets through. Without a tool for
+ * those, the dungeon master's only options are to narrate a wound the sheet
+ * never records, or to invent a roll the player never earned. Both are worse
+ * than a second tool.
+ *
+ * There is no outcome field, and there is no DC. The model says *that*
+ * something hurt them and roughly how badly, from the same table `roll_check`
+ * uses, and the game says what it cost.
+ *
+ * `reason` is not decoration and it is not stored anywhere. It is a commitment
+ * device, the same job `uncertain` does on `roll_check`: a model that has to
+ * write "the fever takes hold" before it learns what the fever cost reaches for
+ * this tool less freely than one that only has to pick an enum. A `harm` whose
+ * reason cannot be stated in a few words is usually a `roll_check` the model
+ * did not want to make.
+ */
+const HarmSchema = z.object({
+  severity: z
+    .enum(SEVERITY_ORDER as unknown as [Severity, ...Severity[]])
+    .describe('How badly this hurts, from the same table roll_check uses.'),
+  reason: z
+    .string()
+    .describe(
+      'Why, in a few words, as the player would understand it: "the fever takes hold", "the beam comes down". If the character was attempting something, this is the wrong tool — call roll_check instead.'
+    ),
+})
+
+const HARM: ToolDef = {
+  name: HARM_TOOL,
+  description:
+    'The world hurts the character, with no attempt of theirs being tested: an ambush landing, a thread catching up with them, poison, fever, cold. Call this BEFORE narrating the injury — it returns what state they are now in, and you narrate that. If they tried something that could go wrong, use roll_check with a severity instead. At most once per turn.',
+  input_schema: toolSchema(HarmSchema),
 }
 
 /**
@@ -951,6 +1001,10 @@ Resolve it, then call narrate with what happens.`,
   // written back to the campaign at each roll. A turn can roll three times, and
   // the third blow has to land on the body the first two left behind.
   let body = campaign.body
+  // One harm per turn, latched across passes rather than counted within one.
+  // A turn that rolls, harms, and then rolls again has had its harm — the
+  // ceiling is on the turn the player experiences, not on a single message.
+  let harmed = false
   // Both fixed for the whole turn, on purpose.
   //
   // `level` is read once so a skill that ranks up mid-turn cannot also unlock a
@@ -1004,11 +1058,11 @@ Resolve it, then call narrate with what happens.`,
       // left on the board.
       tools: lastStep
         ? [narrate]
-        : [ROLL_CHECK, RECALL, GRANT_ITEM, GRANT_POWER, USE_POWER, narrate],
+        : [ROLL_CHECK, HARM, RECALL, GRANT_ITEM, GRANT_POWER, USE_POWER, narrate],
       toolChoice: lastStep ? { type: 'tool', name: NARRATE_TOOL } : { type: 'auto' },
     })
 
-    const { rolls, recalls, grants, powerGrants, powerUses, ending, premature } =
+    const { rolls, recalls, grants, powerGrants, powerUses, harms, ending, premature } =
       partitionTurnCalls(toolUses(data))
 
     if (ending) {
@@ -1077,6 +1131,7 @@ Resolve it, then call narrate with what happens.`,
       grants.length === 0 &&
       powerGrants.length === 0 &&
       powerUses.length === 0 &&
+      harms.length === 0 &&
       premature.length === 0
     ) {
       // The model answered in prose instead of declaring the end of the turn.
@@ -1114,6 +1169,15 @@ Resolve it, then call narrate with what happens.`,
           : brief
 
       results.push({ type: 'tool_result', tool_use_id: call.id, content: fullBrief })
+    }
+    // After the rolls, so that a model sending both in one message gets them in
+    // the order it meant them: the thing they attempted resolves, and then the
+    // world does whatever it was going to do regardless.
+    for (const call of harms) {
+      const { body: afterHarm, note, spent } = harmFor(body, harmed, call.input)
+      body = afterHarm
+      harmed = harmed || spent
+      results.push({ type: 'tool_result', tool_use_id: call.id, content: note })
     }
     for (const call of grants) {
       const { kit: next, note } = grantFor(kit, world, call.input)
@@ -1221,6 +1285,7 @@ function fuseBrief(world: World, fired: readonly string[]): string {
   return [
     `Your narration has been discarded — it described time that did not happen. The player did not get the span they asked for: ${names.join('; ') || 'something they had been ignoring'} caught up with them first, and it is now ${describeClock(world.clock)}.`,
     'Narrate the whole turn again from the start, short, ending on that interruption as a hard move. Begin where they began, cover only the time that actually passed, and never mention a clock or say that less time went by than they wanted — just let the thing arrive.',
+    'If the thing that caught up with them hurts them on the way in, call harm first and narrate the injury the game gives you back. This is the case that tool exists for.',
   ].join(' ')
 }
 
@@ -1627,6 +1692,56 @@ function rollFor(
     .join(' ')
 
   return { entry, brief, body: change ? change.body : body }
+}
+
+/**
+ * Resolve one `harm` call.
+ *
+ * `already` is whether this turn has spent its one harm. The ceiling is real
+ * rather than advisory, and it is enforced here instead of in the prompt
+ * because the failure it prevents is not the model misunderstanding the rule —
+ * it is a model that reaches for the simpler tool twice in a scene that felt
+ * like it deserved it, and drains a character across a turn nobody rolled a die
+ * in. A refusal is answered plainly and the turn carries on; it is a normal
+ * answer, not an error, and the DM narrates the scene without the second blow.
+ */
+function harmFor(
+  body: Body,
+  already: boolean,
+  input: unknown
+): { body: Body; note: string; spent: boolean } {
+  if (already) {
+    return {
+      body,
+      spent: false,
+      note: 'They have already been hurt once this turn, and once is the limit. Narrate what is happening to them without a second injury — a scene can be desperate without costing them twice.',
+    }
+  }
+
+  const raw = (input ?? {}) as { severity?: unknown; reason?: unknown }
+  // Unlike `roll_check`, severity is required here: a `harm` with no severity is
+  // not a milder harm, it is a tool call with nothing in it. Repairing it to the
+  // gentlest row is right — the alternative is refusing, and a refused harm on a
+  // turn where the fiction has already committed to an ambush leaves the DM
+  // narrating a blow the sheet never took.
+  const severity = validateSeverity(raw.severity)
+  const change = applyHarm(body, severity, DEFAULT_DANGER)
+  const reason = typeof raw.reason === 'string' ? raw.reason.slice(0, 120) : ''
+
+  return {
+    body: change.body,
+    spent: true,
+    note: [
+      reason ? `${reason} —` : '',
+      change.steps > 0
+        ? `that hurt them. They are now ${CONDITION_LABEL[change.to].toLowerCase()}: ${CONDITION_PHRASE[change.to]} Narrate it at exactly that weight, no heavier.`
+        : change.from === 'unhurt'
+          ? 'it did not mark them. Narrate the moment without an injury.'
+          : `it cost them nothing further — they are still ${CONDITION_LABEL[change.to].toLowerCase()}. Do not narrate a new wound.`,
+    ]
+      .filter(Boolean)
+      .join(' '),
+  }
 }
 
 /**

--- a/src/app/dicebound/domain/__tests__/body.test.ts
+++ b/src/app/dicebound/domain/__tests__/body.test.ts
@@ -19,7 +19,9 @@ import {
   DEFAULT_DANGER,
   SEVERITY_ORDER,
   TRACK_LENGTH,
+  UNCONTESTED_BAND,
   applyDamage,
+  applyHarm,
   conditionIndex,
   damageFor,
   damageRow,
@@ -278,5 +280,50 @@ describe('reading a body off the wire', () => {
     expect(validateDanger(undefined)).toBe(DEFAULT_DANGER)
     expect(validateDanger('reckless')).toBe(DEFAULT_DANGER)
     expect(validateDanger('gentle')).toBe('gentle')
+  })
+})
+
+describe('harm — damage with nothing rolled against it', () => {
+  it('can never kill a healthy character, at any severity or danger', () => {
+    // The guarantee that falls out of resolving at the mildest band. Something
+    // has to have hurt them first, which means a die was thrown somewhere.
+    for (const danger of DANGER_ORDER) {
+      for (const severity of SEVERITY_ORDER) {
+        expect(applyHarm(undamagedBody(), severity, danger).to).not.toBe('dead')
+      }
+    }
+  })
+
+  it('never costs more than losing the same check would have', () => {
+    // The point of pinning it to the cheapest band: the tool that is easier to
+    // reach for is also the weakest move on the board, so a dungeon master
+    // never gains anything by skipping the die.
+    for (const danger of DANGER_ORDER) {
+      for (const severity of SEVERITY_ORDER) {
+        for (const band of ['failure', 'strong-failure', 'critical-failure'] as const) {
+          expect(damageFor(severity, UNCONTESTED_BAND, danger)).toBeLessThanOrEqual(
+            damageFor(severity, band, danger)
+          )
+        }
+      }
+    }
+  })
+
+  it('inherits the rule that bruising cannot kill', () => {
+    // `applyHarm` goes through `applyDamage`, so the floor on the row holds.
+    // This must not become the path that bypasses the guarantee.
+    for (const danger of DANGER_ORDER) {
+      expect(applyHarm({ condition: 'dying' }, 'bruising', danger).to).toBe('dying')
+    }
+  })
+
+  it('still finishes someone who was already dying, when the fiction meant it', () => {
+    expect(applyHarm({ condition: 'dying' }, 'lethal', 'ordinary').died).toBe(true)
+  })
+
+  it('resolves at the mildest band that costs anything', () => {
+    expect(UNCONTESTED_BAND).toBe('failure')
+    expect(applyHarm(undamagedBody(), 'bruising').steps).toBe(0)
+    expect(applyHarm(undamagedBody(), 'grievous').to).toBe('grazed')
   })
 })

--- a/src/app/dicebound/domain/__tests__/turn.test.ts
+++ b/src/app/dicebound/domain/__tests__/turn.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   GRANT_POWER_TOOL,
+  HARM_TOOL,
   NARRATE_TOOL,
   RECALL_TOOL,
   ROLL_CHECK_TOOL,
@@ -173,5 +174,44 @@ describe('partitionTurnCalls and use_power', () => {
     expect(powerUses.map(c => c.id)).toEqual(['a'])
     expect(ending).toBeNull()
     expect(premature.map(c => c.id)).toEqual(['b'])
+  })
+})
+
+const harmCall = (id: string): ToolCall & { id: string } => ({
+  id,
+  name: HARM_TOOL,
+  input: { severity: 'bloody', reason: 'the beam comes down' },
+})
+
+describe('partitionTurnCalls and harm', () => {
+  it('does not end the turn — a player owed an ambush is owed the narration of it', () => {
+    const { harms, ending } = partitionTurnCalls([harmCall('a')])
+
+    expect(harms.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+  })
+
+  it('discards narration written in the same breath as the harm', () => {
+    // Invariant 2, and the same reason as the die. The model named a severity;
+    // the game decides what that severity costs, and it may cost nothing at
+    // all. Narration composed beside it describes a wound whose weight had not
+    // been assigned yet — and the model's guess at that weight is exactly what
+    // this tool exists to take away from it.
+    const { harms, ending, premature } = partitionTurnCalls([
+      harmCall('a'),
+      narrate('b', 'The beam takes your leg and you will not walk again.'),
+    ])
+
+    expect(harms.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+    expect(premature.map(c => c.id)).toEqual(['b'])
+  })
+
+  it('carries a harm sent alongside a roll, so the loop can order them itself', () => {
+    const { rolls, harms, ending } = partitionTurnCalls([roll('a'), harmCall('b')])
+
+    expect(rolls.map(c => c.id)).toEqual(['a'])
+    expect(harms.map(c => c.id)).toEqual(['b'])
+    expect(ending).toBeNull()
   })
 })

--- a/src/app/dicebound/domain/body.ts
+++ b/src/app/dicebound/domain/body.ts
@@ -411,6 +411,47 @@ export function worsen(condition: Condition, steps: number, fatal: boolean): Con
 }
 
 /**
+ * The band an uncontested harm is resolved at, and why it is the mildest one.
+ *
+ * `damageFor` is written against outcome bands, and some damage has no die
+ * behind it at all — a fuse fires, an ambush starts, a fever that was applied
+ * five turns ago finally does what it said it would. None of those are a check
+ * the player lost, so one of the six bands has to stand in for "no check
+ * happened".
+ *
+ * It is `failure`, the mildest band that costs anything, and the choice is a
+ * safety property rather than a taste. `harm` is *easier to reach for* than
+ * `roll_check` — no DC, no attribute, no clause about what could go wrong — and
+ * the failure mode of the whole tool is a dungeon master that drifts toward it
+ * because it is simpler, draining a character without ever throwing a die.
+ * Pinning it to the cheapest row means the shortcut is also the weakest move on
+ * the board: a real failed check is always at least as bad as an uncontested
+ * harm at the same severity, so nothing is ever gained by skipping the roll.
+ *
+ * It buys one more guarantee for free. At `failure`, the worst row at the worst
+ * danger setting is three steps, and the track is six — so **harm can never
+ * kill a healthy character**, whatever the DM names. Something has to have hurt
+ * them first, which means a die was thrown somewhere along the way.
+ */
+export const UNCONTESTED_BAND: OutcomeBand = 'failure'
+
+/**
+ * Damage with nothing rolled against it.
+ *
+ * A separate export rather than making callers remember to pass
+ * `UNCONTESTED_BAND` themselves, for the same reason `applyDamage` exists
+ * beside `damageFor` and `worsen`: the interesting rule is in the argument, and
+ * an argument a caller assembles by hand is an argument a caller gets wrong.
+ */
+export function applyHarm(
+  body: Body,
+  severity: Severity,
+  danger: Danger = DEFAULT_DANGER
+): BodyChange {
+  return applyDamage(body, severity, UNCONTESTED_BAND, danger)
+}
+
+/**
  * The whole of taking a hit: table, floor, and the record of what moved.
  *
  * This is the function routes and tools should call. `damageFor` and `worsen`

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -25,6 +25,7 @@ export const RECALL_TOOL = 'recall'
 export const GRANT_ITEM_TOOL = 'grant_item'
 export const GRANT_POWER_TOOL = 'grant_power'
 export const USE_POWER_TOOL = 'use_power'
+export const HARM_TOOL = 'harm'
 
 /** One pass's tool calls, sorted into what the loop does with each. */
 export interface TurnCalls<T extends ToolCall> {
@@ -50,6 +51,14 @@ export interface TurnCalls<T extends ToolCall> {
    * to be told what the power made available before it can narrate around it.
    */
   powerUses: T[]
+  /**
+   * `harm` calls — damage with no check behind it.
+   *
+   * Answered and the turn continues, like a lookup and unlike a roll. A turn
+   * where an ambush lands still owes the player the narration of it, and
+   * ending on the tool result would leave them reading nothing at all.
+   */
+  harms: T[]
   /** The `narrate` call that ends the turn, or null while the turn continues. */
   ending: T | null
   /**
@@ -82,6 +91,7 @@ export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T>
   const grants = calls.filter(call => call.name === GRANT_ITEM_TOOL)
   const powerGrants = calls.filter(call => call.name === GRANT_POWER_TOOL)
   const powerUses = calls.filter(call => call.name === USE_POWER_TOOL)
+  const harms = calls.filter(call => call.name === HARM_TOOL)
   const narrations = calls.filter(call => call.name === NARRATE_TOOL)
 
   // A narration sent alongside a lookup is as blind as one sent alongside a
@@ -89,14 +99,30 @@ export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T>
   // for cannot be in it. A power grant belongs in this list for a sharper
   // reason than the others — the grant can be *refused*, and narration written
   // beside it describes the character learning something they did not get.
+  //
+  // `harm` is in the list for the same reason as the die. The model names a
+  // severity; the game decides what that severity costs, and it may cost
+  // nothing at all. Narration composed in the same breath describes a wound
+  // whose weight had not been assigned yet, and the model's guess at that
+  // weight is the exact thing this tool exists to take away from it.
   if (
     rolls.length > 0 ||
     recalls.length > 0 ||
     grants.length > 0 ||
     powerGrants.length > 0 ||
-    powerUses.length > 0
+    powerUses.length > 0 ||
+    harms.length > 0
   ) {
-    return { rolls, recalls, grants, powerGrants, powerUses, ending: null, premature: narrations }
+    return {
+      rolls,
+      recalls,
+      grants,
+      powerGrants,
+      powerUses,
+      harms,
+      ending: null,
+      premature: narrations,
+    }
   }
 
   // Only the first narration ends the turn. A second one is a duplicate, not a
@@ -107,6 +133,7 @@ export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T>
     grants,
     powerGrants,
     powerUses,
+    harms,
     ending: narrations[0] ?? null,
     premature: narrations.slice(1),
   }


### PR DESCRIPTION
Closes #3773. Turn lane, off `main` after #3790 merged.

Damage riding on `roll_check` covers exactly one case: the player attempted something and the die went against them. It covers none of the others — an ambush landing before anyone reacts, a fuse catching up, poison or fever or cold doing what it was always going to do. Without a tool for those, the DM can only narrate a wound the sheet never records, or invent a roll the player never earned.

## The band constant, which is the one open question the issue left

`damageFor` is written against outcome bands and `harm` has no die, so one band has to stand in for "no check happened". It is **`failure`**, the mildest band that costs anything, exported as `UNCONTESTED_BAND` with the reasoning beside it.

That is a safety property, not a taste. `harm` is *easier to reach for* than `roll_check` — no DC, no attribute, no clause about what could go wrong — so the drift the issue warns about is a DM that finds it simpler and drains a character across turns nobody rolled a die in. Pinning it to the cheapest row means **the shortcut is also the weakest move on the board**: a real failed check is always at least as bad as an uncontested harm at the same severity, so nothing is ever gained by skipping the roll. There is a test asserting that ordering across every severity × band × danger.

It buys a second guarantee free. At `failure`, the worst row at the worst danger is three steps against a track of six — so **`harm` can never kill a healthy character**, whatever the DM names. Something has to have hurt them first, which means a die was thrown somewhere. That is the issue's "harm cannot kill on its own" requirement, held by arithmetic rather than by a special case.

## A consequence worth naming: `bruising` harm is always zero

`damageFor('bruising', 'failure', …)` is 0 at every danger setting, so one of the four rows does nothing to the track through this tool. I kept it, deliberately: an uncontested graze genuinely should not move a six-rung track, and the DM still gets a useful answer back — *"it did not mark them. Narrate the moment without an injury."* That produced the right prose in the live run below.

**But it is the number #3779 has to watch.** If the DM settles on `bruising` as its default harm, the tool becomes decorative — every ambush a beat, no ambush a cost — and nothing in the suite would notice.

## The rest

- **Once per turn, latched across passes**, not counted within a message. The ceiling belongs to the turn the player experiences. A second call is answered plainly and the turn carries on — a normal answer, not an error.
- **`reason` is a commitment device**, not a stored field. It does the job `uncertain` does on `roll_check`: a model that has to write "the fever takes hold" before it learns what the fever cost reaches for the tool less freely than one that only picks an enum. It is echoed back in the result and rendered nowhere.
- **Narration sent alongside a harm is discarded**, same as beside the die (invariant 2). The model names a severity; the game decides what it costs, and it may cost nothing at all.
- **`harm` does not end the turn and does not consume a check.** A player owed an ambush is owed the narration of it. `MAX_CHECKS` still bounds the loop and the last pass still forces `narrate`, where `harm` is not offered at all.
- **Severity is required here**, unlike on `roll_check`, and a garbled one repairs to the gentlest row rather than refusing — a refused harm on a turn where the fiction has already committed to an ambush leaves the DM narrating a blow the sheet never took.

## The prompt is a second draft, and the first one silently did nothing

This is the part worth reading. My first wording front-loaded every discouragement — "never reach for harm because it is quicker", "most turns have none" — on top of the `roll_check` section that already says leaving severity off is the ordinary case. Across **four live turns, including a scenario where poison was actively working**, the DM never once called the tool. It narrated the symptoms and ended the turn.

The tool was in the array the whole time. What was missing was the instruction that **`harm` is called BEFORE narrating**, the way `roll_check` is. `narrate` ends the turn and is always the cheaper path, so a tool the model is not told to reach for first is a tool it reaches past. I also added a line to `fuseBrief`, since a thread catching up with the player is the single clearest case for this tool and the DM is already being handed a hard move there.

A tool that reads correctly and never fires is exactly the failure the skill doc warns about, and it is invisible to the test suite. I would not have found it without instrumenting the call.

## Verification

Kept deliberately small on the live API.

```
$ npx tsc --noEmit            (clean)
$ npx tsc --noEmit | grep dicebound     (empty)

$ npx vitest run src/app/dicebound
 Test Files  1 failed | 17 passed (18)
      Tests  3 failed | 392 passed (395)      (+8 new)
```

The 3 failures are the pre-existing `localStorage` ones in `suggestions.test.tsx`.

```
$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
4 problems — all pre-existing, all in files this diff does not touch
$ npm run lint:routes    check-route-slugs: ok
$ npx prettier --check <touched>   clean
```

### The live run, instrumented

A throwaway driving the real `POST` route, with temporary `console.error` on both the tools offered and the tool call received. Removed before commit.

Premise: *"an hour after drinking from the wrong flask; the poison is already working and there is no antidote."* Player action: *"I keep walking down the road and say nothing."*

```
[pass 0] offered=roll_check,harm,recall,grant_item,grant_power,use_power,narrate  called=harm
[harm]   raw={"severity":"bruising","reason":"the poison keeps climbing while you walk"}
         -> unhurt->unhurt steps=0
[pass 1] called=narrate
turn 1: 0 check(s)  body unhurt -> unhurt
```

Every link verified: the tool is offered, the model reaches for it before narrating, the severity reaches `applyHarm`, the result comes back, the blind narration is discarded and re-issued on the next pass. The step arithmetic is the same `applyDamage` path already checked live in #3790 and unit-tested exhaustively here, so I did not spend more turns proving a wound lands.

Two earlier runs (four turns) produced no `harm` call at all — that is the first-draft prompt failure described above, and it is why the wording changed.