### PR TITLE
feat(dicebound): the body on the sheet

### DIFF
--- a/src/app/dicebound/components/__tests__/sheet.test.tsx
+++ b/src/app/dicebound/components/__tests__/sheet.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { Sheet } from '@/app/dicebound/components/sheet'
 import type { SkillId } from '@/app/dicebound/domain/attributes'
+import { CONDITION_LABEL, CONDITION_ORDER } from '@/app/dicebound/domain/body'
 import { type Campaign, newCampaign } from '@/app/dicebound/domain/campaign'
 import {
   RANK_THRESHOLDS,
@@ -59,5 +60,56 @@ describe('Sheet skill progress', () => {
 
     expect(screen.getByText('innate')).toBeTruthy()
     expect(screen.queryByText(/^4\//)).toBeNull()
+  })
+})
+
+describe('Sheet condition', () => {
+  it('shows nothing at all on an unhurt character — the system is invisible until it bites', () => {
+    // Nothing renders until it exists. A new character shown a damage track,
+    // even an empty one, has been told the game is about to hurt them, and that
+    // is a promise the first ten minutes should not be making. This is the rule
+    // with the least protection anywhere on this screen.
+    render(<Sheet campaign={campaignWith({})} />)
+
+    expect(screen.queryByText('Condition')).toBeNull()
+    expect(screen.queryByText(/Unhurt/)).toBeNull()
+    for (const condition of CONDITION_ORDER) {
+      expect(screen.queryByText(CONDITION_LABEL[condition])).toBeNull()
+    }
+  })
+
+  it('names the rung and says what it feels like, once there is one', () => {
+    render(<Sheet campaign={{ ...campaignWith({}), body: { condition: 'bloodied' } }} />)
+
+    expect(screen.getByText('Bloodied')).toBeTruthy()
+    // The phrase comes from domain/body.ts so the sheet and the DM's prompt
+    // agree word for word. A player reading one thing here and hearing another
+    // from the dungeon master is the die card disagreeing with the prose again.
+    expect(screen.getByText(/bleeding in a way that is not going to simply stop/i)).toBeTruthy()
+  })
+
+  it('announces the condition as a sentence rather than an adjective between two numbers', () => {
+    render(<Sheet campaign={{ ...campaignWith({}), body: { condition: 'hurt' } }} />)
+
+    const section = screen.getByRole('region', { name: 'Condition' })
+    expect(section.textContent).toContain('Hurt')
+  })
+
+  it('carries the last rung in the word, not only in the colour', () => {
+    // CLAUDE.md #8. A player at the step before the end must be able to tell
+    // without counting, and without seeing colour at all.
+    render(<Sheet campaign={{ ...campaignWith({}), body: { condition: 'dying' } }} />)
+
+    expect(screen.getByText('Dying')).toBeTruthy()
+    expect(screen.getByText(/on the ground and going/i)).toBeTruthy()
+  })
+
+  it('renders no quantity anywhere — a track is not a health bar', () => {
+    // Settled in #3769: a number or a meter hands the player something to
+    // optimise, which is the whole reason damage is not hit points.
+    render(<Sheet campaign={{ ...campaignWith({}), body: { condition: 'broken' } }} />)
+
+    const region = screen.getByRole('region', { name: 'Condition' })
+    expect(region.textContent).not.toMatch(/\d/)
   })
 })

--- a/src/app/dicebound/components/sheet.tsx
+++ b/src/app/dicebound/components/sheet.tsx
@@ -23,6 +23,7 @@ import {
   SKILLS,
   type SkillId,
 } from '@/app/dicebound/domain/attributes'
+import { type Body, CONDITION_LABEL, CONDITION_PHRASE } from '@/app/dicebound/domain/body'
 import type { Campaign } from '@/app/dicebound/domain/campaign'
 import { type SkillRecord, usesToNextRank } from '@/app/dicebound/domain/character'
 
@@ -47,6 +48,7 @@ export function Sheet({ campaign }: { campaign: Campaign }) {
         <p className="mt-1 text-body-md text-on-surface-variant">{character.concept}</p>
         <SpeciesLine species={campaign.kit.species} />
         <Standing campaign={campaign} />
+        <Condition body={campaign.body} />
         {character.reading && (
           <p className="mt-3 border-l-2 border-ds-tertiary/50 pl-3 text-sm italic text-on-surface-variant">
             {character.reading}
@@ -123,6 +125,66 @@ export function Sheet({ campaign }: { campaign: Campaign }) {
         </dl>
       </section>
     </div>
+  )
+}
+
+/**
+ * What is wrong with them, when anything is.
+ *
+ * **Nothing renders until it exists.** An unhurt character gets no element at
+ * all — no empty bar, no greyed-out track with six rungs showing where the
+ * damage will go, no "Condition: unhurt". The reason is not tidiness: a new
+ * character shown a full-height damage track knows the game is about to hurt
+ * them, and that is a promise the first ten minutes should not be making. It is
+ * also the difference between a character sheet and a form to fill in. The same
+ * rule governs `Standing`, `Powers`, `Items` and every section of the world
+ * panel, and a test guards it here because it is the kind of rule a later
+ * change breaks without anyone noticing.
+ *
+ * Words, not a bar and not a number. A segmented health meter reads as a
+ * quantity to manage, and avoiding exactly that is why damage is a track rather
+ * than hit points (#3769). The strings come from `domain/body.ts` so the sheet
+ * and the dungeon master's prompt agree word for word — a player reading
+ * "bloodied" here and hearing something else from the DM is the same class of
+ * bug as prose disagreeing with the die card.
+ *
+ * `dying` looks different, and does not rely on colour to do it. The word
+ * itself is the signal, which is what a screen reader and a monochrome display
+ * both get; the heavier weight and the warmer rule are reinforcement on top of
+ * a distinction that is already carried by text (CLAUDE.md #8). No alarm
+ * styling beyond that — this is the cave, and the shell stays quiet even when
+ * the news is bad.
+ *
+ * It is a labelled section rather than a bare adjective dropped between the
+ * concept and the attributes, so it is announced as a sentence: "Condition.
+ * Bloodied — bleeding in a way that is not going to simply stop."
+ */
+function Condition({ body }: { body: Body }) {
+  if (body.condition === 'unhurt') return null
+
+  const grave = body.condition === 'dying' || body.condition === 'dead'
+
+  return (
+    <section aria-labelledby="dicebound-condition" className="mt-3">
+      <h3 id="dicebound-condition" className="sr-only">
+        Condition
+      </h3>
+      <p
+        className={`border-l-2 pl-3 text-sm ${
+          grave
+            ? 'border-ds-error text-on-surface'
+            : 'border-ds-tertiary/50 text-on-surface-variant'
+        }`}
+      >
+        <span
+          className={`font-headline ${grave ? 'font-extrabold text-ds-error' : 'font-bold text-on-surface'}`}
+        >
+          {CONDITION_LABEL[body.condition]}
+        </span>
+        <span className="mx-1.5 text-on-surface-variant/50">—</span>
+        {CONDITION_PHRASE[body.condition]}
+      </p>
+    </section>
   )
 }
 


### PR DESCRIPTION
Part of #3778 — the condition half. **Afflictions are not in this PR** and the issue stays open; see below.

Damage has been landing since #3790 and the only place a player could read it was the DM's prose. The sheet said nothing.

## What it looks like

A single line under the concept, species and level, above the attributes:

> **Bloodied** — Bleeding in a way that is not going to simply stop. Whatever comes next comes through it.

Words, not a bar and not a number. A segmented health meter reads as a quantity to manage, and avoiding exactly that is why damage is a track rather than hit points (settled in #3769). A test asserts the region renders **no digit at all**, so the next person who reaches for a "3/6" has to delete a test that says why not.

The strings come from `domain/body.ts` — the same `CONDITION_LABEL` and `CONDITION_PHRASE` the DM's prompt renders from. A player reading "bloodied" here and hearing something else from the dungeon master is the same class of bug as prose disagreeing with the die card, and the fix is that there is only one copy.

## Nothing renders until it exists

The issue is right that this is the rule on this screen with the least protection, so it has five tests rather than one.

An `unhurt` character gets **no element at all** — no empty bar, no greyed-out track showing six rungs of where the damage will go, no "Condition: unhurt". The test iterates every rung in `CONDITION_ORDER` and asserts none of their labels appear, so a future "show the full track, dimmed" idea fails loudly rather than quietly making the sheet a form to fill in.

The reason is not tidiness. A new character shown a damage track has been told the game is about to hurt them, and that is a promise the first ten minutes should not be making.

## Accessibility

- **`dying` is distinguished by the word before anything else.** "Dying" is the signal; the heavier weight and the warmer rule are reinforcement on top of a distinction already carried by text. Nothing here is conveyed by colour alone (CLAUDE.md #8), and there is a test for the word specifically.
- **Announced as a sentence.** It is a labelled `<section>` with a visually-hidden "Condition" heading, so a screen reader reads *"Condition. Bloodied — bleeding in a way that is not going to simply stop"* rather than an adjective floating between two numbers. Tested via `getByRole('region', { name: 'Condition' })`.
- No fixed widths; it inherits the sheet's existing scrolling column, so mobile and desktop are the same layout.
- No alarm styling beyond the rule colour. This is the cave, and the shell stays quiet even when the news is bad.

## What I left out, and why

**Afflictions.** The issue asks for two sections, and the second one has no data: #3774 (the status record) has not landed, so `Status`, `domain/status.ts` and `Campaign.statuses` do not exist. Writing the component now would mean inventing the shape that issue exists to decide, and then rewriting it. **I have not closed #3778** — it needs the afflictions half added once #3774 is in, in this same file.

I could have waited and shipped both together. I did not, because the condition half is the thing you actually asked for and it is complete on its own.

## Collision

`sheet.tsx` is also wanted by **#3777 (the danger dial)**. Nothing is in flight on it, but this needs to land before that starts.

## Verification

```
$ npx tsc --noEmit                      (clean)
$ npx tsc --noEmit | grep dicebound     (empty)

$ npx vitest run src/app/dicebound
 Test Files  1 failed | 17 passed (18)
      Tests  3 failed | 397 passed (400)      (+5 new)

$ npx vitest run components/__tests__/sheet.test.tsx
      Tests  10 passed (10)
```

The 3 failures are the pre-existing `localStorage` ones in `suggestions.test.tsx`.

```
$ npx eslint src/app/dicebound/components/sheet.tsx <test>   clean
$ npm run lint:routes    check-route-slugs: ok
$ npx prettier --check <touched>   clean
```

No live-API run: this is a component that reads `Campaign.body`, it touches no prompt, no tool schema and no turn loop, and the render paths are covered by the component tests. I have not looked at it in a browser at a hurt character — if you want a screenshot before merging, say so and I will play one turn into a wound.