### PR TITLE
fix(voice-journey): warm-ups a beginner can actually follow

### DIFF
--- a/src/lib/voice-journey/__tests__/curriculum.test.ts
+++ b/src/lib/voice-journey/__tests__/curriculum.test.ts
@@ -86,14 +86,55 @@ describe('warm-up rotations', () => {
   })
 
   it('resolves to the borrowed videos, named after the week they came from', () => {
-    const w5a = items.find(i => i.id === 'w5a')!
-    const resolved = videosFor(w5a)
-    expect(resolved).toHaveLength(3)
-    expect(resolved[0].label).toContain('Cheryl Porter')
+    // Week 6 offers every Phase 1 warm-up back to her, then a cool-down.
+    const resolved = videosFor(items.find(i => i.id === 'w6a')!)
+    expect(resolved).toHaveLength(6)
+    expect(resolved[0].label).toContain('Week 1')
+    expect(resolved[3].label).toContain('Week 4')
   })
 
-  it('expands a borrowed step that itself has two videos', () => {
-    // w16a rotates w6a, which is a warm-up paired with a cool-down.
-    expect(videosFor(items.find(i => i.id === 'w16a')!)).toHaveLength(2)
+  it("puts a step's own video after the ones it borrows", () => {
+    // The cool-down belongs after the warm-up she picks, not before it.
+    for (const id of ['w6a', 'w16a']) {
+      const resolved = videosFor(items.find(i => i.id === id)!)
+      expect(resolved[resolved.length - 1].label).toContain('Cool-down')
+      expect(resolved.slice(0, -1).every(v => v.label?.startsWith('Week'))).toBe(true)
+    }
+  })
+
+  it('shares one cool-down between the two weeks that end with one', () => {
+    const cooldowns = items.flatMap(videosFor).filter(v => v.label?.includes('Cool-down'))
+    expect(cooldowns).toHaveLength(2)
+    expect(new Set(cooldowns.map(v => v.url)).size).toBe(1)
+  })
+})
+
+describe('warm-ups are pitched for a beginner', () => {
+  const warmupsIn = (phaseId: string) =>
+    COURSE.find(p => p.id === phaseId)!.weeks.flatMap(w => w.items.filter(i => i.type === 'warmup'))
+
+  it('keeps the intense Cheryl Porter workout out of Phase 1', () => {
+    // It was Weeks 1, 2 and 4 and is too much to start on; it survives as the
+    // Week 12 "level up" pick and nowhere earlier.
+    const cheryl = '1XHXezdnL0A'
+    const phase1 = warmupsIn('p1').flatMap(videosFor)
+    expect(phase1.some(v => v.url.includes(cheryl))).toBe(false)
+
+    const w12a = items.find(i => i.id === 'w12a')!
+    expect(videosFor(w12a)[0].url).toContain(cheryl)
+  })
+
+  it('starts Phase 1 on warm-ups made for young voices', () => {
+    const firstTwo = ['w1a', 'w2a'].map(id => items.find(i => i.id === id)!)
+    expect(firstTwo.every(i => i.title.includes('Young Voices'))).toBe(true)
+    expect(firstTwo.every(i => i.min <= 10)).toBe(true)
+  })
+
+  it('rotates the later weeks over the young-voice pair plus the longer Jacobs', () => {
+    for (const id of ['w13a', 'w14a', 'w15a', 'w16a']) {
+      const item = items.find(i => i.id === id)!
+      expect(item.rotates).toEqual(['w1a', 'w2a', 'w7a'])
+    }
+    expect(videosFor(items.find(i => i.id === 'w7a')!)[0].url).toContain('ck1pzgy07ZU')
   })
 })

--- a/src/lib/voice-journey/curriculum.ts
+++ b/src/lib/voice-journey/curriculum.ts
@@ -66,8 +66,18 @@ const search = (q: string): CourseVideo[] => [
   { url: `https://www.youtube.com/results?search_query=${encodeURIComponent(q)}`, search: true },
 ]
 
-/** The three warm-ups Phase 3 rotates between, and Week 5 and 12 pick from. */
-const WARMUP_ROTATION = ['w1a', 'w3a', 'w7a']
+/**
+ * The cool-down that closes Week 6 and Week 16. Defined once and shared, so the
+ * two weeks that end with one cannot drift apart.
+ */
+const COOL_DOWN = watch('4SaweGqe4dA', 'Cool-down · Vocal Warmups with Kathleen')
+
+/**
+ * What the later weeks rotate between: the two Young Voices warm-ups, pitched
+ * at her age group, and the ten-minute Jacobs — the step up from the
+ * five-minute one she starts on in Week 3.
+ */
+const WARMUP_ROTATION = ['w1a', 'w2a', 'w7a']
 
 export const COURSE: CoursePhase[] = [
   {
@@ -82,9 +92,9 @@ export const COURSE: CoursePhase[] = [
           {
             id: 'w1a',
             type: 'warmup',
-            title: 'Cheryl Porter — 10 Minute Daily Vocal Workout',
-            min: 10,
-            videos: [watch('1XHXezdnL0A')],
+            title: 'Vocal Warmups for Young Voices #1 (Kathleen)',
+            min: 9,
+            videos: [watch('it5Ztro4Dsw')],
           },
           {
             id: 'w1b',
@@ -109,9 +119,9 @@ export const COURSE: CoursePhase[] = [
           {
             id: 'w2a',
             type: 'warmup',
-            title: 'Cheryl Porter — 10 Minute Vocal Workout',
+            title: 'Vocal Warmups for Young Voices #2 (Kathleen)',
             min: 10,
-            videos: [watch('6tbii7Azhzg')],
+            videos: [watch('Smg6deHOQVY')],
           },
           {
             id: 'w2b',
@@ -136,9 +146,9 @@ export const COURSE: CoursePhase[] = [
           {
             id: 'w3a',
             type: 'warmup',
-            title: 'Jacobs Vocal Academy — 10 Minute Vocal Warm Up',
-            min: 10,
-            videos: [watch('ck1pzgy07ZU')],
+            title: 'Jacobs — 5 Minute Vocal Warm Up (piano-led, no talking)',
+            min: 6,
+            videos: [watch('YCLyAmXtpfY')],
           },
           {
             id: 'w3b',
@@ -163,9 +173,9 @@ export const COURSE: CoursePhase[] = [
           {
             id: 'w4a',
             type: 'warmup',
-            title: 'Cheryl Porter — 10 Minute Daily Vocal Workout (2023)',
-            min: 10,
-            videos: [watch('9dVW9E40-Gw')],
+            title: 'Dots Singing — 5 Minute Warm Up for Beginner Singers',
+            min: 5,
+            videos: [watch('hULyHfs6BTE')],
           },
           {
             id: 'w4b',
@@ -190,10 +200,9 @@ export const COURSE: CoursePhase[] = [
           {
             id: 'w5a',
             type: 'warmup',
-            title: 'Her pick — a warm-up she already knows',
-            min: 10,
-            videos: [],
-            rotates: ['w1a', 'w2a', 'w3a'],
+            title: 'New Victory Arts Break — Vocal Warm Up for Kids',
+            min: 7,
+            videos: [watch('bYd8YZa4UTE')],
           },
           {
             id: 'w5b',
@@ -218,12 +227,10 @@ export const COURSE: CoursePhase[] = [
           {
             id: 'w6a',
             type: 'warmup',
-            title: 'Jacobs — 5 Minute Warm Up, then a cool-down',
-            min: 12,
-            videos: [
-              watch('YCLyAmXtpfY', 'Warm-up · Jacobs'),
-              watch('4SaweGqe4dA', 'Cool-down · Vocal Warmups with Kathleen'),
-            ],
+            title: 'Her favourite warm-up so far, then a cool-down',
+            min: 14,
+            videos: [COOL_DOWN],
+            rotates: ['w1a', 'w2a', 'w3a', 'w4a', 'w5a'],
           },
           {
             id: 'w6b',
@@ -255,9 +262,9 @@ export const COURSE: CoursePhase[] = [
           {
             id: 'w7a',
             type: 'warmup',
-            title: 'Jacobs — 15 Minute Vocal Warm Up',
+            title: 'Jacobs — 10 Minute Vocal Warm Up (the step up)',
             min: 10,
-            videos: [watch('1f_SVJMRx5s')],
+            videos: [watch('ck1pzgy07ZU')],
           },
           {
             id: 'w7b',
@@ -390,10 +397,9 @@ export const COURSE: CoursePhase[] = [
           {
             id: 'w12a',
             type: 'warmup',
-            title: 'Her pick — a warm-up she already knows',
+            title: 'Cheryl Porter — 10 Minute Daily Vocal Workout (level up!)',
             min: 10,
-            videos: [],
-            rotates: WARMUP_ROTATION,
+            videos: [watch('1XHXezdnL0A')],
           },
           {
             id: 'w12b',
@@ -510,9 +516,9 @@ export const COURSE: CoursePhase[] = [
             id: 'w16a',
             type: 'warmup',
             title: 'Warm-up + cool-down',
-            min: 12,
-            videos: [],
-            rotates: ['w6a'],
+            min: 14,
+            videos: [COOL_DOWN],
+            rotates: WARMUP_ROTATION,
           },
           // Nothing to watch — the whole step is her answering the question.
           {
@@ -545,7 +551,8 @@ const BY_ID = new Map<string, { item: CourseItem; week: CourseWeek }>(
  * A rotating warm-up borrows from the weeks it points at and is labelled with
  * their titles, so "her pick" reads as a real choice between lessons she has
  * already done rather than three anonymous links. One level deep only: a
- * rotation never points at another rotation.
+ * rotation never points at another rotation, which is why Week 16 rotates the
+ * same set Week 6 does rather than rotating Week 6 itself.
  */
 export function videosFor(item: CourseItem): CourseVideo[] {
   if (!item.rotates?.length) return item.videos
@@ -563,7 +570,10 @@ export function videosFor(item: CourseItem): CourseVideo[] {
     }))
   })
 
-  return [...item.videos, ...borrowed]
+  // Borrowed first, then this step's own: Week 6 and Week 16 each hold a
+  // cool-down of their own, and a cool-down belongs after the warm-up she picks,
+  // not before it.
+  return [...borrowed, ...item.videos]
 }
 
 /** Every item id the course knows about — the allowlist the server validates against. */


### PR DESCRIPTION
Weeks 1, 2 and 4 opened on Cheryl Porter's ten-minute workout, which is a demanding routine to hand someone in their first week. Phase 1 now starts on warm-ups made for young voices and builds from five minutes upward.

| Week | Warm-up | Real length |
|---|---|---|
| 1 | Vocal Warmups for Young Voices #1 (Kathleen) | 8:34 |
| 2 | Vocal Warmups for Young Voices #2 (Kathleen) | 9:37 |
| 3 | Jacobs — 5 Minute Vocal Warm Up, piano-led | 5:38 |
| 4 | Dots Singing — 5 Minute Warm Up for Beginners | 5:12 |
| 5 | New Victory Arts Break — Vocal Warm Up for Kids | 7:11 |
| 6 | her favourite of those five, then the cool-down | — |

Durations are read from the videos rather than guessed, so "about N min" is now true — several steps claimed 10 minutes for a five-minute video.

## Structure

- **Week 5 stops being a rotation** and becomes a real lesson. **Week 6 takes over as the "pick one you liked" week**, which is where it belongs at the end of a phase — and it now offers all five, not three.
- **The later rotation** (Weeks 13–16) is the two Young Voices warm-ups plus the ten-minute Jacobs, **promoted to Week 7** as the step up from the five-minute one she starts on in Week 3.
- **Cheryl Porter survives at Week 12**, labelled as a level-up — a fairer place for it than day one.

Two things worth a reviewer's eye:

- The **cool-down is now a shared constant** rather than living inside Week 6, because Week 16 needs the same one and a second copy is a second thing to fix.
- **`videosFor` returns borrowed videos before the step's own**, so a cool-down lands after the warm-up it follows rather than before it. Weeks 6 and 16 are the only steps holding both.

## Verified

All **27** videos in the course — not just the new ones — checked against YouTube's oEmbed endpoint. Every one resolves. Confirmed in the browser that Phase 1 renders zero links to the Cheryl workout and that Week 6 lists its five options in week order with the cool-down last.

Two notes on the source list: the Young Voices pair is by **Vocal Warmups with Kathleen** — the same coach as the cool-down already in the course. And the Dots Singing video's full title is "5 Minute Vocal Warm Up **Female** for Beginner Singers | Fun For All Ages" — pitched for female voices, which the "all ages" description didn't mention.

Item ids are untouched, so nothing already ticked moves. 27 tests pass (4 new, covering that Phase 1 holds no level-up video and that the rotation is what it should be). `tsc`, `eslint`, `prettier`, `next build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)