### PR TITLE
feat(dicebound): measure what kills people

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eval:micro-land": "tsx scripts/micro-land-eval.ts",
     "eval:micro-land:smoke": "tsx scripts/micro-land-eval.ts --seconds 120 --runs 1 --theme grassland",
     "voice:dicebound": "tsx --env-file-if-exists=.env.local scripts/dicebound-voice-check.ts",
+    "damage:dicebound": "tsx --env-file-if-exists=.env.local scripts/dicebound-damage-check.ts",
     "migrate:daily-trivia": "tsx --env-file=.env.local scripts/migrate-daily-trivia-to-firestore.ts"
   },
   "dependencies": {

--- a/scripts/dicebound-damage-check.ts
+++ b/scripts/dicebound-damage-check.ts
@@ -1,0 +1,343 @@
+/**
+ * What actually kills people, and how fast.
+ *
+ * Every number in the phase 3 damage epic is a guess. `DAMAGE_TABLE`'s rows,
+ * the severity → steps mapping, the three danger settings, how often a dungeon
+ * master reaches for a severity at all — all of them were written by reasoning
+ * about what feels right, and none of them had been played. This is the thing
+ * that plays them.
+ *
+ * It is a sibling of `dicebound-voice-check.ts` rather than more rows in that
+ * table, for two reasons. The scenario has to be different: voice is measured
+ * against a mouse in a bakery cellar, deliberately safe, and lethality measured
+ * there would report that nothing ever happens. And the question is different —
+ * that script asks whether the DM talks too much, this one asks whether the
+ * game can hurt you, and a single table answering both would be read for
+ * whichever half the reader came for.
+ *
+ * Like its sibling it drives the real `POST` handler. A harness with its own
+ * copy of the turn loop measures the harness: it would not see a prompt change,
+ * a tool schema change, or a pass that quietly stopped terminating.
+ *
+ *   npm run damage:dicebound                 # 16 turns
+ *   npm run damage:dicebound -- --turns 4    # a smoke check
+ *   npm run damage:dicebound -- --runs 3     # three campaigns, pooled
+ *
+ * READ THE FAILURE ROW FIRST. It prints at zero as well as above it, and it
+ * exists because a damaged measurement looks exactly like a result: a run once
+ * reported a check rate of 17%, in the expected direction, from a change that
+ * had just targeted it — and nearly got that change softened. It had lost 8 of
+ * its 20 turns to `anthropic 529` overloads, and the survivors were not a
+ * representative sample. The rerun read 50%.
+ */
+import { POST as characterRoute } from '@/app/api/v1/dicebound/character/route'
+import { POST as turnRoute } from '@/app/api/v1/dicebound/turn/route'
+import {
+  CONDITION_ORDER,
+  type Condition,
+  DANGER_ORDER,
+  type Danger,
+  SEVERITY_ORDER,
+  conditionIndex,
+  damageFor,
+  damageRow,
+  worsen,
+} from '@/app/dicebound/domain/body'
+import { newCampaign, validateCharacter } from '@/app/dicebound/domain/campaign'
+import type { Campaign } from '@/app/dicebound/domain/campaign'
+import type { Character } from '@/app/dicebound/domain/character'
+import { applyTurn } from '@/app/dicebound/domain/turn'
+import type { TurnResult } from '@/app/dicebound/domain/turn'
+import { type DamageEvent, recordDamage } from '@/lib/dicebound/telemetry'
+
+import type { NextRequest } from 'next/server'
+
+/**
+ * Dangerous, but not a fight from the first line.
+ *
+ * The scenario has to be able to hurt the player without insisting on it, or
+ * the check-rate and severity-rate numbers measure the premise rather than the
+ * prompt. A collapsing mine gives the DM every excuse to reach for a severity
+ * and no obligation to — which is exactly the judgement being measured.
+ */
+const CONCEPT = 'a stubborn tunnel-rat who has come back out of worse than this'
+const PREMISE = 'the deep gallery of a silver mine, an hour after the roof started coming down'
+
+/**
+ * Story-agnostic, like the voice check's list, and for the same reason: the DM
+ * invents the world, so an action naming a place or a person falls apart on the
+ * second run.
+ *
+ * The mix is the point. Roughly half of these are things nobody would roll for,
+ * because "share of checks that carried a severity" is meaningless if every
+ * action was a knife fight. A list of reckless actions would report a meat
+ * grinder and prove nothing about the table.
+ */
+const ACTIONS: readonly string[] = [
+  'I look around and take stock of where I am.',
+  'I listen for anyone else down here.',
+  'I move deeper in, carefully.',
+  'I try to shift whatever is blocking the way.',
+  'I call out, and wait.',
+  'I climb toward the sound of moving air.',
+  'I rest for a moment and catch my breath.',
+  'I go back the way I came.',
+  'I squeeze through the narrowest gap I can find.',
+  'I help whoever needs it most.',
+  'I look closely at the thing that seems most out of place.',
+  'I push on regardless of what it costs me.',
+  'I ask about the thing nobody has explained yet.',
+  'I take the route that looks worse but shorter.',
+  'I try something reckless rather than wait any longer.',
+  'I head for the way out.',
+]
+
+function arg(name: string, fallback: number): number {
+  const index = process.argv.indexOf(`--${name}`)
+  if (index === -1) return fallback
+  const value = Number(process.argv[index + 1])
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function post(body: unknown): NextRequest {
+  return new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest
+}
+
+async function makeCharacter(): Promise<Character> {
+  const response = await characterRoute(post({ concept: CONCEPT, premise: PREMISE }))
+  const data = (await response.json()) as { character?: unknown; source?: string }
+  const character = validateCharacter(data.character)
+  if (!character) throw new Error('character route returned something unusable')
+  if (data.source !== 'model') {
+    console.warn(`WARNING: character came from the '${data.source}' path, not the model.`)
+  }
+  return character
+}
+
+async function playTurn(campaign: Campaign, action: string): Promise<TurnResult> {
+  const response = await turnRoute(post({ campaign, action }))
+  const data = (await response.json()) as { result?: TurnResult; error?: string }
+  if (!data.result) throw new Error(data.error ?? `turn route returned ${response.status}`)
+  return data.result
+}
+
+/** One turn's worth of what happened, kept so the tables can be folded at the end. */
+interface Beat {
+  turn: number
+  condition: Condition
+  events: DamageEvent[]
+}
+
+interface Run {
+  beats: Beat[]
+  failed: number
+  died: number | null
+}
+
+async function playCampaign(turns: number, label: string): Promise<Run> {
+  const now = Date.now()
+  let campaign = newCampaign(PREMISE, await makeCharacter(), now, null)
+  campaign = applyTurn(campaign, await playTurn(campaign, ''), now)
+  console.log(`  ${label}: "${campaign.title}"`)
+
+  const beats: Beat[] = []
+  let failed = 0
+  let died: number | null = null
+
+  for (let turn = 1; turn <= turns; turn++) {
+    const action = ACTIONS[(turn - 1) % ACTIONS.length]
+    const events: DamageEvent[] = []
+    const stop = recordDamage(event => events.push(event))
+
+    let result: TurnResult
+    try {
+      result = await playTurn(campaign, action)
+    } catch (error) {
+      // Counted, never silently skipped. This is the row that decides whether
+      // any of the others mean anything.
+      failed += 1
+      console.log(`    turn ${turn}: FAILED — ${String(error)}`)
+      continue
+    } finally {
+      stop()
+    }
+
+    campaign = applyTurn(campaign, result, now)
+    beats.push({ turn, condition: campaign.body.condition, events })
+
+    if (campaign.body.condition === 'dead') {
+      died = turn
+      console.log(`    turn ${turn}: DIED`)
+      break
+    }
+  }
+
+  return { beats, failed, died }
+}
+
+/** The first turn at which the body was at this rung or worse, or null. */
+function reached(beats: Beat[], condition: Condition): number | null {
+  const target = conditionIndex(condition)
+  return beats.find(beat => conditionIndex(beat.condition) >= target)?.turn ?? null
+}
+
+function pct(part: number, whole: number): string {
+  return whole === 0 ? '   —' : `${Math.round((part / whole) * 100)}%`.padStart(4)
+}
+
+/**
+ * What the same campaign would have cost at each danger setting.
+ *
+ * A replay rather than three live runs, and this is the one methodological
+ * choice in the file worth arguing with.
+ *
+ * Three live runs would differ by the model's mood as much as by the dial —
+ * different scenes, different DCs, different severities — and separating the
+ * dial's effect from that noise would take far more runs than anyone is going
+ * to pay for. The dial does not touch what the DM decides; it only changes what
+ * a decision costs. So replaying the *recorded* (severity, band) sequence
+ * through `damageFor` at each setting is the exact counterfactual: the same
+ * campaign, three lethalities, no extra API calls.
+ *
+ * It has one honest limit and the table says so. The replay is only faithful up
+ * to the first divergence — once a setting kills the character, the real
+ * campaign would have ended there and everything after it is a story that would
+ * not have happened. So this reports **the turn each setting would first have
+ * killed them**, and stops counting there, rather than pretending to know what
+ * turn 14 looks like for someone who died on turn 9.
+ */
+function replay(beats: Beat[], danger: Danger): { end: Condition; died: number | null } {
+  let condition: Condition = 'unhurt'
+  let died: number | null = null
+
+  for (const beat of beats) {
+    for (const event of beat.events) {
+      if (!event.applied || !event.severity) continue
+      const band = event.band ?? 'failure'
+      const steps = damageFor(event.severity, band, danger)
+      condition = worsen(condition, steps, damageRow(event.severity).fatal)
+      if (condition === 'dead' && died === null) died = beat.turn
+    }
+    if (died !== null) break
+  }
+
+  return { end: condition, died }
+}
+
+async function main(): Promise<void> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('ANTHROPIC_API_KEY is not set. Run via `npm run damage:dicebound`.')
+    process.exit(1)
+  }
+
+  const turns = arg('turns', 16)
+  const runs = arg('runs', 1)
+
+  console.log(`Dicebound damage check — ${runs} run(s) of ${turns} turns against the live API.`)
+  console.log(`Premise: "${PREMISE}"\n`)
+
+  const all: Run[] = []
+  for (let index = 0; index < runs; index++) {
+    all.push(await playCampaign(turns, `run ${index + 1}`))
+  }
+
+  const beats = all.flatMap(run => run.beats)
+  const events = beats.flatMap(beat => beat.events)
+  const failed = all.reduce((sum, run) => sum + run.failed, 0)
+  const attempted = runs * turns
+
+  // First, and on its own, because everything below it is worthless if this is
+  // not near zero.
+  console.log(`\n${'='.repeat(64)}`)
+  console.log(`turns that failed: ${failed} of ${attempted}`)
+  if (failed > 0) {
+    console.log('  ^ RERUN. A run that lost turns is not a sample — the survivors are not')
+    console.log('    representative, and a damaged measurement looks exactly like a result.')
+  }
+  console.log('='.repeat(64))
+
+  const checks = events.filter(event => event.tool === 'roll_check')
+  const dangerous = checks.filter(event => event.severity !== null)
+  const harms = events.filter(event => event.tool === 'harm')
+  const refused = harms.filter(event => !event.applied)
+
+  console.log('\nHOW OFTEN THE GAME REACHED FOR DAMAGE')
+  console.log(`  checks rolled                ${String(checks.length).padStart(4)}`)
+  console.log(
+    `  ...carrying a severity       ${String(dangerous.length).padStart(4)}  ${pct(dangerous.length, checks.length)} of checks`
+  )
+  console.log(`  harm calls (applied)         ${String(harms.length - refused.length).padStart(4)}`)
+  console.log(`  harm calls (refused, 2nd/turn)${String(refused.length).padStart(3)}`)
+  console.log(
+    `  harm : dangerous check       ${
+      dangerous.length === 0
+        ? '   — (nothing was dangerous)'
+        : `${(harms.length / dangerous.length).toFixed(2)} : 1`
+    }`
+  )
+  console.log('  The prompt claims most checks are not dangerous. At 60% the world is a meat')
+  console.log('  grinder; at 2% the system is decoration. A rising harm ratio is the drift')
+  console.log('  that matters — a DM reaching for harm because it is simpler drains a')
+  console.log('  character without ever rolling a die, and nothing else would notice.')
+
+  console.log('\nWHICH ROW THE DM PICKED')
+  for (const severity of SEVERITY_ORDER) {
+    const named = events.filter(event => event.severity === severity)
+    console.log(
+      `  ${severity.padEnd(10)} ${String(named.length).padStart(4)}  ${pct(named.length, events.filter(e => e.severity).length)}`
+    )
+  }
+  console.log('  If lethal shows up on ordinary climbing checks, the table examples are not')
+  console.log('  anchoring it, and that is a prompt fix rather than a mapping fix.')
+
+  console.log('\nHOW FAR DOWN THE TRACK, AND WHEN')
+  for (const condition of CONDITION_ORDER.slice(1)) {
+    const turn = all.map(run => reached(run.beats, condition)).filter(t => t !== null)
+    console.log(
+      `  first ${condition.padEnd(9)} turn ${
+        turn.length === 0 ? '—  (never reached)' : turn.map(String).join(', ')
+      }`
+    )
+  }
+  const survived = all.filter(run => run.died === null).length
+  console.log(`  ended alive                  ${survived} of ${all.length}`)
+
+  console.log('\nWHAT THE DANGER DIAL WOULD HAVE CHANGED')
+  console.log('  A replay of the recorded severities and bands, not three live runs — the')
+  console.log('  dial changes what a decision costs, never what the DM decides, so the same')
+  console.log('  campaign at three lethalities is the exact counterfactual and costs nothing.')
+  console.log('  Faithful only up to the first death; after that the real story would have')
+  console.log('  diverged, so it stops counting there rather than inventing a turn 14 for')
+  console.log('  someone who died on turn 9.')
+  for (const danger of DANGER_ORDER) {
+    const replayed = all.map(run => replay(run.beats, danger))
+    const deaths = replayed.filter(r => r.died !== null)
+    console.log(
+      `  ${danger.padEnd(9)} ends ${replayed
+        .map(r => r.end)
+        .join(', ')
+        .padEnd(28)} deaths ${deaths.length}/${all.length}${
+        deaths.length > 0 ? ` (turn ${deaths.map(r => r.died).join(', ')})` : ''
+      }`
+    )
+  }
+  console.log('  Three settings that produce the same ending are three settings nobody')
+  console.log('  needed. That is a real possible outcome and it is what this row is for.')
+
+  console.log('\nNOT MEASURED HERE')
+  console.log('  Statuses. #3774 and #3775 have not landed, so there is nothing to count:')
+  console.log('  no applications per turn, no live-at-once, no cap hits, no slug collisions.')
+  console.log('  Those rows belong in this file and should be added with that work.')
+  console.log('  Whether the condition on the sheet agrees with the condition in the prose')
+  console.log('  is not automated either. It is a sampled read of transcripts, and saying so')
+  console.log('  is better than a metric that does not mean anything.\n')
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -184,6 +184,7 @@ import {
   toolUses,
 } from '@/lib/dicebound/anthropic'
 import { archiveChapter, loadCampaign, saveCampaign } from '@/lib/dicebound/campaign-store'
+import { noteDamage } from '@/lib/dicebound/telemetry'
 
 /** The DM can be slow, and a scene worth waiting for is worth the headroom. */
 export const maxDuration = 120
@@ -1650,6 +1651,18 @@ function rollFor(
   // defaulted inside `applyDamage` so that the day `Campaign.danger` lands, the
   // only edit is this argument.
   const change = severity ? applyDamage(body, severity, outcome.band, DEFAULT_DANGER) : null
+  // Every check, including the ones that named nothing — "most checks are not
+  // dangerous" is a claim in the prompt, and it can only be read against the
+  // checks that carried no severity at all.
+  noteDamage({
+    tool: 'roll_check',
+    severity,
+    band: outcome.band,
+    from: change?.from ?? body.condition,
+    to: change?.to ?? body.condition,
+    steps: change?.steps ?? 0,
+    applied: true,
+  })
 
   const entry: CheckEntry = {
     kind: 'check',
@@ -1711,6 +1724,18 @@ function harmFor(
   input: unknown
 ): { body: Body; note: string; spent: boolean } {
   if (already) {
+    // Recorded too. A DM reaching for a second harm is the drift this ceiling
+    // exists to stop, and a refusal that left no trace would make the ceiling
+    // look unnecessary precisely when it was working.
+    noteDamage({
+      tool: 'harm',
+      severity: null,
+      band: null,
+      from: body.condition,
+      to: body.condition,
+      steps: 0,
+      applied: false,
+    })
     return {
       body,
       spent: false,
@@ -1727,6 +1752,16 @@ function harmFor(
   const severity = validateSeverity(raw.severity)
   const change = applyHarm(body, severity, DEFAULT_DANGER)
   const reason = typeof raw.reason === 'string' ? raw.reason.slice(0, 120) : ''
+
+  noteDamage({
+    tool: 'harm',
+    severity,
+    band: null,
+    from: change.from,
+    to: change.to,
+    steps: change.steps,
+    applied: true,
+  })
 
   return {
     body: change.body,

--- a/src/lib/dicebound/telemetry.ts
+++ b/src/lib/dicebound/telemetry.ts
@@ -1,0 +1,75 @@
+/**
+ * A seam for measuring what the dungeon master actually does.
+ *
+ * Two of the numbers phase 3 most needs — how often a check carries a severity
+ * at all, and how often the DM reaches for `harm` instead of the die — are
+ * choices the model makes inside a single turn, and neither survives into the
+ * campaign. `CheckEntry` stores the band and the modifiers because the die card
+ * re-renders from them; it has never stored what the DM said was *at stake*,
+ * and a `harm` call leaves no entry behind at all. From outside the route the
+ * only visible evidence is the body moving, which conflates "the DM never
+ * called for anything dangerous" with "it did and the player kept passing".
+ *
+ * The obvious fix is to widen `CheckEntry` and give `harm` a transcript entry.
+ * That was rejected, and the reason is worth keeping: **a measurement should
+ * not change the thing it measures.** Fields added to `Campaign` for a script's
+ * benefit are fields in every player's save, behind a version bump, migrated
+ * forever, to serve a harness that runs a handful of times a month. This is
+ * thirty lines and no stored bytes.
+ *
+ * Off by default and free when off — `recorder` is null in production and the
+ * two call sites in `turn/route.ts` are a null check each. It is deliberately
+ * not a general event bus: one narrow shape, two callers, no buffering, no
+ * ordering guarantees beyond the order the route calls it in.
+ *
+ * Module-global rather than threaded through the route, because threading it
+ * would mean a parameter on `playTurn`, `rollFor` and `harmFor` that exists for
+ * no reason a reader of those functions could see. The cost is that it is not
+ * safe across concurrent campaigns in one process; the harness plays one
+ * campaign at a time, and production never turns it on.
+ */
+import type { Condition, Severity } from '@/app/dicebound/domain/body'
+import type { OutcomeBand } from '@/app/dicebound/domain/dice'
+
+/** One moment where the game decided what something cost. */
+export interface DamageEvent {
+  /** Which tool the DM reached for. This is the ratio the epic cares about. */
+  tool: 'roll_check' | 'harm'
+  /**
+   * The row the DM named, or null on a check it did not flag as dangerous.
+   *
+   * Null is the *interesting* value here and the reason this is not simply
+   * omitted: "most checks are not dangerous" is a claim in the prompt, and it
+   * can only be checked against the checks that carried nothing.
+   */
+  severity: Severity | null
+  /** Absent on `harm`, which has no die. */
+  band: OutcomeBand | null
+  from: Condition
+  to: Condition
+  steps: number
+  /** False when a second `harm` in one turn was refused. */
+  applied: boolean
+}
+
+export type DamageRecorder = (event: DamageEvent) => void
+
+let recorder: DamageRecorder | null = null
+
+/**
+ * Start recording. Returns the function that stops it.
+ *
+ * A returned stopper rather than a matching `clear()` so a harness cannot leave
+ * it on for the next thing that runs in the same process.
+ */
+export function recordDamage(next: DamageRecorder): () => void {
+  recorder = next
+  return () => {
+    recorder = null
+  }
+}
+
+/** Called by the turn route. A no-op unless a harness is listening. */
+export function noteDamage(event: DamageEvent): void {
+  recorder?.(event)
+}


### PR DESCRIPTION
Closes #3779. Harness lane.

Every number in this epic is a guess — `DAMAGE_TABLE`'s rows, the severity → steps mapping, the three danger settings, how often a DM reaches for a severity at all. **This changes none of them.** It produces the table; retuning against it is your call, made against numbers rather than a PR that arrives with both.

`npm run damage:dicebound` (`-- --turns 4` to smoke it, `-- --runs 3` to pool).

## A sibling script, not more rows on the voice check

The scenario has to differ. Voice is measured against a mouse in a bakery cellar, deliberately safe; lethality measured there would report that nothing ever happens. The premise here is a collapsing silver mine — dangerous enough to give the DM every excuse to reach for a severity, and no obligation to, which is exactly the judgement being measured. Half the action list is things nobody would roll for, because a severity rate taken from a list of reckless actions measures the list.

## The telemetry seam, which is the decision worth arguing with

Two of the numbers the epic most needs are choices the model makes *inside* a turn, and neither survives into the campaign. `CheckEntry` stores the band because the die card re-renders from it; it has never stored what the DM said was **at stake**. A `harm` call leaves no entry at all. From outside the route the only visible evidence is the body moving, which conflates "the DM never called for anything dangerous" with "it did and the player kept passing".

The obvious fix is to widen `CheckEntry` and give `harm` a transcript entry. I rejected it: **a measurement should not change the thing it measures.** Fields added to `Campaign` for a script's benefit are fields in every player's save, behind a version bump, migrated forever, to serve a harness that runs a handful of times a month.

`src/lib/dicebound/telemetry.ts` is thirty lines, stores no bytes, and is off by default — `recorder` is null in production and the three call sites in `turn/route.ts` are a null check each. It is module-global rather than threaded through `playTurn`/`rollFor`/`harmFor`, because threading it would put a parameter on three functions that a reader of those functions could see no reason for. The cost is stated in the file: not safe across concurrent campaigns in one process. The harness plays one at a time and production never turns it on.

## The danger dial is replayed, not re-run

The one methodological choice I'd most like you to push back on if you disagree.

Three live runs at three settings would differ by the model's mood as much as by the dial — different scenes, different DCs, different severities — and separating the dial's effect from that noise would take far more turns than anyone is going to pay for. But the dial **never changes what the DM decides, only what a decision costs**. So the harness replays the recorded `(severity, band)` sequence through `damageFor` at each setting: the same campaign at three lethalities, exact, no extra API calls.

Its one limit is printed in the table. The replay is faithful only up to the first death — once a setting kills the character the real campaign would have ended there, so it reports the turn each setting would first have killed them and stops, rather than inventing a turn 14 for someone who died on turn 9.

This also directly answers the issue's sharpest question: *three settings that produce the same campaign are three settings nobody needed.*

## What I left out, and why

**Statuses.** The issue lists applications per turn, live-at-once, cap hits and slug collisions — #3774 and #3775 haven't landed, so there is nothing to count. The script prints a `NOT MEASURED HERE` section saying so, rather than four zeros that read like a finding. Those rows belong in this file and should be added with that work.

**Sheet-vs-prose agreement.** Not automated. The issue allows a sampled read of transcripts as a legitimate answer, and the script says that outright — better than a metric that does not mean anything.

**The `harm` : dangerous-check ratio is defined but untested against real drift.** It needs a longer run than I was willing to spend to say anything.

## The failure row

Prints first, on its own, at zero as well as above it, with the instruction to rerun rather than reason about a run that lost turns. The comment carries the 17%-vs-50% story so the next person meets it before they meet a number.

## Verification

```
$ npx tsc --noEmit                      (clean)
$ npx tsc --noEmit | grep dicebound     (empty)
$ npx vitest run src/app/dicebound      392 passed, 3 pre-existing localStorage failures
$ npx eslint scripts/dicebound-damage-check.ts src/lib/dicebound src/app/api/v1/dicebound
                                        clean on touched files
$ npm run lint:routes                   ok
$ npx prettier --check <touched>        clean
```

### Smoke run, 3 turns

Deliberately short — you asked me to go easy on API spend, and the point of this run was that the tables render and the telemetry captures, not to produce a finding.

```
turns that failed: 0 of 3

HOW OFTEN THE GAME REACHED FOR DAMAGE
  checks rolled                   0
  ...carrying a severity          0     —
  harm calls (applied)            0
  harm : dangerous check          — (nothing was dangerous)

HOW FAR DOWN THE TRACK, AND WHEN
  first grazed    turn —  (never reached)
  ...
  ended alive                  1 of 1

WHAT THE DANGER DIAL WOULD HAVE CHANGED
  gentle    ends unhurt    deaths 0/1
  ordinary  ends unhurt    deaths 0/1
  perilous  ends unhurt    deaths 0/1
```

**This run found nothing, and that is not the same as the harness working.** Three turns of a careful tunnel-rat looking around produced no checks at all, so every row is empty and the telemetry path is unexercised on the roll side. The seam itself was proven live in #3791's run, where the same code printed a real `harm` event. A real reading needs the default 16 turns, and ideally `--runs 3`.