### PR TITLE
feat(voice-journey): a singing course tracker that follows her between devices

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -46,6 +46,11 @@ service cloud.firestore {
       match /diceboundChapters/{docId} { allow read, write: if false; }
     }
 
+    // Singing course progress — one unlisted page, no account behind it.
+    // Written only through /api/v1/voice-journey, which validates every key
+    // against the curriculum. The client must never reach it directly.
+    match /voiceJourney/{docId} { allow read, write: if false; }
+
     // Nicknames uniqueness index — server only
     match /nicknames/{name} { allow read, write: if false; }
 

--- a/src/app/api/v1/voice-journey/route.ts
+++ b/src/app/api/v1/voice-journey/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Read and write the singing course progress.
+ *
+ * Deliberately unauthenticated: the page behind it is unlisted, has no account
+ * attached, and exists so one child's check marks follow her between devices.
+ * What keeps that safe is not a token but the narrowness of what can be stored
+ * — `saveProgress` accepts only known item ids and real dates, so the route
+ * cannot be used as free storage. See `progress-store.ts`.
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { isPlainObject, loadProgress, saveProgress } from '@/lib/voice-journey/progress-store'
+
+/** Never serve a build-time snapshot — the whole point is the latest state. */
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    return NextResponse.json(await loadProgress())
+  } catch (error) {
+    console.error('voice-journey progress read failed:', error)
+    return NextResponse.json({ error: 'Could not read your progress.' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Expected a JSON body.' }, { status: 400 })
+  }
+
+  // A body that is not an object is a bug or a poke at the endpoint, never a
+  // real "she unchecked everything" — sanitizing it would silently wipe the
+  // course, so it is refused instead.
+  if (!isPlainObject(body)) {
+    return NextResponse.json({ error: 'Expected a progress object.' }, { status: 400 })
+  }
+
+  try {
+    return NextResponse.json(await saveProgress(body))
+  } catch (error) {
+    console.error('voice-journey progress write failed:', error)
+    return NextResponse.json({ error: 'Could not save your progress.' }, { status: 500 })
+  }
+}
+
+/**
+ * The same write, for `navigator.sendBeacon`.
+ *
+ * A tab closing mid-flush is exactly when a check mark is most likely to be
+ * lost, and a beacon is the only request the browser promises to finish — but
+ * it can only ever be a POST.
+ */
+export const POST = PUT

--- a/src/app/route-constants.ts
+++ b/src/app/route-constants.ts
@@ -16,4 +16,6 @@ export const ROUTE_CONSTANTS = {
   DISNEYLAND_HUNT: '/disneyland-hunt',
   MICRO_LAND: '/micro-land',
   DICEBOUND: '/dicebound',
+  // Unlisted on purpose — not on the home grid, not in the nav.
+  VOICE_JOURNEY: '/voice-journey',
 }

--- a/src/app/voice-journey/layout.tsx
+++ b/src/app/voice-journey/layout.tsx
@@ -1,0 +1,34 @@
+import { Fredoka, Nunito } from 'next/font/google'
+
+import type { Metadata } from 'next'
+import type React from 'react'
+
+/**
+ * This page keeps the fonts it was designed with rather than the cave's.
+ * It is not a game on the arcade floor — it is one child's practice tracker,
+ * unlisted and unlinked, so the shared chrome would only be in the way.
+ */
+const fredoka = Fredoka({
+  subsets: ['latin'],
+  weight: ['500', '600', '700'],
+  variable: '--font-voice-display',
+  display: 'swap',
+})
+
+const nunito = Nunito({
+  subsets: ['latin'],
+  weight: ['600', '700', '800'],
+  variable: '--font-voice-body',
+  display: 'swap',
+})
+
+export const metadata: Metadata = {
+  title: 'My Voice Journey',
+  description: 'A singing practice tracker.',
+  // Unlisted, not secret — but there is no reason for it to turn up in search.
+  robots: { index: false, follow: false },
+}
+
+export default function VoiceJourneyLayout({ children }: { children: React.ReactNode }) {
+  return <div className={`${fredoka.variable} ${nunito.variable}`}>{children}</div>
+}

--- a/src/app/voice-journey/page.tsx
+++ b/src/app/voice-journey/page.tsx
@@ -1,0 +1,716 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import {
+  COURSE,
+  type CourseItem,
+  type CoursePhase,
+  type ItemType,
+} from '@/lib/voice-journey/curriculum'
+
+import { type SyncState, localDayKey, todayLocal, useProgress } from './use-progress'
+
+const TYPE_META: Record<ItemType, { label: string; color: string; bg: string }> = {
+  warmup: { label: 'Warm-up', color: 'var(--vj-amber)', bg: 'var(--vj-warmup-bg)' },
+  concept: { label: 'Learn', color: 'var(--vj-purple)', bg: 'var(--vj-learn-bg)' },
+  song: { label: 'Sing it', color: 'var(--vj-pink)', bg: 'var(--vj-song-bg)' },
+}
+
+const SOLFEGE = ['do', 're', 'mi', 'fa', 'sol', 'la', 'ti', 'do']
+/** Four weeks of dots on the Progress tab. */
+const GRID_DAYS = 28
+
+/** A rising scale that fills as she works — the page's one signature drawing. */
+function ScaleMeter({ fraction, width = 240 }: { fraction: number; width?: number }) {
+  const n = SOLFEGE.length
+  const filled = Math.round(fraction * n)
+  const h = 64
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${h}`}
+      width="100%"
+      style={{ maxWidth: width, display: 'block' }}
+      role="img"
+      aria-label={`Progress: ${Math.round(fraction * 100)} percent`}
+    >
+      {SOLFEGE.map((s, i) => {
+        const x = 14 + (i * (width - 28)) / (n - 1)
+        const y = h - 16 - (i * (h - 34)) / (n - 1)
+        const done = i < filled
+        return (
+          <g key={`${s}-${i}`}>
+            {i < n - 1 && (
+              <line
+                x1={x}
+                y1={y}
+                x2={14 + ((i + 1) * (width - 28)) / (n - 1)}
+                y2={h - 16 - ((i + 1) * (h - 34)) / (n - 1)}
+                stroke={i < filled - 1 ? 'var(--vj-purple)' : 'var(--vj-line)'}
+                strokeWidth="2.5"
+                strokeLinecap="round"
+              />
+            )}
+            <circle
+              cx={x}
+              cy={y}
+              r={done ? 7 : 5.5}
+              fill={done ? 'var(--vj-purple)' : 'var(--vj-card)'}
+              stroke={done ? 'var(--vj-purple)' : 'var(--vj-line-strong)'}
+              strokeWidth="2"
+            />
+            <text
+              x={x}
+              y={h - 2}
+              textAnchor="middle"
+              fontSize="9"
+              fontWeight="800"
+              fill={done ? 'var(--vj-ink)' : 'var(--vj-ghost)'}
+            >
+              {s}
+            </text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+/** Quiet unless something needs saying — a save in flight should not shout. */
+function SyncBadge({ state }: { state: SyncState }) {
+  if (state === 'saved') return null
+  const saving = state === 'saving'
+  return (
+    <div
+      role="status"
+      style={{
+        fontSize: 12,
+        fontWeight: 800,
+        color: saving ? 'var(--vj-saving-fg)' : 'var(--vj-offline-fg)',
+        background: saving ? 'var(--vj-saving-bg)' : 'var(--vj-offline-bg)',
+        borderRadius: 999,
+        padding: '4px 12px',
+        marginBottom: 12,
+        display: 'inline-block',
+      }}
+    >
+      {saving ? 'Saving…' : 'Saved on this device — will sync when you’re back online'}
+    </div>
+  )
+}
+
+const CARD: React.CSSProperties = {
+  background: 'var(--vj-card)',
+  borderRadius: 20,
+  padding: 20,
+  boxShadow: '0 2px 10px rgba(124,58,237,0.08)',
+}
+
+/**
+ * The page's own world: its palette, its reset, its scope.
+ *
+ * The colors live here as custom properties rather than inline hex, both
+ * because the repo's lint rule requires it and because this palette is
+ * deliberately *not* the cave's design system — it is the look she picked, kept
+ * behind one id so it cannot leak into anything else.
+ */
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      id="voice-journey"
+      style={{
+        minHeight: '100dvh',
+        background: 'var(--vj-bg)',
+        color: 'var(--vj-ink)',
+        fontFamily: 'var(--font-voice-body), sans-serif',
+      }}
+    >
+      <style>{`
+        #voice-journey {
+          --vj-bg: #FBF8FF;
+          --vj-card: #ffffff;
+          --vj-ink: #2A1E3F;
+          --vj-purple: #7C3AED;
+          --vj-purple-soft: #A855F7;
+          --vj-pink: #FF5E8A;
+          --vj-amber: #FFB020;
+          --vj-green: #1F9E7A;
+          --vj-muted: #5C4B7D;
+          --vj-faded: #8578A3;
+          --vj-disabled: #6B5C89;
+          --vj-ghost: #A79BC2;
+          --vj-lilac: #EFE8FA;
+          --vj-lilac-dim: #F0EAFB;
+          --vj-line: #E4DAF6;
+          --vj-line-strong: #CBBBEA;
+          --vj-underline: #E0D5F5;
+          --vj-warmup-bg: #FFF4DC;
+          --vj-learn-bg: #F0E8FF;
+          --vj-song-bg: #FFE7EE;
+          --vj-saving-bg: #F4EEFC;
+          --vj-saving-fg: #8A7BA8;
+          --vj-offline-bg: #FDE8E7;
+          --vj-offline-fg: #B4453F;
+        }
+        #voice-journey * { box-sizing: border-box; }
+        #voice-journey button { cursor: pointer; font-family: inherit; }
+        #voice-journey a { color: inherit; }
+        #voice-journey .tabbtn:focus-visible,
+        #voice-journey .itemrow:focus-visible,
+        #voice-journey .bigbtn:focus-visible,
+        #voice-journey a:focus-visible { outline: 3px solid var(--vj-purple); outline-offset: 2px; border-radius: 6px; }
+        @keyframes voice-pop { 0% { transform: scale(0.6); opacity: 0; } 60% { transform: scale(1.15); } 100% { transform: scale(1); opacity: 1; } }
+        #voice-journey .celebrate { animation: voice-pop 0.5s ease; }
+        @media (prefers-reduced-motion: reduce) { #voice-journey .celebrate { animation: none; } }
+      `}</style>
+      {children}
+    </div>
+  )
+}
+
+type Tab = 'today' | 'course' | 'progress'
+
+export default function VoiceJourneyPage() {
+  const { completed, log, ready, sync, toggleItem, logToday } = useProgress()
+  const [tab, setTab] = useState<Tab>('today')
+  const [openPhase, setOpenPhase] = useState<string | null>('p1')
+  const [celebrate, setCelebrate] = useState(false)
+
+  const allWeeks = useMemo(() => COURSE.flatMap(p => p.weeks.map(w => ({ ...w, phase: p }))), [])
+  const allItems = useMemo(() => allWeeks.flatMap(w => w.items), [allWeeks])
+
+  // The first week with anything left in it — falls back to the last week so a
+  // finished course still has something to show.
+  const currentWeek = useMemo(
+    () => allWeeks.find(w => w.items.some(i => !completed[i.id])) ?? allWeeks[allWeeks.length - 1],
+    [allWeeks, completed]
+  )
+  const nextItem = currentWeek.items.find(i => !completed[i.id])
+
+  const streak = useMemo(() => {
+    const days = new Set(log)
+    const cursor = new Date()
+    // A day with no practice yet does not break the streak until it is over.
+    if (!days.has(todayLocal())) cursor.setDate(cursor.getDate() - 1)
+    let count = 0
+    while (days.has(localDayKey(cursor))) {
+      count++
+      cursor.setDate(cursor.getDate() - 1)
+    }
+    return count
+  }, [log])
+
+  const practicedToday = log.includes(todayLocal())
+  const totalDone = allItems.filter(i => completed[i.id]).length
+  const totalItems = allItems.length
+
+  const phaseFraction = (phase: CoursePhase) => {
+    const items = phase.weeks.flatMap(w => w.items)
+    return items.filter(i => completed[i.id]).length / items.length
+  }
+
+  const onLogPractice = () => {
+    if (!logToday()) return
+    setCelebrate(true)
+    setTimeout(() => setCelebrate(false), 1600)
+  }
+
+  if (!ready) {
+    return (
+      <Shell>
+        <div style={{ padding: 40, color: 'var(--vj-purple)', fontWeight: 800 }}>Warming up…</div>
+      </Shell>
+    )
+  }
+
+  return (
+    <Shell>
+      <header
+        style={{
+          background:
+            'linear-gradient(120deg, var(--vj-purple) 0%, var(--vj-purple-soft) 55%, var(--vj-pink) 130%)',
+          color: 'var(--vj-card)',
+          padding: '28px 20px 22px',
+          borderRadius: '0 0 28px 28px',
+        }}
+      >
+        <div
+          style={{
+            maxWidth: 680,
+            margin: '0 auto',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-end',
+            gap: 12,
+            flexWrap: 'wrap',
+          }}
+        >
+          <div>
+            <h1
+              style={{
+                fontFamily: 'var(--font-voice-display), sans-serif',
+                fontWeight: 700,
+                fontSize: 28,
+                lineHeight: 1.1,
+                margin: 0,
+              }}
+            >
+              My Voice Journey
+            </h1>
+            <div style={{ opacity: 0.9, fontWeight: 700, fontSize: 13, marginTop: 4 }}>
+              {currentWeek.phase.name} · {currentWeek.label} · {totalDone}/{totalItems} steps done
+            </div>
+          </div>
+          <div
+            style={{
+              background: 'rgba(255,255,255,0.18)',
+              borderRadius: 16,
+              padding: '8px 14px',
+              textAlign: 'center',
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--font-voice-display), sans-serif',
+                fontSize: 24,
+                fontWeight: 700,
+              }}
+            >
+              🔥 {streak}
+            </div>
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 800,
+                letterSpacing: 0.5,
+                textTransform: 'uppercase',
+              }}
+            >
+              day streak
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main style={{ maxWidth: 680, margin: '0 auto', padding: '18px 16px 60px' }}>
+        <SyncBadge state={sync} />
+
+        <nav style={{ display: 'flex', gap: 8, marginBottom: 18 }} aria-label="Sections">
+          {(
+            [
+              ['today', 'Today'],
+              ['course', 'Course map'],
+              ['progress', 'Progress'],
+            ] as const
+          ).map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              className="tabbtn"
+              onClick={() => setTab(key)}
+              aria-current={tab === key ? 'page' : undefined}
+              style={{
+                flex: 1,
+                padding: '10px 0',
+                borderRadius: 14,
+                border: 'none',
+                fontWeight: 800,
+                fontSize: 14,
+                background: tab === key ? 'var(--vj-ink)' : 'var(--vj-lilac)',
+                color: tab === key ? 'var(--vj-card)' : 'var(--vj-muted)',
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </nav>
+
+        {tab === 'today' && (
+          <section>
+            <div style={{ ...CARD, marginBottom: 14 }}>
+              <div
+                style={{
+                  fontSize: 12,
+                  fontWeight: 800,
+                  letterSpacing: 1,
+                  textTransform: 'uppercase',
+                  color: 'var(--vj-purple)',
+                }}
+              >
+                Up next · {currentWeek.phase.name}, {currentWeek.label}
+              </div>
+              {nextItem ? (
+                <>
+                  <div
+                    style={{
+                      fontFamily: 'var(--font-voice-display), sans-serif',
+                      fontSize: 22,
+                      fontWeight: 600,
+                      margin: '8px 0 4px',
+                    }}
+                  >
+                    {nextItem.title}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 700,
+                      color: 'var(--vj-muted)',
+                      marginBottom: 14,
+                    }}
+                  >
+                    <span
+                      style={{
+                        background: TYPE_META[nextItem.type].bg,
+                        color: TYPE_META[nextItem.type].color,
+                        padding: '3px 10px',
+                        borderRadius: 999,
+                        fontWeight: 800,
+                        marginRight: 8,
+                      }}
+                    >
+                      {TYPE_META[nextItem.type].label}
+                    </span>
+                    about {nextItem.min} min
+                  </div>
+                  <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+                    <a
+                      href={nextItem.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      style={{
+                        background: 'var(--vj-pink)',
+                        color: 'var(--vj-card)',
+                        textDecoration: 'none',
+                        fontWeight: 800,
+                        padding: '12px 18px',
+                        borderRadius: 14,
+                      }}
+                    >
+                      ▶ Watch on YouTube
+                    </a>
+                    <button
+                      type="button"
+                      className="bigbtn"
+                      onClick={() => toggleItem(nextItem.id)}
+                      style={{
+                        background: 'var(--vj-green)',
+                        color: 'var(--vj-card)',
+                        border: 'none',
+                        fontWeight: 800,
+                        padding: '12px 18px',
+                        borderRadius: 14,
+                        fontSize: 14,
+                      }}
+                    >
+                      ✓ Done!
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <div
+                  style={{
+                    fontFamily: 'var(--font-voice-display), sans-serif',
+                    fontSize: 20,
+                    marginTop: 8,
+                  }}
+                >
+                  Course complete — encore! 🎤
+                </div>
+              )}
+            </div>
+
+            <div style={CARD}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  gap: 10,
+                  flexWrap: 'wrap',
+                }}
+              >
+                <div>
+                  <div
+                    style={{
+                      fontFamily: 'var(--font-voice-display), sans-serif',
+                      fontSize: 18,
+                      fontWeight: 600,
+                    }}
+                  >
+                    Did you practice today?
+                  </div>
+                  <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--vj-muted)' }}>
+                    Even 10 minutes counts.
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="bigbtn"
+                  onClick={onLogPractice}
+                  disabled={practicedToday}
+                  style={{
+                    background: practicedToday ? 'var(--vj-lilac)' : 'var(--vj-amber)',
+                    color: practicedToday ? 'var(--vj-disabled)' : 'var(--vj-ink)',
+                    border: 'none',
+                    fontWeight: 800,
+                    padding: '12px 18px',
+                    borderRadius: 14,
+                    fontSize: 14,
+                    cursor: practicedToday ? 'default' : 'pointer',
+                  }}
+                >
+                  {practicedToday ? 'Logged ✓' : 'I practiced! 🎵'}
+                </button>
+              </div>
+              {celebrate && (
+                <div
+                  className="celebrate"
+                  style={{
+                    marginTop: 12,
+                    fontFamily: 'var(--font-voice-display), sans-serif',
+                    fontSize: 18,
+                    color: 'var(--vj-purple)',
+                  }}
+                >
+                  🔥 Streak: {streak} day{streak === 1 ? '' : 's'} — keep singing!
+                </div>
+              )}
+            </div>
+          </section>
+        )}
+
+        {tab === 'course' && (
+          <section>
+            {COURSE.map((phase, pi) => {
+              const open = openPhase === phase.id
+              return (
+                <div
+                  key={phase.id}
+                  style={{ ...CARD, padding: 0, marginBottom: 14, overflow: 'hidden' }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setOpenPhase(open ? null : phase.id)}
+                    aria-expanded={open}
+                    className="tabbtn"
+                    style={{
+                      width: '100%',
+                      textAlign: 'left',
+                      background: 'none',
+                      border: 'none',
+                      padding: 18,
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <div>
+                        <div
+                          style={{
+                            fontSize: 11,
+                            fontWeight: 800,
+                            letterSpacing: 1,
+                            textTransform: 'uppercase',
+                            color: 'var(--vj-purple)',
+                          }}
+                        >
+                          Phase {pi + 1}
+                        </div>
+                        <div
+                          style={{
+                            fontFamily: 'var(--font-voice-display), sans-serif',
+                            fontSize: 20,
+                            fontWeight: 600,
+                          }}
+                        >
+                          {phase.name}
+                        </div>
+                        <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--vj-muted)' }}>
+                          {phase.tagline}
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        style={{
+                          fontFamily: 'var(--font-voice-display), sans-serif',
+                          fontSize: 18,
+                          color: 'var(--vj-purple)',
+                        }}
+                      >
+                        {open ? '–' : '+'}
+                      </div>
+                    </div>
+                    <div style={{ marginTop: 8 }}>
+                      <ScaleMeter fraction={phaseFraction(phase)} />
+                    </div>
+                  </button>
+
+                  {open &&
+                    phase.weeks.map(week => (
+                      <div
+                        key={week.id}
+                        style={{
+                          borderTop: '1.5px solid var(--vj-lilac-dim)',
+                          padding: '12px 18px',
+                        }}
+                      >
+                        <div
+                          style={{
+                            fontWeight: 800,
+                            fontSize: 13,
+                            color: 'var(--vj-muted)',
+                            marginBottom: 8,
+                          }}
+                        >
+                          {week.label}
+                        </div>
+                        {week.items.map((item: CourseItem) => {
+                          const done = !!completed[item.id]
+                          const meta = TYPE_META[item.type]
+                          return (
+                            <div
+                              key={item.id}
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 10,
+                                padding: '7px 0',
+                              }}
+                            >
+                              <button
+                                type="button"
+                                className="itemrow"
+                                onClick={() => toggleItem(item.id)}
+                                aria-pressed={done}
+                                aria-label={`${item.title} — ${done ? 'done' : 'not done yet'}`}
+                                style={{
+                                  width: 26,
+                                  height: 26,
+                                  borderRadius: 9,
+                                  flexShrink: 0,
+                                  border: `2.5px solid ${done ? 'var(--vj-green)' : 'var(--vj-line-strong)'}`,
+                                  background: done ? 'var(--vj-green)' : 'var(--vj-card)',
+                                  color: 'var(--vj-card)',
+                                  fontWeight: 900,
+                                  fontSize: 14,
+                                  lineHeight: 1,
+                                }}
+                              >
+                                {done ? '✓' : ''}
+                              </button>
+                              <span
+                                style={{
+                                  background: meta.bg,
+                                  color: meta.color,
+                                  padding: '2px 8px',
+                                  borderRadius: 999,
+                                  fontSize: 11,
+                                  fontWeight: 800,
+                                  flexShrink: 0,
+                                }}
+                              >
+                                {meta.label}
+                              </span>
+                              <a
+                                href={item.url}
+                                target="_blank"
+                                rel="noreferrer"
+                                style={{
+                                  fontSize: 14,
+                                  fontWeight: 700,
+                                  // Longhand, not the `textDecoration` shorthand: React warns
+                                  // when a shorthand and a longhand for the same property both
+                                  // change on a rerender, and this row does exactly that.
+                                  textDecorationLine: done ? 'line-through' : 'underline',
+                                  textDecorationColor: 'var(--vj-underline)',
+                                  color: done ? 'var(--vj-faded)' : 'var(--vj-ink)',
+                                }}
+                              >
+                                {item.title}
+                              </a>
+                            </div>
+                          )
+                        })}
+                      </div>
+                    ))}
+                </div>
+              )
+            })}
+          </section>
+        )}
+
+        {tab === 'progress' && (
+          <section>
+            <div style={{ ...CARD, marginBottom: 14 }}>
+              <h2
+                style={{
+                  fontFamily: 'var(--font-voice-display), sans-serif',
+                  fontSize: 20,
+                  fontWeight: 600,
+                  marginBottom: 6,
+                  marginTop: 0,
+                }}
+              >
+                The whole journey
+              </h2>
+              <ScaleMeter fraction={totalDone / totalItems} width={360} />
+              <div
+                style={{ fontWeight: 800, fontSize: 13, color: 'var(--vj-muted)', marginTop: 6 }}
+              >
+                {totalDone} of {totalItems} steps · {Math.round((totalDone / totalItems) * 100)}%
+              </div>
+            </div>
+
+            <div style={CARD}>
+              <h2
+                style={{
+                  fontFamily: 'var(--font-voice-display), sans-serif',
+                  fontSize: 20,
+                  fontWeight: 600,
+                  marginBottom: 10,
+                  marginTop: 0,
+                }}
+              >
+                Practice days
+              </h2>
+              <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
+                {Array.from({ length: GRID_DAYS }).map((_, i) => {
+                  const d = new Date()
+                  d.setDate(d.getDate() - (GRID_DAYS - 1 - i))
+                  const key = localDayKey(d)
+                  const hit = log.includes(key)
+                  return (
+                    <div
+                      key={key}
+                      title={`${key} — ${hit ? 'practiced' : 'no practice'}`}
+                      role="img"
+                      aria-label={`${key}, ${hit ? 'practiced' : 'no practice'}`}
+                      style={{
+                        width: 18,
+                        height: 18,
+                        borderRadius: 6,
+                        background: hit ? 'var(--vj-amber)' : 'var(--vj-lilac-dim)',
+                        border: hit ? 'none' : '1.5px solid var(--vj-line)',
+                      }}
+                    />
+                  )
+                })}
+              </div>
+              <div
+                style={{ fontWeight: 800, fontSize: 13, color: 'var(--vj-muted)', marginTop: 10 }}
+              >
+                Last 4 weeks · {log.length} total practice day{log.length === 1 ? '' : 's'} ·
+                current streak 🔥 {streak}
+              </div>
+            </div>
+          </section>
+        )}
+      </main>
+    </Shell>
+  )
+}

--- a/src/app/voice-journey/use-progress.ts
+++ b/src/app/voice-journey/use-progress.ts
@@ -1,0 +1,225 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { VoiceJourneyProgress } from '@/lib/voice-journey/progress-store'
+
+const ENDPOINT = '/api/v1/voice-journey'
+const CACHE_KEY = 'voice-journey-progress-v1'
+/** Long enough to swallow a burst of taps, short enough to feel instant. */
+const FLUSH_DELAY_MS = 600
+
+export type SyncState = 'saving' | 'saved' | 'offline'
+
+/**
+ * A calendar day in the device's own timezone.
+ *
+ * `toISOString().slice(0, 10)` would be tempting and wrong: it is UTC, so an
+ * evening practice session in the Americas gets filed under tomorrow, and the
+ * streak counter then finds a hole where a practice day should be.
+ */
+export function localDayKey(date: Date): string {
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${date.getFullYear()}-${month}-${day}`
+}
+
+/** Today as the device sees it. */
+export function todayLocal(): string {
+  return localDayKey(new Date())
+}
+
+interface CachedProgress extends VoiceJourneyProgress {
+  /** True when this device holds changes the server has not accepted yet. */
+  dirty: boolean
+}
+
+function readCache(): CachedProgress | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<CachedProgress>
+    if (typeof parsed !== 'object' || parsed === null) return null
+    return {
+      completed: parsed.completed ?? {},
+      log: Array.isArray(parsed.log) ? parsed.log : [],
+      updatedAt: typeof parsed.updatedAt === 'number' ? parsed.updatedAt : 0,
+      dirty: parsed.dirty === true,
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeCache(next: CachedProgress): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(next))
+  } catch {
+    // Private browsing, or a full quota. The server is still the real store.
+  }
+}
+
+/**
+ * Her progress, shared across every device she opens the page on.
+ *
+ * The local cache is a paint accelerator and an offline buffer, never the
+ * truth: a returning visit shows the last known state immediately, then the
+ * server's copy replaces it a moment later. Writes go the other way — state
+ * changes at once, the network catches up, and a failed write leaves the page
+ * usable with `sync` reading 'offline' until it lands.
+ *
+ * Conflicts resolve last-write-wins, which is right for a single singer and
+ * would not be for two. Coming back to a tab re-reads the server first, so the
+ * common two-device case — tablet in the morning, phone at night — does not
+ * clobber itself.
+ */
+export function useProgress() {
+  const [completed, setCompleted] = useState<Record<string, boolean>>({})
+  const [log, setLog] = useState<string[]>([])
+  const [ready, setReady] = useState(false)
+  const [sync, setSync] = useState<SyncState>('saved')
+
+  /** The state a flush should send — refs so timers never send a stale closure. */
+  const pending = useRef<{ completed: Record<string, boolean>; log: string[] }>({
+    completed: {},
+    log: [],
+  })
+  const dirty = useRef(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const started = useRef(false)
+
+  const adopt = useCallback((next: VoiceJourneyProgress, isDirty: boolean) => {
+    setCompleted(next.completed)
+    setLog(next.log)
+    pending.current = { completed: next.completed, log: next.log }
+    dirty.current = isDirty
+    writeCache({ ...next, dirty: isDirty })
+  }, [])
+
+  const flush = useCallback(async () => {
+    if (!dirty.current) return
+    setSync('saving')
+    try {
+      const res = await fetch(ENDPOINT, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(pending.current),
+      })
+      if (!res.ok) throw new Error(`save failed: ${res.status}`)
+      const saved = (await res.json()) as VoiceJourneyProgress
+      // Only the timestamp is adopted. Re-adopting the body would undo any tap
+      // that happened while this request was in flight.
+      dirty.current = false
+      writeCache({ ...pending.current, updatedAt: saved.updatedAt, dirty: false })
+      setSync('saved')
+    } catch {
+      setSync('offline')
+    }
+  }, [])
+
+  const schedule = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => {
+      timer.current = null
+      void flush()
+    }, FLUSH_DELAY_MS)
+  }, [flush])
+
+  const commit = useCallback(
+    (nextCompleted: Record<string, boolean>, nextLog: string[]) => {
+      setCompleted(nextCompleted)
+      setLog(nextLog)
+      pending.current = { completed: nextCompleted, log: nextLog }
+      dirty.current = true
+      writeCache({ ...pending.current, updatedAt: Date.now(), dirty: true })
+      schedule()
+    },
+    [schedule]
+  )
+
+  const pull = useCallback(async () => {
+    // A device holding unsent taps pushes them rather than being overwritten.
+    if (dirty.current) {
+      await flush()
+      return
+    }
+    try {
+      const res = await fetch(ENDPOINT, { cache: 'no-store' })
+      if (!res.ok) throw new Error(`load failed: ${res.status}`)
+      adopt((await res.json()) as VoiceJourneyProgress, false)
+      setSync('saved')
+    } catch {
+      setSync('offline')
+    }
+  }, [adopt, flush])
+
+  useEffect(() => {
+    if (started.current) return
+    started.current = true
+
+    const cached = readCache()
+    if (cached) {
+      adopt(
+        { completed: cached.completed, log: cached.log, updatedAt: cached.updatedAt },
+        cached.dirty
+      )
+      setReady(true)
+    }
+
+    void pull().finally(() => setReady(true))
+  }, [adopt, pull])
+
+  // Coming back to the tab is the moment the other device's work should appear.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') void pull()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    window.addEventListener('online', onVisible)
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible)
+      window.removeEventListener('online', onVisible)
+    }
+  }, [pull])
+
+  // A pending tap must not die with the tab.
+  useEffect(() => {
+    const onHide = () => {
+      if (!dirty.current) return
+      navigator.sendBeacon?.(
+        ENDPOINT,
+        new Blob([JSON.stringify(pending.current)], { type: 'application/json' })
+      )
+    }
+    window.addEventListener('pagehide', onHide)
+    return () => window.removeEventListener('pagehide', onHide)
+  }, [])
+
+  const toggleItem = useCallback(
+    (id: string) => {
+      const nextCompleted = { ...pending.current.completed }
+      let nextLog = pending.current.log
+
+      if (nextCompleted[id]) {
+        delete nextCompleted[id]
+      } else {
+        nextCompleted[id] = true
+        const today = todayLocal()
+        if (!nextLog.includes(today)) nextLog = [...nextLog, today].sort()
+      }
+
+      commit(nextCompleted, nextLog)
+    },
+    [commit]
+  )
+
+  /** Returns false when today was already logged, so the caller can skip the fanfare. */
+  const logToday = useCallback((): boolean => {
+    const today = todayLocal()
+    if (pending.current.log.includes(today)) return false
+    commit(pending.current.completed, [...pending.current.log, today].sort())
+    return true
+  }, [commit])
+
+  return { completed, log, ready, sync, toggleItem, logToday }
+}

--- a/src/components/layout-shell.tsx
+++ b/src/components/layout-shell.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
+
 import { ROUTE_CONSTANTS } from '@/app/route-constants'
+
 import type { ReactNode } from 'react'
 
 const IMMERSIVE_ROUTES = [
@@ -9,6 +11,7 @@ const IMMERSIVE_ROUTES = [
   ROUTE_CONSTANTS.MICRO_LAND,
   `${ROUTE_CONSTANTS.SPECK_WARS}/play`,
   `${ROUTE_CONSTANTS.SPECK_WARS}/skirmish`,
+  ROUTE_CONSTANTS.VOICE_JOURNEY,
 ]
 
 export function LayoutShell({
@@ -24,7 +27,11 @@ export function LayoutShell({
   const isImmersive = IMMERSIVE_ROUTES.some(r => pathname.startsWith(r))
 
   if (isImmersive) {
-    return <main id="main-content" className="flex-1 z-20 relative">{children}</main>
+    return (
+      <main id="main-content" className="flex-1 z-20 relative">
+        {children}
+      </main>
+    )
   }
 
   return (
@@ -36,7 +43,9 @@ export function LayoutShell({
         Skip to main content
       </a>
       {nav}
-      <main id="main-content" className="flex-1 container mx-auto p-4 z-20 relative">{children}</main>
+      <main id="main-content" className="flex-1 container mx-auto p-4 z-20 relative">
+        {children}
+      </main>
       {footer}
     </>
   )

--- a/src/lib/voice-journey/__tests__/progress-store.test.ts
+++ b/src/lib/voice-journey/__tests__/progress-store.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The sanitizer is what stands in for authentication on this route: the write
+ * endpoint is open, so what keeps it safe is that almost nothing can be stored
+ * through it. These tests pin that down.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { ITEM_IDS } from '@/lib/voice-journey/curriculum'
+import { sanitizeProgress } from '@/lib/voice-journey/progress-store'
+
+const realItem = [...ITEM_IDS][0]
+
+function dayOffsetFromToday(days: number): string {
+  const d = new Date()
+  d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
+describe('sanitizeProgress', () => {
+  it('keeps ticks against real curriculum items', () => {
+    expect(sanitizeProgress({ completed: { [realItem]: true }, log: [] }).completed).toEqual({
+      [realItem]: true,
+    })
+  })
+
+  it('drops item ids the course does not define', () => {
+    const { completed } = sanitizeProgress({
+      completed: { [realItem]: true, notAnItem: true, '../../etc/passwd': true },
+      log: [],
+    })
+    expect(completed).toEqual({ [realItem]: true })
+  })
+
+  it('stores only ticks, never explicit falses', () => {
+    expect(sanitizeProgress({ completed: { [realItem]: false }, log: [] }).completed).toEqual({})
+  })
+
+  it('ignores a prototype-polluting key', () => {
+    const { completed } = sanitizeProgress({ completed: { __proto__: true }, log: [] })
+    expect(Object.keys(completed)).toEqual([])
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
+
+  it('rejects dates that are not real days', () => {
+    const { log } = sanitizeProgress({
+      completed: {},
+      log: ['2026-02-31', '2026-2-1', 'today', ''],
+    })
+    expect(log).toEqual([])
+  })
+
+  it('rejects days before the course existed and beyond tomorrow', () => {
+    const { log } = sanitizeProgress({
+      completed: {},
+      log: ['1999-01-01', '2099-12-31', dayOffsetFromToday(10)],
+    })
+    expect(log).toEqual([])
+  })
+
+  it('accepts a day just ahead, for a device whose clock runs fast', () => {
+    const tomorrow = dayOffsetFromToday(1)
+    expect(sanitizeProgress({ completed: {}, log: [tomorrow] }).log).toEqual([tomorrow])
+  })
+
+  it('dedupes and sorts practice days', () => {
+    const { log } = sanitizeProgress({
+      completed: {},
+      log: ['2026-03-02', '2026-03-01', '2026-03-02'],
+    })
+    expect(log).toEqual(['2026-03-01', '2026-03-02'])
+  })
+
+  it('caps the log, keeping the most recent days', () => {
+    const days: string[] = []
+    const d = new Date('2024-01-01T00:00:00Z')
+    for (let i = 0; i < 900; i++) {
+      days.push(d.toISOString().slice(0, 10))
+      d.setUTCDate(d.getUTCDate() + 1)
+    }
+    // Every day here is in the past, so only the cap trims them.
+    const { log } = sanitizeProgress({ completed: {}, log: days })
+    expect(log.length).toBeLessThanOrEqual(730)
+    expect(log[log.length - 1]).toBe(days[days.length - 1])
+  })
+
+  it('drops unknown top-level fields rather than storing them', () => {
+    const result = sanitizeProgress({ completed: {}, log: [], note: 'x'.repeat(10_000) })
+    expect(Object.keys(result).sort()).toEqual(['completed', 'log'])
+  })
+
+  it('survives junk in place of the whole payload', () => {
+    for (const junk of [null, undefined, 'hello', 42, [1, 2, 3]]) {
+      expect(sanitizeProgress(junk)).toEqual({ completed: {}, log: [] })
+    }
+  })
+
+  it('survives junk in place of each field', () => {
+    expect(sanitizeProgress({ completed: 'nope', log: 'nope' })).toEqual({ completed: {}, log: [] })
+  })
+})

--- a/src/lib/voice-journey/curriculum.ts
+++ b/src/lib/voice-journey/curriculum.ts
@@ -1,0 +1,501 @@
+/**
+ * The sixteen-week singing course, and the shape of one child's progress
+ * through it.
+ *
+ * The course is content, not configuration: edit it freely. Progress is stored
+ * against item ids, so renaming a title or swapping a video keeps the check
+ * marks — but changing an `id` orphans whatever was ticked against the old one,
+ * and the server will drop it on the next write (see `sanitizeProgress`).
+ * Add weeks by appending; ids only ever need to be unique.
+ */
+
+export type ItemType = 'warmup' | 'concept' | 'song'
+
+export interface CourseItem {
+  id: string
+  type: ItemType
+  /** What she actually does. Shown as the step title. */
+  title: string
+  /** A YouTube search, not a fixed video — results stay fresh as channels change. */
+  url: string
+  /** Rough minutes, so a day can be sized before it starts. */
+  min: number
+}
+
+export interface CourseWeek {
+  id: string
+  label: string
+  items: CourseItem[]
+}
+
+export interface CoursePhase {
+  id: string
+  name: string
+  tagline: string
+  weeks: CourseWeek[]
+}
+
+const yt = (q: string) => `https://www.youtube.com/results?search_query=${encodeURIComponent(q)}`
+
+export const COURSE: CoursePhase[] = [
+  {
+    id: 'p1',
+    name: 'Foundations',
+    tagline: 'Breath, posture, pitch — and making practice a habit',
+    weeks: [
+      {
+        id: 'w1',
+        label: 'Week 1',
+        items: [
+          {
+            id: 'w1a',
+            type: 'warmup',
+            title: 'Cheryl Porter — beginner warm-up',
+            url: yt('Cheryl Porter vocal warm up beginner'),
+            min: 10,
+          },
+          {
+            id: 'w1b',
+            type: 'concept',
+            title: 'Posture & breathing basics (VLTW Ep. 1)',
+            url: yt('Voice Lessons To The World Ep 1'),
+            min: 12,
+          },
+          {
+            id: 'w1c',
+            type: 'song',
+            title: 'Sing an easy favorite song, focus on posture',
+            url: yt('easy songs to sing for beginners'),
+            min: 10,
+          },
+        ],
+      },
+      {
+        id: 'w2',
+        label: 'Week 2',
+        items: [
+          {
+            id: 'w2a',
+            type: 'warmup',
+            title: 'Cheryl Porter — lip trills & sirens',
+            url: yt('Cheryl Porter lip trill warm up'),
+            min: 10,
+          },
+          {
+            id: 'w2b',
+            type: 'concept',
+            title: 'Breathing from the diaphragm (Dr. Dan)',
+            url: yt('Dr Dan Voice Essentials diaphragm breathing'),
+            min: 12,
+          },
+          {
+            id: 'w2c',
+            type: 'song',
+            title: 'Same song — breathe low before each phrase',
+            url: yt('how to breathe while singing a song'),
+            min: 10,
+          },
+        ],
+      },
+      {
+        id: 'w3',
+        label: 'Week 3',
+        items: [
+          {
+            id: 'w3a',
+            type: 'warmup',
+            title: 'Jacobs Vocal Academy — daily warm-up',
+            url: yt('Jacobs Vocal Academy 10 minute warm up'),
+            min: 10,
+          },
+          {
+            id: 'w3b',
+            type: 'concept',
+            title: 'Matching pitch & singing in tune',
+            url: yt('how to match pitch singing beginner'),
+            min: 12,
+          },
+          {
+            id: 'w3c',
+            type: 'song',
+            title: 'Record yourself once — listen back for pitch',
+            url: yt('how to practice singing with recording'),
+            min: 10,
+          },
+        ],
+      },
+      {
+        id: 'w4',
+        label: 'Week 4',
+        items: [
+          {
+            id: 'w4a',
+            type: 'warmup',
+            title: 'Cheryl Porter — five-tone scales',
+            url: yt('Cheryl Porter five tone scale exercise'),
+            min: 10,
+          },
+          {
+            id: 'w4b',
+            type: 'concept',
+            title: 'Vocal Nebula — breathing for singing pt. 1–2',
+            url: yt('Vocal Nebula breathing for singing beginners'),
+            min: 15,
+          },
+          {
+            id: 'w4c',
+            type: 'song',
+            title: 'New song of her choice, apply breath support',
+            url: yt('breath support singing practice'),
+            min: 10,
+          },
+        ],
+      },
+      {
+        id: 'w5',
+        label: 'Week 5',
+        items: [
+          {
+            id: 'w5a',
+            type: 'warmup',
+            title: 'Rotate her favorite warm-up so far',
+            url: yt('vocal warm up for kids and teens'),
+            min: 10,
+          },
+          {
+            id: 'w5b',
+            type: 'concept',
+            title: 'Good tone without pushing (VLTW)',
+            url: yt('Voice Lessons To The World tone quality'),
+            min: 12,
+          },
+          {
+            id: 'w5c',
+            type: 'song',
+            title: 'Sing soft vs. loud on purpose — dynamics play',
+            url: yt('singing dynamics exercise beginner'),
+            min: 10,
+          },
+        ],
+      },
+      {
+        id: 'w6',
+        label: 'Week 6',
+        items: [
+          {
+            id: 'w6a',
+            type: 'warmup',
+            title: 'Warm-up + gentle cool-down (Dr. Dan)',
+            url: yt('Dr Dan vocal cool down'),
+            min: 12,
+          },
+          {
+            id: 'w6b',
+            type: 'concept',
+            title: 'Phase recap — what does good practice feel like?',
+            url: yt('how to practice singing effectively beginner'),
+            min: 10,
+          },
+          {
+            id: 'w6c',
+            type: 'song',
+            title: "Mini 'concert': perform 1–2 songs for family",
+            url: yt('performing for family practice confidence'),
+            min: 15,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'p2',
+    name: 'Technique',
+    tagline: 'One concept a week: registers, the break, vowels, range',
+    weeks: [
+      {
+        id: 'w7',
+        label: 'Week 7',
+        items: [
+          {
+            id: 'w7a',
+            type: 'warmup',
+            title: 'Daily warm-up rotation',
+            url: yt('Jacobs Vocal Academy warm up head voice'),
+            min: 10,
+          },
+          {
+            id: 'w7b',
+            type: 'concept',
+            title: 'Chest voice vs. head voice (VLTW)',
+            url: yt('Voice Lessons To The World chest voice head voice'),
+            min: 12,
+          },
+          {
+            id: 'w7c',
+            type: 'song',
+            title: 'Find both voices in a song she knows',
+            url: yt('chest voice head voice song examples'),
+            min: 10,
+          },
+        ],
+      },
+      {
+        id: 'w8',
+        label: 'Week 8',
+        items: [
+          {
+            id: 'w8a',
+            type: 'warmup',
+            title: 'Sirens & slides warm-up',
+            url: yt('vocal siren exercise warm up'),
+            min: 10,
+          },
+          {
+            id: 'w8b',
+            type: 'concept',
+            title: 'Releasing the vocal break (Madeleine Harvey)',
+            url: yt('Madeleine Harvey vocal break'),
+            min: 12,
+          },
+          {
+            id: 'w8c',
+            type: 'song',
+            title: 'Gentle passes over the break in a song',
+            url: yt('smooth vocal break singing exercise'),
+            min: 10,
+          },
+        ],
+      },
+      {
+        id: 'w9',
+        label: 'Week 9',
+        items: [
+          {
+            id: 'w9a',
+            type: 'warmup',
+            title: 'Vowel-focused warm-up',
+            url: yt('vowel modification warm up singing'),
+            min: 10,
+          },
+          {
+            id: 'w9b',
+            type: 'concept',
+            title: 'Vowels & clear words while singing (VLTW)',
+            url: yt('Voice Lessons To The World vowels diction'),
+            min: 12,
+          },
+          {
+            id: 'w9c',
+            type: 'song',
+            title: 'Exaggerate vowels in a chorus, then relax them',
+            url: yt('singing diction exercise'),
+            min: 10,
+          },
+        ],
+      },
+      {
+        id: 'w10',
+        label: 'Week 10',
+        items: [
+          {
+            id: 'w10a',
+            type: 'warmup',
+            title: 'Range-stretch warm-up (gentle!)',
+            url: yt('gentle range extension warm up singing'),
+            min: 10,
+          },
+          {
+            id: 'w10b',
+            type: 'concept',
+            title: 'Extending range safely (Dr. Dan)',
+            url: yt('Dr Dan Voice Essentials extend vocal range safely'),
+            min: 12,
+          },
+          {
+            id: 'w10c',
+            type: 'song',
+            title: "Move a song's key up/down to fit her voice",
+            url: yt('change song key to fit your voice'),
+            min: 10,
+          },
+        ],
+      },
+      {
+        id: 'w11',
+        label: 'Week 11',
+        items: [
+          {
+            id: 'w11a',
+            type: 'warmup',
+            title: 'Agility runs — simple riffs',
+            url: yt('Cheryl Porter riffs and runs beginner'),
+            min: 10,
+          },
+          {
+            id: 'w11b',
+            type: 'concept',
+            title: 'Intro to riffs & runs (start slow)',
+            url: yt('riffs and runs for beginners slow'),
+            min: 12,
+          },
+          {
+            id: 'w11c',
+            type: 'song',
+            title: 'Learn ONE tiny riff from a song she loves',
+            url: yt('easy riffs to learn singing'),
+            min: 10,
+          },
+        ],
+      },
+      {
+        id: 'w12',
+        label: 'Week 12',
+        items: [
+          {
+            id: 'w12a',
+            type: 'warmup',
+            title: 'Her pick — favorite warm-up',
+            url: yt('fun vocal warm up'),
+            min: 10,
+          },
+          {
+            id: 'w12b',
+            type: 'concept',
+            title: 'Vibrato basics — what it is, no forcing',
+            url: yt('what is vibrato singing beginner'),
+            min: 12,
+          },
+          {
+            id: 'w12c',
+            type: 'song',
+            title: 'Record & compare to Week 3 recording',
+            url: yt('track singing progress recording'),
+            min: 15,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'p3',
+    name: 'Songs & Style',
+    tagline: 'Technique in service of music she loves',
+    weeks: [
+      {
+        id: 'w13',
+        label: 'Week 13',
+        items: [
+          {
+            id: 'w13a',
+            type: 'warmup',
+            title: 'Warm-up rotation',
+            url: yt('daily vocal warm up 10 minutes'),
+            min: 10,
+          },
+          {
+            id: 'w13b',
+            type: 'concept',
+            title: 'Song breakdown — how pros learn a song',
+            url: yt('Tara Simon song breakdown tutorial'),
+            min: 12,
+          },
+          {
+            id: 'w13c',
+            type: 'song',
+            title: "Pick a 'project song' for the month",
+            url: yt('how to learn a song step by step singing'),
+            min: 15,
+          },
+        ],
+      },
+      {
+        id: 'w14',
+        label: 'Week 14',
+        items: [
+          {
+            id: 'w14a',
+            type: 'warmup',
+            title: 'Warm-up rotation',
+            url: yt('vocal warm up before singing songs'),
+            min: 10,
+          },
+          {
+            id: 'w14b',
+            type: 'concept',
+            title: 'Phrasing & emotion (Eric Arceneaux)',
+            url: yt('Eric Arceneaux phrasing emotion singing'),
+            min: 12,
+          },
+          {
+            id: 'w14c',
+            type: 'song',
+            title: 'Project song: verse + chorus polished',
+            url: yt('song phrasing practice'),
+            min: 15,
+          },
+        ],
+      },
+      {
+        id: 'w15',
+        label: 'Week 15',
+        items: [
+          {
+            id: 'w15a',
+            type: 'warmup',
+            title: 'Warm-up rotation',
+            url: yt('vocal warm up routine'),
+            min: 10,
+          },
+          {
+            id: 'w15b',
+            type: 'concept',
+            title: 'Stage presence & confidence basics',
+            url: yt('stage presence for young singers'),
+            min: 12,
+          },
+          {
+            id: 'w15c',
+            type: 'song',
+            title: 'Full run-throughs, standing, like a show',
+            url: yt('performance practice singing'),
+            min: 15,
+          },
+        ],
+      },
+      {
+        id: 'w16',
+        label: 'Week 16',
+        items: [
+          {
+            id: 'w16a',
+            type: 'warmup',
+            title: 'Warm-up + cool-down',
+            url: yt('vocal warm up and cool down'),
+            min: 12,
+          },
+          {
+            id: 'w16b',
+            type: 'concept',
+            title: "Reflect: favorite thing she's learned",
+            url: yt('singing progress reflection'),
+            min: 5,
+          },
+          {
+            id: 'w16c',
+            type: 'song',
+            title: 'Living-room concert! Record the performance',
+            url: yt('home concert performance'),
+            min: 20,
+          },
+        ],
+      },
+    ],
+  },
+]
+
+/** Every item id the course knows about — the allowlist the server validates against. */
+export const ITEM_IDS: ReadonlySet<string> = new Set(
+  COURSE.flatMap(p => p.weeks.flatMap(w => w.items.map(i => i.id)))
+)
+
+export const TOTAL_ITEMS = ITEM_IDS.size

--- a/src/lib/voice-journey/progress-store.ts
+++ b/src/lib/voice-journey/progress-store.ts
@@ -1,0 +1,113 @@
+/**
+ * One child's progress through the singing course, kept in Firestore so it
+ * follows her between the tablet and the phone.
+ *
+ * There is no account behind this. The page is unlisted and the document id is
+ * fixed, which means the write path is reachable by anyone who finds the API
+ * route — so the blast radius is bounded here rather than by a login. Nothing
+ * arbitrary can be stored: keys must be item ids the course actually defines,
+ * dates must be real dates in a plausible window, and both collections are
+ * capped. The worst a stranger can do is tick a checkbox she can untick.
+ *
+ * `completed` stores only the ticks. Unchecking deletes the key rather than
+ * writing `false`, which keeps the document small and makes "how many are done"
+ * a key count.
+ */
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+import { ITEM_IDS } from './curriculum'
+
+/** The single document. There is one singer; a second would get a second id. */
+const PROFILE_ID = 'default'
+const COLLECTION = 'voiceJourney'
+
+/** Two years of daily practice — far past the sixteen-week course. */
+const MAX_LOG_DAYS = 730
+/** Guards against a clock-skewed device logging a day that hasn't happened. */
+const FUTURE_GRACE_DAYS = 2
+/** The course started being usable in 2026; anything older is not a real entry. */
+const EARLIEST_LOG_DAY = '2026-01-01'
+
+export interface VoiceJourneyProgress {
+  /** Item id → true. Only ticked items are present. */
+  completed: Record<string, boolean>
+  /** Practice days as local `YYYY-MM-DD`, unique and ascending. */
+  log: string[]
+  /** Epoch millis of the last write, so a client can tell which state is newer. */
+  updatedAt: number
+}
+
+export const EMPTY_PROGRESS: VoiceJourneyProgress = { completed: {}, log: [], updatedAt: 0 }
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** `YYYY-MM-DD` that round-trips — rejects '2026-02-31' as well as '2026-2-1'. */
+function isRealDay(day: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return false
+  const parsed = new Date(`${day}T00:00:00Z`)
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === day
+}
+
+function latestAcceptableDay(): string {
+  const limit = new Date()
+  limit.setUTCDate(limit.getUTCDate() + FUTURE_GRACE_DAYS)
+  return limit.toISOString().slice(0, 10)
+}
+
+/**
+ * Everything that comes off the wire goes through here, on the way in and on
+ * the way out — a document written before a curriculum edit gets the same
+ * treatment as an untrusted request body, so retired item ids stop counting
+ * toward her total instead of lingering as an invisible tick.
+ */
+export function sanitizeProgress(input: unknown): Omit<VoiceJourneyProgress, 'updatedAt'> {
+  const raw = isPlainObject(input) ? input : {}
+
+  const completed: Record<string, boolean> = {}
+  if (isPlainObject(raw.completed)) {
+    for (const [id, done] of Object.entries(raw.completed)) {
+      if (done === true && ITEM_IDS.has(id)) completed[id] = true
+    }
+  }
+
+  const latest = latestAcceptableDay()
+  const days = Array.isArray(raw.log) ? raw.log : []
+  const log = Array.from(
+    new Set(
+      days.filter(
+        (day): day is string =>
+          typeof day === 'string' && isRealDay(day) && day >= EARLIEST_LOG_DAY && day <= latest
+      )
+    )
+  )
+    .sort()
+    .slice(-MAX_LOG_DAYS)
+
+  return { completed, log }
+}
+
+function docRef() {
+  return getFirestoreDb().collection(COLLECTION).doc(PROFILE_ID)
+}
+
+/** Her progress, or an empty course when she has never opened the page. */
+export async function loadProgress(): Promise<VoiceJourneyProgress> {
+  const snap = await docRef().get()
+  if (!snap.exists) return EMPTY_PROGRESS
+
+  const data = snap.data() ?? {}
+  return {
+    ...sanitizeProgress(data),
+    updatedAt: typeof data.updatedAt === 'number' ? data.updatedAt : 0,
+  }
+}
+
+/** Writes the whole document and returns exactly what was stored. */
+export async function saveProgress(input: unknown): Promise<VoiceJourneyProgress> {
+  const clean = sanitizeProgress(input)
+  const stored: VoiceJourneyProgress = { ...clean, updatedAt: Date.now() }
+  await docRef().set(stored)
+  return stored
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       'src/app/dicebound/**/*.test.ts',
       'src/app/dicebound/**/*.test.tsx',
       'src/lib/dicebound/**/*.test.ts',
+      'src/lib/voice-journey/**/*.test.ts',
     ],
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
An unlisted page at `/voice-journey` holding a sixteen-week singing course — three phases, forty-eight steps, a practice streak. Ported from an artifact built on claude.ai, with progress moved into Firestore so it tracks across devices.

## Why it isn't in the cave

It is not a game on the arcade floor — it is one child's practice tracker. So it is absent from the home grid and both nav bars, marked `noindex`, and registered as an immersive route so the shared chrome stays out of its way. It keeps the fonts and palette it was designed with, scoped behind one id so they cannot leak.

`ROUTE_CONSTANTS.VOICE_JOURNEY` exists to keep the string in one place, not to list it anywhere.

## Persistence

Follows the repo's usual shape: the client never touches Firestore, a route handler does it with the admin SDK, and `firestore.rules` denies client access to the collection.

There is deliberately no account behind it. What bounds an open write endpoint is not a token but the narrowness of what it accepts — keys must be item ids the curriculum defines, dates must be real days in a plausible window, and both collections are capped. The route cannot be used as free storage; the worst a stranger can do is tick a checkbox she can untick.

A body that is *not* an object is refused rather than sanitized into an empty course, since that would silently wipe her progress.

Local cache paints instantly, then the server's copy replaces it. Writes go the other way: the checkbox ticks at once, the network catches up 600ms later, and a failed save leaves the page usable with a quiet offline note. Returning to a backgrounded tab re-reads the server first. A closing tab flushes via `sendBeacon`, which is why the route also accepts POST.

Conflicts resolve last-write-wins — right for one singer, wrong for two, if that ever changes.

## Two bugs fixed from the original

- Dates came from `toISOString()`, which is UTC — an evening practice session in the Americas was filed under tomorrow, and the streak counter found a hole where a practice day should have been.
- Course rows set the `textDecoration` shorthand alongside `textDecorationColor`, which React warned about on every rerender.

## Verification

- **Cross-device**, in two isolated browser contexts: tablet ticked two steps → phone (open the whole time, never reloaded) picked them up on refocus → phone added a third → tablet picked that up. Firestore ended holding all three.
- **The validator**, since it stands in for auth: unknown item ids, `__proto__`, `2026-02-31`, year 2099, duplicates and a 10KB junk field are all stripped. 12 unit tests.
- Browser console clean through tick, untick, and tab switching.
- `tsc`, `eslint`, `prettier --check`, `check-route-slugs`, and `next build` all pass.

The 81 test failures on `main` (comet-cards jokers, micro-land sim) are pre-existing — verified against a stashed tree, identical set of failing files, none in this change.

## Note

The page is unlisted but the URL is guessable. If that matters, renaming the route is a folder rename plus the one constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)