### PR TITLE
fix(micro-land): fish stop hanging at the waterline

### DIFF
--- a/src/app/micro-land/domain/__tests__/swimmer-waterline.test.ts
+++ b/src/app/micro-land/domain/__tests__/swimmer-waterline.test.ts
@@ -1,0 +1,151 @@
+/**
+ * A swimmer stays under the water it needs.
+ *
+ * Both tests reproduce the same field report from two directions: fish that
+ * "get stuck moving back and forth and up" until they are pinned at the top of
+ * the pool, where they starve or drown. Two independent things put them there.
+ *
+ * The physics: buoyancy used to be all-or-nothing above `wet > 0.3`, so a
+ * neutral fish (`buoyancy: 1`) that was a third submerged had its gravity
+ * switched fully off and hung at the waterline with nothing to pull it back
+ * under.
+ *
+ * The steering: `flee` is the reciprocal of the bearing to the threat, so a
+ * fish with a predator below it swam *up* — out of the water, out of its
+ * habitat, and into the drowning timer, all to escape something that could not
+ * follow it there.
+ *
+ * The pool is deliberately static: `tickTiles` is never called, so the water
+ * neither flows nor drains and `wet` measures the creature's choice rather than
+ * the terrain's.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { bodyBox, sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import {
+  boxLiquidFraction,
+  createWorld,
+  registerBlueprint,
+  spawnCreature,
+} from '@/app/micro-land/domain/sim/world'
+import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+/** Surface of the pool: air above this row, water from it down to the floor. */
+const SURFACE = 60
+const FLOOR = WORLD_H - 12
+
+function pool(): WorldState {
+  const w = createWorld(7)
+  const water = MATERIAL_INDEX.water
+  const stone = MATERIAL_INDEX.stone
+  for (let y = SURFACE; y < FLOOR; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = water
+  }
+  for (let y = FLOOR; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = stone
+  }
+  // Nothing generative: no seed bank, no sprouts wandering into the assertions.
+  w.dormant = true
+  w.elapsed = 1
+  return w
+}
+
+function fishBp(id: string, extra: Record<string, unknown> = {}): CreatureBlueprint {
+  return sanitizeBlueprint({
+    name: id,
+    tags: ['fish'],
+    art: { palette: { a: '#3399ff' }, frames: [['aaa', 'aaa', 'aaa']], frameMs: 200 },
+    move: { kind: 'swim', speed: 5, jump: 0, restlessness: 0.4 },
+    // Neutral buoyancy is the case that used to hang at the waterline: gravity
+    // and lift cancel exactly, so nothing decided which way it went.
+    body: { mass: 0.4, bounce: 0.1, drag: 0.45, buoyancy: 1, immuneTo: [] },
+    habitat: { needs: ['water'], drowns: false },
+    diet: { eats: [], fears: [], lifespanSeconds: 600 },
+    ...extra,
+  })
+}
+
+function wetness(w: WorldState, c: Creature, bp: CreatureBlueprint): number {
+  const body = bodyBox(bp)
+  return boxLiquidFraction(w, c.x + body.dx, c.y + body.dy, body.w, body.h)
+}
+
+function run(w: WorldState, seconds: number, each?: () => void): void {
+  const rng = makeRng(99)
+  for (let i = 0; i < Math.round(seconds * 60); i++) {
+    w.elapsed += 1 / 60
+    tickCreatures(w, 1 / 60, rng, 1, [])
+    each?.()
+  }
+}
+
+describe('a swimmer at the waterline sinks back under', () => {
+  it('a fish two-thirds out of the water submerges instead of hanging there', () => {
+    const w = pool()
+    const bp = fishBp('surfacer')
+    registerBlueprint(w, bp)
+    // Top-left at SURFACE - 2 puts one of its three rows in the water: 0.33,
+    // just over the old threshold, which is exactly where gravity used to
+    // switch off.
+    const fish = spawnCreature(w, bp, 100, SURFACE - 2)
+    expect(fish).not.toBeNull()
+    expect(wetness(w, fish!, bp)).toBeLessThan(0.5)
+
+    run(w, 4)
+
+    expect(w.creatures).toContain(fish!)
+    expect(wetness(w, fish!, bp)).toBe(1)
+  })
+})
+
+describe('a swimmer flees sideways, not out of the pool', () => {
+  it('a fish with a predator below it stays in the water', () => {
+    const w = pool()
+    const prey = fishBp('flee-fish', { senses: { sight: 30 } })
+    const hunter = sanitizeBlueprint({
+      name: 'stalker-fish',
+      tags: ['predator'],
+      art: { palette: { a: '#993333' }, frames: [['aaa', 'aaa', 'aaa']], frameMs: 200 },
+      // Stationary, so the geometry under test stays the geometry under test.
+      move: { kind: 'swim', speed: 0, jump: 0, restlessness: 0 },
+      body: { mass: 1, bounce: 0, drag: 0.4, buoyancy: 1, immuneTo: [] },
+      habitat: { needs: ['water'], drowns: false },
+      diet: { eats: ['fish'], fears: [], lifespanSeconds: 600 },
+    })
+    registerBlueprint(w, prey)
+    registerBlueprint(w, hunter)
+
+    // Prey four tiles under the surface, predator ten tiles below the prey —
+    // near enough to be seen, far enough that "away" is unambiguously upward.
+    const fish = spawnCreature(w, prey, 200, SURFACE + 4)
+    const pred = spawnCreature(w, hunter, 200, SURFACE + 14)
+    expect(fish).not.toBeNull()
+    expect(pred).not.toBeNull()
+
+    let fled = false
+    let driest = 1
+    run(w, 6, () => {
+      if (!w.creatures.includes(fish!)) return
+      if (fish!.mood === 'flee') fled = true
+      driest = Math.min(driest, wetness(w, fish!, prey))
+    })
+
+    // The test is only worth anything if the fish actually ran.
+    expect(fled).toBe(true)
+    /**
+     * Not `toBe(1)`: a fleeing fish is entitled to press right up under the
+     * surface, and a body resting on a fractional `y` straddles one more tile
+     * row than it is tall, so the fraction reads a little under 1 while every
+     * part of the animal is still wet. The number that matters is how far this
+     * is from the 0.25 the habitat check kills at — the same run against the
+     * old buoyancy and the old steering ends at exactly 0.25, a fish three
+     * quarters out of the pool with the drowning timer already running.
+     */
+    expect(driest).toBeGreaterThan(0.6)
+    expect(fish!.distress).toBe(0)
+  })
+})

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -6700,9 +6700,29 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
     }
   }
 
-  // Obstacle avoidance: walk and crawl locomotion steer around solid walls.
-  // Flyers and swimmers are free to move through/over terrain so skip this.
-  if (bp.move.kind === 'walk' || bp.move.kind === 'crawl') {
+  /**
+   * Obstacle avoidance: walk, crawl and swim steer around solid walls.
+   *
+   * Swimmers used to be grouped with flyers and skipped, on the grounds that
+   * both move freely — but a flyer goes *over* a wall and a fish cannot go
+   * through one. Water is a room, with a floor and walls and a ceiling, and a
+   * fish handed a straight bearing to something on the far side of a rock swam
+   * into the rock and stayed there. Nothing downstream rescued it: the turn the
+   * collision resolver makes on a bounce flips `drift`, and both `hunt` and
+   * `flee` steer by the target instead, so the bounce was invisible to the only
+   * part of the fish that had an opinion about where to go. That is the "back
+   * and forth" half of the surface-pinning report — pressing into a wall while
+   * bobbing at the waterline.
+   *
+   * Measured on tidepool over three seeds: swimmer time showing no horizontal
+   * progress across four seconds fell from 52% to 44%, and the share spent
+   * against a wall with somewhere to be from 5.8% to 4.0%. Total swimmer-life
+   * came back to where it was before any of this — the fish are not living
+   * longer yet, they are spending less of it stuck.
+   *
+   * Flyers still skip it, and should: air is not a room.
+   */
+  if (bp.move.kind === 'walk' || bp.move.kind === 'crawl' || bp.move.kind === 'swim') {
     const len = Math.hypot(wantX, wantY)
     if (len > 0.01 && solidAhead(w, c, body, wantX / len, wantY / len)) {
       const angle = Math.atan2(wantY, wantX)
@@ -6723,6 +6743,37 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
         wantX = 0
         wantY = 0
       }
+    }
+  }
+
+  /**
+   * The waterline is a ceiling, and a fish that has broken it dives.
+   *
+   * `clearRun` already says air is a wall to a fish, but only about food it
+   * cannot see; nothing said it about the direction the animal was actually
+   * swimming. Every steering mode above hands back a straight bearing to a
+   * point — flee runs the reciprocal of the bearing to the threat, hunt runs
+   * the bearing to the prey — and none of them know that half the plane is
+   * lethal. A Finling with a Gulper below it fled *upward*, which is the one
+   * direction that ends the chase by killing the fish rather than losing the
+   * predator: it left the water, started the drowning timer, and went on
+   * fleeing. Once buoyancy stopped holding fish at the waterline this was what
+   * still put them there, and the two together take the measured surface time
+   * on tidepool from 11.5% of a swimmer's life to 0.1%.
+   *
+   * Two clauses, and the order matters. Not fully submerged is an emergency, so
+   * the dive overrides whatever it wanted, harder the more of it is in the air.
+   * Submerged but aiming at air only loses the climb — the horizontal component
+   * survives, so a fish still flees sideways at full speed rather than stalling
+   * in front of the thing eating it.
+   */
+  let bodyWet = -1
+  if (bp.move.kind === 'swim' || bp.habitat.needs?.includes('water')) {
+    bodyWet = boxLiquidFraction(w, c.x + body.dx, c.y + body.dy, body.w, body.h)
+    if (bodyWet < 0.9) {
+      wantY = Math.max(wantY, 1 - bodyWet)
+    } else if (wantY < 0 && !waterAbove(w, c, body)) {
+      wantY = 0
     }
   }
 
@@ -6859,8 +6910,27 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
       break
     }
     case 'swim': {
-      const wet = boxLiquidFraction(w, c.x, c.y, bw, bh)
-      if (wet > 0.3) {
+      /**
+       * The core, not the sprite, and any water at all rather than a third of
+       * it — both for the same reason, which is that this branch is the only
+       * thing a swimmer can steer with and losing it strands the animal.
+       *
+       * Asking about the sprite (invariant 9: `artSize` is what it looks like,
+       * `bodyBox` is what it collides with) called a big swimmer beached over
+       * water its whole body was in, purely because its fins were dry. And the
+       * old `> 0.3` gate cut the thrust out at exactly the moment a fish
+       * breaking the surface needs it most: it went limp the instant it was
+       * more than two-thirds out, so the one stroke that would have pulled it
+       * back under was the stroke it could not take. Below this it really is on
+       * dry land, and flopping is all it has.
+       *
+       * Read off `bodyWet` rather than measured again so the dive decision
+       * above and the thrust that has to carry it out cannot disagree about how
+       * wet the animal is. Every `swim` blueprint takes that branch, so by here
+       * it is always a real fraction.
+       */
+      const wet = bodyWet
+      if (wet > 0.05) {
         // Current adds directly to the swimmer's acceleration. Swimming with
         // the current is free speed; fighting it costs effort.
         const cx = TUNING.currentX
@@ -6906,6 +6976,18 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
   if (bp.art.faceMotion && Math.abs(c.vx) > 0.2) {
     c.facing = c.vx > 0 ? 1 : -1
   }
+}
+
+/**
+ * Is there liquid in the two rows directly above this body?
+ *
+ * The vertical twin of `unliveableAhead`, and it exists for the same reason:
+ * something that lives in water needs to know that the direction it is about to
+ * commit to has water in it. Two rows rather than one so a fish swimming just
+ * under the surface still reads the air above as air.
+ */
+function waterAbove(w: WorldState, c: Creature, body: BodyBox): boolean {
+  return boxLiquidFraction(w, c.x + body.dx, c.y + body.dy - 2, body.w, 2) >= 0.5
 }
 
 function touchesSurface(w: WorldState, c: Creature, body: BodyBox): boolean {
@@ -6969,10 +7051,34 @@ function integrate(
 
   if (!weightless) {
     let g = TUNING.gravity * bp.body.mass * gravityScale
-    if (inLiquid) {
-      // Buoyancy above 1 pushes up harder than gravity pulls down.
-      g *= 1 - bp.body.buoyancy
-    }
+    /**
+     * Buoyancy lifts in proportion to how much of the body is actually under
+     * the liquid — a float only displaces what it has pushed under.
+     *
+     * This used to be all-or-nothing above a `wet > 0.3` threshold, and that
+     * built a trap at the waterline that swimmers could not get out of. A
+     * neutral fish (`buoyancy: 1`) at 40% submerged had its gravity switched
+     * fully off, so nothing pulled it back under; anything that put it up there
+     * in the first place — fleeing something below it, reaching for prey above,
+     * a lucky run of the wander jitter — left it hanging half out of the water
+     * for the rest of its life, wobbling across the 0.3 line and starving with
+     * food two tiles below it. Measured on tidepool over three seeds, swimmers
+     * spent 11.5% of their lives with the body breaking the surface and 0.8% of
+     * it below the 0.25 the habitat check kills at; individual Finlings held
+     * there for stretches of 100-330 s. Starvation is what actually collected
+     * them — the bobbing keeps resetting the drowning timer, so they hang above
+     * the food rather than suffocate above it.
+     *
+     * Scaling by `wet` removes the equilibrium instead of moving it. A body
+     * denser than water (`buoyancy < 1`) now has no depth at which it floats, so
+     * it sinks until it is under; a neutral one is weightless only when fully
+     * submerged, which is the one place a fish wants to be; and one lighter than
+     * water settles with `1 / buoyancy` of itself below the line and bobs there
+     * rather than launching clear of the surface and falling back. Fully
+     * submerged (`wet === 1`) is arithmetically identical to what this did
+     * before, so nothing that lives underwater changes.
+     */
+    g *= 1 - bp.body.buoyancy * wet
     if (kind === 'drift') g *= 0.35
     if (inGoo) g *= 1 - goo * 0.85
     c.vy += g * dt


### PR DESCRIPTION
Recovered from uncommitted work in the main worktree — no issue, it came from a field report: fish "get stuck moving back and forth and up" until they sit at the top of the pool, where they starve or drown.

Three independent things put them there, and each is enough on its own.

**Buoyancy was all-or-nothing.** Above `wet > 0.3` gravity switched fully off, so a neutral fish (`buoyancy: 1`) a third submerged had nothing pulling it back under. Anything that put it up there — fleeing something below, reaching for prey above, a lucky run of wander jitter — left it hanging half out of the water for the rest of its life, wobbling across the 0.3 line and starving with food two tiles down. Scaling lift by how much of the body is actually under the liquid removes the equilibrium rather than moving it. Fully submerged is arithmetically identical to the old behaviour, so nothing that lives underwater changes.

**Every steering mode aimed at points, and none knew half the plane was lethal.** `flee` is the reciprocal of the bearing to the threat, so a Finling with a Gulper below it fled straight up — out of the water, into the drowning timer, still fleeing. `clearRun` already knew air is a wall to a fish, but only about food it could not see, never about the direction the animal was actually swimming. Two clauses now, and the order matters: not fully submerged is an emergency and overrides the bearing; submerged but aiming at air only loses the climb, so a fish still flees sideways at full speed rather than stalling in front of the thing eating it.

**Swimmers skipped obstacle avoidance.** Grouped with flyers on the grounds that both move freely — but a flyer goes *over* a wall and a fish cannot go *through* one. Water is a room. A fish handed a straight bearing to something behind a rock swam into the rock and stayed there: the collision resolver flips `drift` on a bounce, and both `hunt` and `flee` steer by the target instead, so the bounce was invisible to the only part of the fish with an opinion about where to go. That is the "back and forth" half of the report. Flyers still skip it, and should — air is not a room.

Two smaller corrections fall out of the same reading. The swim thrust gate asked `boxLiquidFraction` about the sprite rather than the body box, which called a big swimmer beached over water its whole body was in because its fins were dry (invariant 9). And the gate cut thrust at `> 0.3` — exactly when a fish breaking the surface needs it most, so the one stroke that would have pulled it back under was the stroke it could not take.

## Measured

tidepool, three seeds:

| | before | after |
|---|---|---|
| swimmer life with the body breaking the surface | 11.5% | 0.1% |
| below the 0.25 the habitat check kills at | 0.8% | nil |
| no horizontal progress across four seconds | 52% | 44% |
| pressed against a wall with somewhere to be | 5.8% | 4.0% |

Total swimmer-life is back where it was before any of this. The fish are not living longer yet — they are spending less of it stuck.

## Verification

```
$ npx vitest run src/app/micro-land/domain/__tests__/swimmer-waterline.test.ts
 ✓ a fish two-thirds out of the water submerges instead of hanging there
 ✓ a fish with a predator below it stays in the water
 Test Files  1 passed (1)   Tests  2 passed (2)

$ npx tsc --noEmit 2>&1 | grep micro-land
(empty)
```

Full micro-land suite: **4 failed / 319 passed** with this change, **5 failed / 316 passed** on `main` — the change adds no failure. Those failures (`biotic-resistance`, `carnivorous-plant` ×2, `invasive-species`, `soil-engineer`) are load-sensitive timeouts and assertions that pass when run in isolation; `biotic-resistance` fails identically either way.

eslint on `creature-sim.ts` reports 2 problems at lines 71 and 1345 — both pre-existing and far from this change (hunks are at 6700+). `creature-sim.ts` was deliberately kept out of the prettier run; the new test file is formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)