### PR TITLE
feat(dicebound): death ends the run, and it ends in voice

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -51,6 +51,7 @@ import {
   type Severity,
   applyDamage,
   applyHarm,
+  isDead,
   validateSeverity,
 } from '@/app/dicebound/domain/body'
 import {
@@ -60,6 +61,7 @@ import {
   MAX_ACTION,
   TRANSCRIPT_WINDOW,
   type TranscriptEntry,
+  isEnded,
   trimToFit,
   validateCampaign,
 } from '@/app/dicebound/domain/campaign'
@@ -293,6 +295,7 @@ ${SEVERITY_LINES}
 You are choosing this BEFORE the dice are thrown, and that is the entire point of putting it here: you do not yet know whether it lands. A success costs them nothing at all, whatever row you named.
 Never pick lethal for something the player could not have seen coming. If the fiction did not already tell them this could kill them, it is not that row — and if you are reaching for it because the scene needs weight, use a hard move instead.
 The game decides what a hit costs. You are told afterwards what state they are in, and you narrate that and nothing heavier. Do not decide how badly they are hurt, do not describe a wound the roll did not give them, and do not soften one it did.
+A character can die. You never decide that and you are never asked — if a blow ends them you will be told so in the result, plainly, and then the story is over. Narrate their death once, in voice, and stop. Do not leave them clinging on and do not write a rescue the dice did not give them.
 
 WHEN THE WORLD HURTS THEM ANYWAY
 Not all damage comes from a failed attempt. An ambush lands before anyone can react. A thread they have been ignoring catches up with them. Poison, fever, cold and hunger do what they were always going to do, whatever the player does that turn. When the fiction is already hurting them and no attempt of theirs is being tested, call harm — the same severity table as roll_check, plus a few words saying why.
@@ -798,6 +801,18 @@ export async function POST(request: NextRequest) {
 
   const { campaign, uid } = found
 
+  // A finished story does not take another turn.
+  //
+  // Nothing this game ships sends one — the client renders the ending screen
+  // where the composer was — but the campaign is what is authoritative, so the
+  // rule lives where the authority is rather than where the button is. It is
+  // also the last line of defence for the thing the whole epic is about: a
+  // player who kept a tab open across the turn that killed them, or who
+  // replays a request, must not get to play on past their own ending.
+  if (isEnded(campaign)) {
+    return NextResponse.json({ error: 'That story has already found its ending.' }, { status: 409 })
+  }
+
   const action = typeof body.action === 'string' ? body.action.trim().slice(0, MAX_ACTION) : ''
   const isOpening = campaign.transcript.length === 0
 
@@ -1038,7 +1053,15 @@ Resolve it, then call narrate with what happens.`,
   }
 
   for (let step = 0; step <= MAX_CHECKS; step++) {
-    const lastStep = step === MAX_CHECKS
+    // The final pass — or the pass after the one that killed them.
+    //
+    // A dead character has no more attempts left in them, so the turn stops
+    // offering the tools that would take one. `narrate` is forced exactly as it
+    // is at `MAX_CHECKS`, and for exactly the same reason: finishing is the
+    // only move on the board. It also closes the fuse path below, which is
+    // right — a thread catching up with someone who is already gone is a
+    // deadline landing on an empty room.
+    const lastStep = step === MAX_CHECKS || isDead(body)
     // Whether anything has actually been rolled this turn, which is what sets
     // the word budget. Derived from the entries rather than the step counter: a
     // model that spent a pass on nothing has not earned the longer budget.
@@ -1216,8 +1239,14 @@ Resolve it, then call narrate with what happens.`,
 
   if (!narration) {
     // Every pass returned tool calls and the forced final call still produced
-    // nothing usable. Rare, but the player is owed a turn either way.
-    narration = 'The moment resolves, and the situation has changed. Look around.'
+    // nothing usable. Rare, but the player is owed a turn either way — and on
+    // the one turn that can never be taken again, owed it more than usual. The
+    // ordinary fallback hands the player back the initiative, which is the one
+    // thing a death does not do; told to "look around" after dying they would
+    // reasonably conclude the game had broken rather than ended.
+    narration = isDead(body)
+      ? 'The story stops here, in the middle of itself, the way they do.'
+      : 'The moment resolves, and the situation has changed. Look around.'
   }
 
   entries.push({ kind: 'narration', text: narration })
@@ -1232,7 +1261,11 @@ Resolve it, then call narrate with what happens.`,
   // `className === null` is the whole of the once-ness. Nothing re-reads the
   // histogram at level 3, and whether a class should ever be revisited is a
   // decision this issue deliberately does not settle by accident.
-  if (kit.className === null) {
+  //
+  // `!isDead(body)` because the cave forming an opinion about what somebody was,
+  // one paragraph after they stopped being it, is the single worst place this
+  // line could land. A death is not a level-up screen.
+  if (kit.className === null && !isDead(body)) {
     const { character: credited } = creditSkills(campaign.character, entries, world.clock.elapsed)
     if (shouldNameClass(kit, levelFor(earnedRanks(credited)))) {
       const shape = classShape(credited)
@@ -1257,7 +1290,11 @@ Resolve it, then call narrate with what happens.`,
   // It goes in the transcript rather than into a field, which is also how the
   // DM finds out: next turn it reads this line back, and the powers block in
   // the prompt already shows the refilled counts.
-  if (restoredCharges > 0) {
+  //
+  // Not for someone who is not there. A rest that "settles" after a death reads
+  // as an afterlife the fiction never offered, and a turn can absolutely end
+  // with both — a safe span of travel that a fuse fires into.
+  if (restoredCharges > 0 && !isDead(body)) {
     entries.push({
       kind: 'narration',
       text: rested
@@ -1733,11 +1770,13 @@ function harmFor(
     spent: true,
     note: [
       reason ? `${reason} —` : '',
-      change.steps > 0
-        ? `that hurt them. They are now ${CONDITION_LABEL[change.to].toLowerCase()}: ${CONDITION_PHRASE[change.to]} Narrate it at exactly that weight, no heavier.`
-        : change.from === 'unhurt'
-          ? 'it did not mark them. Narrate the moment without an injury.'
-          : `it cost them nothing further — they are still ${CONDITION_LABEL[change.to].toLowerCase()}. Do not narrate a new wound.`,
+      change.died
+        ? 'that killed them. The story ends here, and this is the last thing you will ever write in it. Narrate their death once, in voice, and stop — no clinging on, no help arriving.'
+        : change.steps > 0
+          ? `that hurt them. They are now ${CONDITION_LABEL[change.to].toLowerCase()}: ${CONDITION_PHRASE[change.to]} Narrate it at exactly that weight, no heavier.`
+          : change.from === 'unhurt'
+            ? 'it did not mark them. Narrate the moment without an injury.'
+            : `it cost them nothing further — they are still ${CONDITION_LABEL[change.to].toLowerCase()}. Do not narrate a new wound.`,
     ]
       .filter(Boolean)
       .join(' '),
@@ -1759,6 +1798,14 @@ function harmFor(
  */
 function woundBrief(change: ReturnType<typeof applyDamage> | null, succeeded: boolean): string {
   if (!change || succeeded) return ''
+  // Told plainly, and told *here*, because there is no version of this where a
+  // dungeon master that has not been told writes the right paragraph. It has
+  // spent the whole campaign narrating consequences it can walk back; this is
+  // the one it cannot, and a model left to infer it from the word "dead" on a
+  // sheet writes a wound and a rescue. The instruction is what buys the ending.
+  if (change.died) {
+    return 'THAT KILLED THEM. The story ends here, and this is the last thing you will ever write in it. Narrate their death — once, in the voice you have been telling this in, inside the budget. Do not leave them clinging on, do not put help on the way, and do not soften it into a wound they might survive. Close on the fiction and stop.'
+  }
   if (change.steps > 0) {
     return `THAT HURT THEM. They are now ${CONDITION_LABEL[change.to].toLowerCase()}: ${CONDITION_PHRASE[change.to]} Narrate the injury at exactly that weight — not heavier because the moment deserved it, and not lighter because you would rather they were fine.`
   }

--- a/src/app/dicebound/DiceboundGame.tsx
+++ b/src/app/dicebound/DiceboundGame.tsx
@@ -20,10 +20,12 @@ import { useAuth } from '@/hooks/useAuth'
 import { accountBackend, localBackend } from './backend'
 import { Composer } from './components/composer'
 import { Creation } from './components/creation'
+import { Ending } from './components/ending'
 import { ShareButton } from './components/share'
 import { Sheet } from './components/sheet'
 import { SignInInvite } from './components/sign-in-invite'
 import { Transcript } from './components/transcript'
+import { isEnded } from './domain/campaign'
 import { useDicebound } from './store'
 
 export function DiceboundGame() {
@@ -75,6 +77,9 @@ export function DiceboundGame() {
   if (phase === 'creating' || !campaign) {
     return <Creation onBegin={begin} pending={pending} error={error} />
   }
+
+  const ended = isEnded(campaign)
+  const anonymous = !configured || Boolean(user?.isAnonymous)
 
   return (
     <div className="flex h-[calc(100dvh-var(--dicebound-chrome,8rem))] gap-0 md:gap-6">
@@ -130,7 +135,16 @@ export function DiceboundGame() {
           </p>
         )}
 
-        <Composer onSend={act} disabled={pending} suggestions={suggestions} />
+        {/*
+          The composer is not disabled at the end, it is gone. A greyed-out
+          input under a finished story invites the player to work out what they
+          would have to do to re-enable it, and the answer is nothing.
+        */}
+        {ended ? (
+          <Ending campaign={campaign} onBegin={() => void abandon()} invite={anonymous} />
+        ) : (
+          <Composer onSend={act} disabled={pending} suggestions={suggestions} />
+        )}
       </div>
 
       {/* Desktop: the sheet is always there. Mobile: it slides over. */}
@@ -153,19 +167,27 @@ export function DiceboundGame() {
           </button>
         )}
         <Sheet campaign={campaign} />
-        <div className="flex flex-col gap-4 p-5 pt-0">
-          {(!configured || user?.isAnonymous) && <SignInInvite streak={campaign.currentStreak} />}
-          <button
-            type="button"
-            onClick={() => {
-              if (window.confirm('Leave this story behind? It will not come back.')) void abandon()
-            }}
-            disabled={pending}
-            className="text-sm text-on-surface-variant/70 underline hover:text-ds-error focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ds-error disabled:opacity-50"
-          >
-            Begin a different story
-          </button>
-        </div>
+        {/*
+          Both of these move to the ending screen once there is one, rather than
+          being shown twice. The invite in particular: asking in two places at
+          the same moment is the difference between an offer and a nag.
+        */}
+        {!ended && (
+          <div className="flex flex-col gap-4 p-5 pt-0">
+            {anonymous && <SignInInvite streak={campaign.currentStreak} />}
+            <button
+              type="button"
+              onClick={() => {
+                if (window.confirm('Leave this story behind? It will not come back.'))
+                  void abandon()
+              }}
+              disabled={pending}
+              className="text-sm text-on-surface-variant/70 underline hover:text-ds-error focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ds-error disabled:opacity-50"
+            >
+              Begin a different story
+            </button>
+          </div>
+        )}
       </aside>
     </div>
   )

--- a/src/app/dicebound/components/__tests__/ending.test.tsx
+++ b/src/app/dicebound/components/__tests__/ending.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+/**
+ * The last screen.
+ *
+ * Two of these protect rules with no other guard. Starting again must not be a
+ * single unguarded tap while the shelf that would keep the finished story does
+ * not exist yet (#3780) — and the tally must not print things that did not
+ * happen, which is the same rule as the empty inventory grid.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Ending } from '@/app/dicebound/components/ending'
+import { shareText } from '@/app/dicebound/components/share'
+import { type Campaign, newCampaign } from '@/app/dicebound/domain/campaign'
+import { blankAttributes } from '@/app/dicebound/domain/character'
+
+afterEach(cleanup)
+
+function ended(over: Partial<Campaign> = {}): Campaign {
+  const base = newCampaign(
+    'a lighthouse that has started walking',
+    { name: 'Pell', concept: 'a salvager', reading: '', attributes: blankAttributes(), skills: {} },
+    1000,
+    null
+  )
+  return {
+    ...base,
+    title: 'The Lamp That Walked',
+    body: { condition: 'dead' },
+    ending: { cause: 'death', condition: 'dead', at: 4200, endedAt: 5000 },
+    stats: { turns: 41, checks: 17, successes: 9, naturalTwenties: 2, naturalOnes: 0 },
+    ...over,
+  }
+}
+
+describe('the ending screen', () => {
+  it('names the character and what the story cost them', () => {
+    render(<Ending campaign={ended()} onBegin={() => {}} invite={false} />)
+
+    expect(screen.getByText(/Here the telling stops/)).toBeTruthy()
+    expect(screen.getByText(/Pell came as far as/)).toBeTruthy()
+    expect(screen.getByText(/41 turns · 17 rolls of the die · 2 natural twenties/)).toBeTruthy()
+  })
+
+  it('leaves out what did not happen — no "0 natural ones" on the tally', () => {
+    // Same rule as the empty inventory grid (CLAUDE.md #17). A record of a
+    // finished story should contain the things that occurred in it, and a
+    // player who never rolled a 1 does not need to be told the count.
+    render(<Ending campaign={ended()} onBegin={() => {}} invite={false} />)
+
+    expect(screen.queryByText(/natural ones/)).toBeNull()
+  })
+
+  it('reads the rung off the record, not off a live body that could still move', () => {
+    render(<Ending campaign={ended()} onBegin={() => {}} invite={false} />)
+
+    expect(screen.getByText('Dead')).toBeTruthy()
+  })
+})
+
+describe('beginning again', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('asks before it lets the finished story go', () => {
+    // Not paperwork. The campaign is kept when it ends — that is the whole
+    // reason the ending is a record — but there is one story per player, so
+    // starting another is the thing that actually releases this one. Until the
+    // shelf exists (#3780) the player is told that in the sentence rather than
+    // finding out afterwards.
+    const onBegin = vi.fn()
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<Ending campaign={ended()} onBegin={onBegin} invite={false} />)
+    fireEvent.click(screen.getByText('Begin a new story'))
+
+    expect(window.confirm).toHaveBeenCalled()
+    expect(onBegin).not.toHaveBeenCalled()
+  })
+
+  it('goes through once the player has said so', () => {
+    const onBegin = vi.fn()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<Ending campaign={ended()} onBegin={onBegin} invite={false} />)
+    fireEvent.click(screen.getByText('Begin a new story'))
+
+    expect(onBegin).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('what a finished story shares', () => {
+  it('shares the whole run rather than the last roll it happened to end on', () => {
+    // A finished story is the only genuinely shareable artifact this game has
+    // ever had, and it outranks the die card: a good roll is a moment out of a
+    // story, and the story is the thing worth sending someone.
+    const text = shareText(ended())
+
+    expect(text).toContain('Pell died')
+    expect(text).toContain('The Lamp That Walked')
+    expect(text).toContain('41 turns')
+  })
+})

--- a/src/app/dicebound/components/ending.tsx
+++ b/src/app/dicebound/components/ending.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+/**
+ * The last screen of a story.
+ *
+ * This is the run boundary both design docs have been waiting for. Until the
+ * track could bottom out there was nowhere to put an end-of-session beat, so
+ * there was no ceremony, nothing to share that was a whole thing rather than a
+ * moment, and no honest place to ask anyone to sign up. All three land here.
+ *
+ * **It replaces the composer, and the transcript stays.** That placement is the
+ * only real design decision in the file, and the alternative — a full-screen
+ * takeover — was rejected because the most important thing on the page is the
+ * paragraph in which the character died, and a takeover covers it. The player
+ * types in this spot every turn of the game; the last thing that happens is
+ * that there is nothing to type there any more, which says it better than a
+ * modal would.
+ *
+ * Voice is the cosmic narrator (CLAUDE.md #4, #7). This is the most emotionally
+ * loaded surface the game has and it does not get a default dialog.
+ */
+import { useEffect, useRef } from 'react'
+
+import { CONDITION_LABEL } from '@/app/dicebound/domain/body'
+import type { Campaign } from '@/app/dicebound/domain/campaign'
+import { currentPlace, describeClock } from '@/app/dicebound/domain/world'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+import { ShareButton } from './share'
+import { SignInInvite } from './sign-in-invite'
+
+/**
+ * The confirmation is not paperwork.
+ *
+ * A finished story is kept — the campaign is marked ended, never deleted, and
+ * that is the whole reason `Ending` is a record rather than a flag inferred
+ * from the track. But there is still one campaign per player, so starting
+ * another is what finally lets this one go, and the player is told so in the
+ * sentence rather than finding out afterwards. The shelf that would make this
+ * non-destructive is #3780, and it is deliberately not built yet.
+ */
+const CONFIRM =
+  'Begin a new story? This one stays where it is until you do — starting another lets it go.'
+
+export function Ending({
+  campaign,
+  onBegin,
+  invite,
+}: {
+  campaign: Campaign
+  onBegin: () => void
+  /** Whether this player is still anonymous, and so has something to be offered. */
+  invite: boolean
+}) {
+  const headingRef = useRef<HTMLParagraphElement>(null)
+
+  /**
+   * Move the reader to the ending once, when it arrives.
+   *
+   * A screen reader that stays parked in the composer it was in a moment ago
+   * is a player who is told nothing at all — the composer is simply gone, which
+   * announces as silence. `preventScroll` because the transcript has already
+   * scrolled to the death paragraph and dragging the viewport away from it is
+   * the one thing this screen must not do.
+   */
+  useEffect(() => {
+    headingRef.current?.focus({ preventScroll: true })
+  }, [])
+
+  const where = currentPlace(campaign.world)
+  const { stats } = campaign
+  const rung = campaign.ending?.condition ?? campaign.body.condition
+
+  const tally = [
+    `${stats.turns} ${stats.turns === 1 ? 'turn' : 'turns'}`,
+    `${stats.checks} ${stats.checks === 1 ? 'roll' : 'rolls'} of the die`,
+    // Zeroes are left off rather than printed. "0 natural twenties" is a line
+    // about something that did not happen, and a tally of a finished story
+    // should only contain things that did (CLAUDE.md #17, in spirit).
+    stats.naturalTwenties > 0
+      ? `${stats.naturalTwenties} natural ${stats.naturalTwenties === 1 ? 'twenty' : 'twenties'}`
+      : '',
+    stats.naturalOnes > 0
+      ? `${stats.naturalOnes} natural ${stats.naturalOnes === 1 ? 'one' : 'ones'}`
+      : '',
+  ].filter(Boolean)
+
+  return (
+    <section
+      aria-labelledby="dicebound-ending-heading"
+      className="dicebound-ending border-t-2 border-ds-error/30 bg-surface-container-low px-4 py-6 md:px-8"
+    >
+      <div className="mx-auto flex max-w-2xl flex-col gap-5">
+        <div>
+          <p
+            id="dicebound-ending-heading"
+            ref={headingRef}
+            tabIndex={-1}
+            className="font-headline text-headline-md text-on-surface focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ds-primary"
+          >
+            Here the telling stops.
+          </p>
+          <p className="mt-2 text-body-lg text-on-surface-variant">
+            {campaign.character.name} came as far as{' '}
+            {where ? <span className="text-on-surface">{where.name}</span> : 'this'}, and no
+            further. {describeClock(campaign.world.clock)}.
+          </p>
+        </div>
+
+        <p className="border-l-2 border-ds-error/40 pl-3 font-label text-label-caps uppercase tracking-widest text-on-surface-variant/80">
+          {CONDITION_LABEL[rung]}
+        </p>
+
+        <p className="text-body-md text-on-surface-variant">{tally.join(' · ')}.</p>
+
+        <p className="text-body-md italic text-on-surface-variant/80">
+          The cave keeps what happened here. It does not give it back.
+        </p>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <ShareButton campaign={campaign} label="Share this story" />
+          <ChunkyButton
+            variant="exit"
+            size="md"
+            shape="pill"
+            onClick={() => {
+              if (window.confirm(CONFIRM)) onBegin()
+            }}
+          >
+            Begin a new story
+          </ChunkyButton>
+        </div>
+
+        {invite && <SignInInvite streak={campaign.currentStreak} ending />}
+      </div>
+    </section>
+  )
+}

--- a/src/app/dicebound/components/share.tsx
+++ b/src/app/dicebound/components/share.tsx
@@ -12,12 +12,19 @@
  * Before the first roll there is nothing worth sharing but the premise, so
  * that is what it falls back to. The link always drops the visitor straight
  * into play (principle 1), never onto a marketing page.
+ *
+ * A finished story outranks the last roll, and it is the only genuinely
+ * shareable artifact this game has ever had — a run that ended is a whole
+ * thing, where a good roll is a moment out of one. That branch is why the
+ * ending screen reuses this button rather than growing its own.
  */
 import { useState } from 'react'
 
 import { SKILLS } from '@/app/dicebound/domain/attributes'
 import type { Campaign, CheckEntry } from '@/app/dicebound/domain/campaign'
 import { BAND_LABEL } from '@/app/dicebound/domain/dice'
+import { currentPlace, dayOf } from '@/app/dicebound/domain/world'
+import { ChunkyButton } from '@/components/ui/chunky-button'
 
 function lastCheck(campaign: Campaign): CheckEntry | null {
   for (let i = campaign.transcript.length - 1; i >= 0; i--) {
@@ -31,6 +38,16 @@ export function shareText(campaign: Campaign): string {
   const check = lastCheck(campaign)
   const who = campaign.character.name
 
+  // The whole story beats the last roll of it. Numbers rather than adjectives,
+  // for the same reason the roll line is: a stranger reading this learns what
+  // the game is from the shape of the sentence, and "62 turns" tells them more
+  // about that than "an epic campaign" ever could.
+  if (campaign.ending) {
+    const where = currentPlace(campaign.world)
+    const day = dayOf(campaign.world.clock)
+    return `${who} died${where ? ` at ${where.name}` : ''} on day ${day} of "${campaign.title}". ${campaign.stats.turns} turns, ${campaign.stats.checks} rolls of the die, and that was the last of them.`
+  }
+
   if (!check) {
     return `${who} is about to find out what happens in "${campaign.title}" — ${campaign.premise}.`
   }
@@ -41,7 +58,16 @@ export function shareText(campaign: Campaign): string {
   return `${who} tried to ${check.attempt.toLowerCase()}${skill}. Needed ${check.dc}, rolled ${check.roll}${check.modifier >= 0 ? '+' : '−'}${Math.abs(check.modifier)} = ${check.total}. ${BAND_LABEL[check.band]}.${flourish}`
 }
 
-export function ShareButton({ campaign }: { campaign: Campaign }) {
+/**
+ * `label` turns the header's icon into a full action.
+ *
+ * One component with two shapes rather than two components: the interesting
+ * part of sharing is `shareText` and the OS-sheet-then-clipboard fallback
+ * below, and a second copy of that is a second thing to fix. The header wants
+ * an icon because it sits beside a title; the ending screen wants a button a
+ * player is actually being invited to press.
+ */
+export function ShareButton({ campaign, label }: { campaign: Campaign; label?: string }) {
   const [copied, setCopied] = useState(false)
 
   const share = async () => {
@@ -66,6 +92,20 @@ export function ShareButton({ campaign }: { campaign: Campaign }) {
     } catch {
       // Clipboard blocked. Nothing useful to say, and nothing broken.
     }
+  }
+
+  if (label) {
+    return (
+      <ChunkyButton variant="primary" size="md" shape="pill" onClick={share}>
+        <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+          {copied ? 'check' : 'ios_share'}
+        </span>
+        {copied ? 'Copied' : label}
+        <span aria-live="polite" className="sr-only">
+          {copied ? 'Copied to clipboard' : ''}
+        </span>
+      </ChunkyButton>
+    )
   }
 
   return (

--- a/src/app/dicebound/components/sign-in-invite.tsx
+++ b/src/app/dicebound/components/sign-in-invite.tsx
@@ -1,12 +1,25 @@
 'use client'
 
 /**
- * Sign-up prompt (interaction model 4, trigger 2 — streak threshold).
+ * Sign-up prompt (interaction model 4, triggers 1 and 2).
  *
- * A run-loop game has no end-of-session beat to hang trigger 1 on, so the
- * honest moment here is the one where the player has something worth losing:
- * a character several days deep, kept on one device against an anonymous uid.
- * Three days is the threshold the model names.
+ * Two moments, one component. The streak threshold came first because a
+ * run-loop game had no end-of-session beat to hang trigger 1 on: the honest
+ * moment was the one where the player had something worth losing — a character
+ * several days deep, kept on one device against an anonymous uid. Three days is
+ * the threshold the model names.
+ *
+ * Now a run can end, and `ending` is trigger 1 arriving late. It is the
+ * stronger of the two by some distance: a player who has just lost a character
+ * they spent a week on is being offered a reason to keep the record, which is
+ * the honest version of that pitch rather than a growth prompt wearing one. It
+ * ignores the streak, because a story that finished on day two still finished.
+ *
+ * What it does **not** ignore is a dismissal. A player who said "not now" a
+ * week ago has answered this question, and the ending being a bigger moment is
+ * a reason to ask well rather than a licence to ask again — the file's own rule
+ * is that erring toward asking less often is the right direction to be wrong
+ * in, and an ending is exactly where that rule earns its keep.
  *
  * It sells depth, not access — the campaign already saves without an account,
  * and the copy says so rather than implying otherwise. It is inline in the
@@ -37,7 +50,7 @@ function suppressedUntil(): number {
   }
 }
 
-export function SignInInvite({ streak }: { streak: number }) {
+export function SignInInvite({ streak, ending = false }: { streak: number; ending?: boolean }) {
   /**
    * Read once, in a lazy initializer rather than an effect.
    *
@@ -47,7 +60,8 @@ export function SignInInvite({ streak }: { streak: number }) {
    */
   const [dismissed, setDismissed] = useState(() => Date.now() <= suppressedUntil())
 
-  if (dismissed || streak < INVITE_AT_STREAK) return null
+  if (dismissed) return null
+  if (!ending && streak < INVITE_AT_STREAK) return null
 
   const dismiss = () => {
     setDismissed(true)
@@ -61,7 +75,9 @@ export function SignInInvite({ streak }: { streak: number }) {
   return (
     <aside className="rounded-ds-sm border-2 border-ds-tertiary/40 bg-surface-container p-4">
       <p className="text-body-md text-on-surface">
-        {streak} days deep. Sign in and the cave will carry this story to your other devices.
+        {ending
+          ? 'That was a whole story, start to finish. Sign in and it stays yours — on this device and any other.'
+          : `${streak} days deep. Sign in and the cave will carry this story to your other devices.`}
       </p>
       <div className="mt-3 flex items-center gap-4">
         <a

--- a/src/app/dicebound/domain/__tests__/ending.test.ts
+++ b/src/app/dicebound/domain/__tests__/ending.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The run boundary.
+ *
+ * Every rule here exists because the alternative is a specific, playable bug:
+ * a dead character handed a composer, a story that un-ends on reload, or an
+ * ending whose timestamp moves every time the save is validated. The last one
+ * sounds cosmetic and is not — the ending is the only thing that will ever say
+ * *when* a story finished, and everything phase 3 deferred reads it.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  CAMPAIGN_VERSION,
+  type Campaign,
+  isEnded,
+  newCampaign,
+  validateCampaign,
+} from '@/app/dicebound/domain/campaign'
+import { blankAttributes } from '@/app/dicebound/domain/character'
+import { applyTurn } from '@/app/dicebound/domain/turn'
+
+function campaign(): Campaign {
+  return newCampaign(
+    'a lighthouse that has started walking',
+    {
+      name: 'Pell',
+      concept: 'a very small person with a very large hammer',
+      reading: '',
+      attributes: blankAttributes(),
+      skills: {},
+    },
+    1000,
+    null
+  )
+}
+
+describe('ending a run', () => {
+  it('a new story has no ending — nothing renders until it exists', () => {
+    expect(campaign().ending).toBeNull()
+    expect(isEnded(campaign())).toBe(false)
+  })
+
+  it('writes the ending down on the turn that reaches the last rung', () => {
+    const after = applyTurn(campaign(), { entries: [], body: { condition: 'dead' } }, 5000)
+
+    expect(after.ending).toEqual({ cause: 'death', condition: 'dead', at: 0, endedAt: 5000 })
+    expect(isEnded(after)).toBe(true)
+  })
+
+  it('stamps the clock the fiction died on, not the one the save happened at', () => {
+    // Story time and wall time answer different questions, and the screen asks
+    // the first one: "day four, dusk" is what the player remembers, and it is
+    // the only one of the two that survives a campaign being played across a
+    // week of evenings.
+    const world = { ...campaign().world, clock: { ...campaign().world.clock, elapsed: 4200 } }
+    const after = applyTurn(campaign(), { entries: [], body: { condition: 'dead' }, world }, 5000)
+
+    expect(after.ending?.at).toBe(4200)
+    expect(after.ending?.endedAt).toBe(5000)
+  })
+
+  it('leaves a story that is still going alone', () => {
+    const after = applyTurn(campaign(), { entries: [], body: { condition: 'dying' } }, 5000)
+
+    expect(after.ending).toBeNull()
+    expect(isEnded(after)).toBe(false)
+  })
+
+  it('never revises an ending it has already written', () => {
+    // Permanence, as a property of the field rather than of the fiction. It is
+    // also what keeps a re-saved campaign from creeping forward in time every
+    // time it is touched — an ending that moved would make "how long ago did
+    // this story finish" answerable only as "just now".
+    const dead = applyTurn(campaign(), { entries: [], body: { condition: 'dead' } }, 5000)
+    const again = applyTurn(dead, { entries: [], body: { condition: 'dead' } }, 9000)
+
+    expect(again.ending?.endedAt).toBe(5000)
+  })
+
+  it('is over whether or not the record made it — the track is checked too', () => {
+    // The state this rules out is the bad one: dead body, no ending, and a game
+    // that carries on because the flag it consults was never set.
+    const halfway: Campaign = { ...campaign(), body: { condition: 'dead' }, ending: null }
+    expect(isEnded(halfway)).toBe(true)
+  })
+})
+
+describe('an ending on the wire', () => {
+  it('survives the round trip', () => {
+    const dead = applyTurn(campaign(), { entries: [], body: { condition: 'dead' } }, 5000)
+    const read = validateCampaign(JSON.parse(JSON.stringify(dead)))
+
+    expect(read?.ending).toEqual(dead.ending)
+  })
+
+  it('reads a story that ended before endings existed as ended', () => {
+    // The window this covers is real: the condition track shipped first, so
+    // there are saved campaigns sitting on the last rung with no record of
+    // having stopped. Version 3 is not bumped for it — the migration is that
+    // the ending is stamped from what the campaign already holds.
+    const orphan = {
+      ...campaign(),
+      version: 3,
+      body: { condition: 'dead' },
+      updatedAt: 7777,
+      ending: undefined,
+    }
+    const read = validateCampaign(JSON.parse(JSON.stringify(orphan)))
+
+    expect(read?.ending).toEqual({ cause: 'death', condition: 'dead', at: 0, endedAt: 7777 })
+  })
+
+  it('does not invent an ending for a campaign that is merely old', () => {
+    const ancient = { ...campaign(), version: 1, body: undefined, ending: undefined }
+    const read = validateCampaign(JSON.parse(JSON.stringify(ancient)))
+
+    expect(read?.version).toBe(CAMPAIGN_VERSION)
+    expect(read?.ending).toBeNull()
+  })
+
+  it('repairs a garbled ending rather than dropping it — losing it resurrects them', () => {
+    // Of the two ways to be wrong about a finished story, showing the ending
+    // screen over a wrong day number is recoverable and handing a dead
+    // character their turn back is not.
+    const mangled = {
+      ...campaign(),
+      body: { condition: 'dead' },
+      updatedAt: 4444,
+      ending: { cause: 'nonsense', condition: 'sideways', at: 'later' },
+    }
+    const read = validateCampaign(JSON.parse(JSON.stringify(mangled)))
+
+    expect(read?.ending).toEqual({ cause: 'death', condition: 'dead', at: 0, endedAt: 4444 })
+  })
+})

--- a/src/app/dicebound/domain/campaign.ts
+++ b/src/app/dicebound/domain/campaign.ts
@@ -20,10 +20,17 @@
  * Set, a Date or a class.
  */
 import { ATTRIBUTE_IDS, isAttributeId, isSkillId } from './attributes'
-import { type Body, undamagedBody, validateBody } from './body'
+import {
+  type Body,
+  CONDITION_ORDER,
+  type Condition,
+  isDead,
+  undamagedBody,
+  validateBody,
+} from './body'
 import { MAX_SKILL_RANK, blankAttributes, normalizeAttributes } from './character'
 import { type Kit, emptyKit, validateKit } from './kit'
-import { boundedInt, int, isPlainObject, str } from './validate'
+import { boundedInt, int, isPlainObject, oneOf, str } from './validate'
 import { type World, emptyWorld, validateWorld } from './world'
 
 import type { AttributeId, SkillId } from './attributes'
@@ -45,6 +52,11 @@ import type { Modifier, OutcomeBand, RolledTwice } from './dice'
  * and the stakes of getting it wrong are now a step higher — a version 2
  * campaign reads as a valid campaign with an undamaged body, because the only
  * honest reading of "this save predates injury" is that nobody has been injured.
+ *
+ * `ending` is deliberately *not* a fourth version. A campaign saved without one
+ * is a story still going, which is true of every campaign that ever had no
+ * `ending` field — except a character already sitting on the last rung, and
+ * that one case is stamped on read rather than versioned. See `readEnding`.
  */
 export const CAMPAIGN_VERSION = 3
 
@@ -105,6 +117,35 @@ export interface CampaignStats {
   naturalOnes: number
 }
 
+/**
+ * How a story stopped.
+ *
+ * A written record rather than `body.condition === 'dead'` read back, and the
+ * difference is the sentence in #3769 saying that nothing built here may assume
+ * permanence is forever. An ending *inferred* from the track is an ending
+ * welded to the track: the day a gentler mode arrives — a run that can be
+ * walked away from, a death that costs something other than the character —
+ * there is nowhere to write that down, and the softer path becomes a rewrite
+ * instead of a branch. Everything downstream reads this field and re-decides
+ * nothing.
+ *
+ * It is also what makes the ending survivable in the other direction. The
+ * campaign is not deleted when it ends; this is the flag that says the
+ * transcript sitting in storage is a finished story rather than one waiting for
+ * its next turn.
+ *
+ * `cause` has exactly one value today, and is a field for the same reason.
+ */
+export interface Ending {
+  cause: 'death'
+  /** The rung it ended on, so the screen can name it in the game's own words. */
+  condition: Condition
+  /** Clock minute of the fiction. Story time — "day four, dusk" — not a timestamp. */
+  at: number
+  /** Wall-clock ms, which is the only thing here that can say "a week ago". */
+  endedAt: number
+}
+
 export interface Campaign {
   version: number
   /** The player's one-line answer to "where does your story begin?". */
@@ -114,6 +155,11 @@ export interface Campaign {
   character: Character
   /** Where the character is on the condition track. Added in version 3. */
   body: Body
+  /**
+   * Set once, when the run ends. Null for a story still being told, which is
+   * almost all of them — nothing renders until it exists (CLAUDE.md #17).
+   */
+  ending: Ending | null
   /** Places, people, things and threads, plus the clock. Added in version 2. */
   world: World
   /** Carried items, powers, species and the discovered class. Added in version 2. */
@@ -186,6 +232,7 @@ export function newCampaign(
     title: 'An Untitled Story',
     character,
     body: undamagedBody(),
+    ending: null,
     world: emptyWorld(),
     kit: emptyKit(),
     transcript: [],
@@ -252,18 +299,23 @@ export function validateCampaign(value: unknown): Campaign | null {
   // there was never anything in these fields to lose.
   const migrating = value.version < 2
 
+  const body = validateBody(value.body)
+  const world = migrating ? emptyWorld() : validateWorld(value.world)
+  const updatedAt = int(value.updatedAt)
+
   return {
     version: CAMPAIGN_VERSION,
     premise: str(value.premise, MAX_PREMISE),
     title: str(value.title, 120, 'An Untitled Story'),
     character,
-    // No `migrating` guard, unlike the two below it. `validateBody` already
+    // No `migrating` guard, unlike `world` and `kit`. `validateBody` already
     // reads an absent body as an undamaged one, so the version 2 → 3 migration
     // is the ordinary path through it rather than a branch that has to be
     // remembered — and a branch nobody has to remember is a branch that cannot
-    // be forgotten at the next bump.
-    body: validateBody(value.body),
-    world: migrating ? emptyWorld() : validateWorld(value.world),
+    // be forgotten at the next bump. `readEnding` is built the same way.
+    body,
+    ending: readEnding(value.ending, body, world.clock.elapsed, updatedAt),
+    world,
     kit: migrating ? emptyKit() : validateKit(value.kit),
     transcript: transcript.slice(-CONDENSE_AT * 2),
     synopsis: str(value.synopsis, 8000),
@@ -280,8 +332,63 @@ export function validateCampaign(value: unknown): Campaign | null {
     currentStreak: Math.max(0, int(value.currentStreak)),
     longestStreak: Math.max(0, int(value.longestStreak)),
     startedAt: int(value.startedAt),
-    updatedAt: int(value.updatedAt),
+    updatedAt,
   }
+}
+
+/**
+ * Whether the last step has been taken.
+ *
+ * `endedAt` is the caller's clock rather than this module's, for the reason
+ * everything in `domain/` takes its time as an argument: a pure function cannot
+ * read one, and a run whose ending time depended on when the save happened to
+ * be validated would be a different story every time it loaded.
+ */
+export function endingFor(body: Body, at: number, endedAt: number): Ending | null {
+  if (!isDead(body)) return null
+  return { cause: 'death', condition: body.condition, at, endedAt }
+}
+
+/**
+ * Whether this story is over.
+ *
+ * Reads the track as well as the record, and the redundancy is the point. The
+ * record is what the ending screen renders from; the track is the thing no code
+ * path can forget to set, because it is where the damage already landed. The
+ * failure this shape prevents is narrow and bad: a campaign that is dead but
+ * not marked ended is a dead character being handed a composer, and the turn
+ * after that is a dungeon master narrating for someone who is not there.
+ */
+export function isEnded(campaign: Campaign): boolean {
+  return campaign.ending !== null || isDead(campaign.body)
+}
+
+/**
+ * An ending off the wire, or the one that should already have been written.
+ *
+ * The second half is a migration, not a repair. The condition track shipped
+ * before endings did, so there is a window of saved campaigns whose character
+ * is on the last rung with nothing recording that the story stopped — and
+ * "dead but still playable" is the one state nothing downstream knows how to
+ * render. It is stamped from what the campaign already holds: the clock it died
+ * on is the clock it is still sitting at, because nothing has happened since,
+ * and `updatedAt` is the turn that killed them for exactly the same reason.
+ *
+ * A malformed stored ending is repaired rather than dropped. Losing the record
+ * would resurrect the character, and of the two ways to be wrong about a
+ * finished story — showing the ending screen over a slightly wrong day number,
+ * or handing a dead character their turn back — only one of them is a game.
+ */
+function readEnding(value: unknown, body: Body, at: number, updatedAt: number): Ending | null {
+  if (isPlainObject(value)) {
+    return {
+      cause: 'death',
+      condition: oneOf(value.condition, CONDITION_ORDER, 'dead'),
+      at: Math.max(0, int(value.at, at)),
+      endedAt: int(value.endedAt, updatedAt),
+    }
+  }
+  return endingFor(body, at, updatedAt)
 }
 
 export function validateCharacter(value: unknown): Character | null {

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -6,6 +6,7 @@
  * so the interesting arithmetic — streaks, skill ranks, the running tally of
  * natural 20s — can be tested without a network or a browser.
  */
+import { endingFor } from './campaign'
 import { type Character, recordSkillUse } from './character'
 
 import type { Body } from './body'
@@ -235,6 +236,7 @@ export function applyTurn(campaign: Campaign, result: TurnResult, now: number): 
   // turn never reached a narrate and so produced no world.
   const clock = (result.world ?? campaign.world).clock.elapsed
   const { character, entries } = creditSkills(campaign.character, result.entries, clock)
+  const body = result.body ?? campaign.body
 
   const kept =
     result.dropped && result.dropped > 0
@@ -247,7 +249,19 @@ export function applyTurn(campaign: Campaign, result: TurnResult, now: number): 
     synopsis: result.synopsis ?? campaign.synopsis,
     world: result.world ?? campaign.world,
     kit: result.kit ?? campaign.kit,
-    body: result.body ?? campaign.body,
+    body,
+    // The one place a run ends.
+    //
+    // Here rather than in the route, because both paths through a turn come
+    // back through this function — the server-authoritative one and the
+    // anonymous local one — and an ending stamped in only one of them is a
+    // dead character who can keep playing as long as Firebase is switched off.
+    //
+    // `campaign.ending ??` is the whole of permanence. An ending is written
+    // once and never revised, which also means this function does not need an
+    // opinion about whether death can be undone later: that is a decision about
+    // what may *clear* the field, and it stays a branch somewhere else.
+    ending: campaign.ending ?? endingFor(body, clock, now),
     chapters: result.chapters ?? campaign.chapters,
     character,
     transcript: [...kept, ...entries],

--- a/src/app/dicebound/store.ts
+++ b/src/app/dicebound/store.ts
@@ -40,7 +40,14 @@ import { getTodayPST, getYesterdayOf } from '@/lib/dates'
 
 import { createCharacter, fetchSuggestions, takeTurn } from './api'
 import { type CampaignBackend, nullBackend } from './backend'
-import { type Campaign, MAX_CONCEPT, MAX_PREMISE, newCampaign, withVisit } from './domain/campaign'
+import {
+  type Campaign,
+  MAX_CONCEPT,
+  MAX_PREMISE,
+  isEnded,
+  newCampaign,
+  withVisit,
+} from './domain/campaign'
 import { applyTurn } from './domain/turn'
 
 import type { Character } from './domain/character'
@@ -164,6 +171,11 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
   async act(action) {
     const { campaign, pending } = get()
     if (!campaign || pending) return
+    // A finished story takes no more turns. The UI renders the ending screen
+    // where the composer was, so nothing can reach this — but the route refuses
+    // an ended campaign with a 409, and a client that could still send one would
+    // turn "your character is dead" into an error bar the player has to dismiss.
+    if (isEnded(campaign)) return
 
     const text = action.trim()
     if (!text) return
@@ -223,6 +235,11 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
   async refreshSuggestions() {
     const campaign = get().campaign
     if (!campaign || campaign.transcript.length === 0) return
+    // Nothing to suggest to someone with no next move. This also matters on
+    // load: `attach` asks for three every time a story is opened, and a
+    // finished one would pay for a model call on every visit to a screen whose
+    // whole point is that there is nothing left to try.
+    if (isEnded(campaign)) return
     if (get().suggestionsHidden) return
 
     const seq = get().suggestSeq + 1

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -733,6 +733,23 @@ body {
   animation: dicebound-suggestions-in 0.3s ease-out;
 }
 
+/* ───────────────────────────────────────────────────────────────────
+   Dicebound — the ending, arriving where the composer was.
+   Slower than anything else in the game on purpose: the player is
+   still reading the paragraph their character died in, and a panel
+   that snaps into place under it reads as a dialog rather than as a
+   thing the story did. Reduced motion is handled by the global rule.
+   ─────────────────────────────────────────────────────────────────── */
+
+@keyframes dicebound-ending-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.dicebound-ending {
+  animation: dicebound-ending-in 1.2s ease-out;
+}
+
 @media print {
   /* Page break control */
   .break-after-page {

--- a/src/lib/dicebound/campaign-store.ts
+++ b/src/lib/dicebound/campaign-store.ts
@@ -82,6 +82,11 @@ export async function saveCampaign(uid: string, campaign: Campaign): Promise<voi
     level: levelFor(earnedRanks(campaign.character)),
     className: campaign.kit.className ?? null,
     species: campaign.kit.species?.name ?? null,
+    // A finished story, readable without parsing the blob. This file's own
+    // rule: anything a future home page or shelf has to ask about becomes a
+    // scalar here, because the alternative is reading every player's whole
+    // campaign to answer "which of these are over".
+    endedAt: campaign.ending?.endedAt ?? null,
     storyDay: dayOf(campaign.world.clock),
     entities: Object.keys(campaign.world.entities).length,
     chapters: campaign.chapters,


### PR DESCRIPTION
Closes #3776.

The track has been able to reach `dead` since #3771 and nothing happened when it did. `applyDamage` returned `died: true`, the route saved the rung, and the game carried on — composer live, suggestions refreshing, the dungeon master narrating for someone who was not there. This is the run boundary both design docs have been carrying an open question about, and it is what heirlooms, a shelf of stories and a share card worth sharing have all been waiting to attach to.

**Death happens in code.** No tool, and the DM is never asked. It is the inverse of the rule that the model cannot grant progression and rests on the same observation: a model that can decide the character dies can also decide it does not, and the second one is what it will actually do. What it gets instead is the fact, plainly, in the tool result that already reports the wound — invariant 19, and the failure it prevents is a maiming plus a rescue written by a DM left to infer it from the word "dead" on a sheet.

**`Ending` is a record, not `body.condition === 'dead'` read back.** An ending inferred from the track is welded to it, and #3769 is explicit that nothing here may assume permanence is forever. Stamped in `applyTurn` so both paths through a turn get it — server-authoritative and anonymous-local — and `campaign.ending ??` is the whole of permanence.

**Not a version bump.** A campaign with no `ending` is a story still going, which is true of all of them except a character already on the last rung; that window is stamped on read from the clock and `updatedAt` the campaign already holds.

**The loop stops offering a dead character more attempts.** `lastStep` becomes `step === MAX_CHECKS || isDead(body)`, so `narrate` is forced the same way it is on the final pass. That closes the fuse path too, and the class-naming beat and the rest line are suppressed — a level-up paragraph one line after someone dies is the worst place either could land. The fallback narration grows a death branch: "look around" after dying reads as a broken game rather than a finished one.

**The screen replaces the composer rather than covering the page.** The most important thing on screen is the paragraph the character died in, and a takeover hides it. Share and the sign-up invite both land here and both reuse the existing components; `shareText` gains an ending branch because a finished story outranks the last roll it happened to end on.

## Not delivered

**Starting again still lets the ended story go**, behind a confirm whose copy says so. The issue asks for one tap that does not destroy the ended campaign; keeping it needs somewhere to put it, that is #3780, and #3780 is gated. Rather than ship a silent delete I shipped an explicit one — the fallback the issue itself names. The campaign is otherwise never deleted on ending, and `endedAt` is written as a scalar beside the blob so a shelf can find finished stories without parsing every player's story.

**One design call worth a second opinion:** the ending invite respects an existing "not now" dismissal rather than overriding it. An ending is the stronger moment, but `sign-in-invite.tsx`'s own rule is that erring toward asking less often is the right direction to be wrong in. Easy to flip if you'd rather it always asked.

## Verification

```
$ npx tsc --noEmit 2>&1 | grep dicebound
(empty)

$ npx vitest run src/app/dicebound
 Test Files  1 failed | 19 passed (20)
      Tests  3 failed | 408 passed (411)
```

The 3 failures are pre-existing in `components/__tests__/suggestions.test.tsx` (`window.localStorage.setItem is not a function`) — confirmed identical on `main` with the branch stashed. 16 new tests.

```
$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound/turn
2 problems — both pre-existing (suggestions.test.tsx import/order, loot.test.ts sort-imports),
confirmed identical on main.

$ npm run lint:routes
check-route-slugs: ok

$ npx prettier --write <touched files>
```

`globals.css` was hand-edited and deliberately kept out of the prettier run.

### A real death, against the real API

A scratch script drove the turn route directly, forced the body to `dying`, and asked for something lethal. It landed on the first attempt.

```
[check] Dive into the drowned gallery and swim through the dark to the bell
        — constitution DC 18, rolled 14+0 = 14 → failure

DM: The cold takes you the way a hand takes a moth. You get eight strokes into the
    dark, the lamp dead behind you and the line paying out from your shoulder, and
    the roof of the gallery drops lower than you guessed — timber, silt, the soft
    nothing of a hundred years of drowned air. Somewhere ahead, close enough that
    you feel it in your teeth before you hear it, the bell moves. Once. A long
    bronze note travelling through the water toward you, and it is the most
    beautiful sound Kettlecross has never heard.

    You turn for the ladder. It is not far. It is only that there is no more of you
    left to spend, and the black water is very still, and the bell rings again over
    a town that will go on forgetting.

body -> dead
ending: {"cause":"death","condition":"dead","at":3,"endedAt":1787196803710}

a turn taken after the ending:  status 409: That story has already found its ending.
round trip through validateCampaign:  {"cause":"death","condition":"dead","at":3,...}
```

No clinging on, no help arriving, closes on the fiction. An earlier run of the same beat *passed* its check and cost nothing, which is the other half working — a success costs nothing whatever severity was named.

The scratch script was deleted rather than committed; measuring what kills people is #3779's job.

### Not verified

The ending screen has not been seen in a browser. It renders in jsdom under a component test and the page compiles clean under `next dev`, but there is no headless browser in this repo and engineering a death through the UI means seeding storage by hand. Layout and colour are unconfirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)