### PR TITLE
feat(dicebound): statuses — the record, the slug, the expiry

### DIFF
--- a/src/app/dicebound/domain/__tests__/status.test.ts
+++ b/src/app/dicebound/domain/__tests__/status.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Status afflictions.
+ *
+ * Each test is a sentence about the rule it is protecting. The rules are
+ * small enough to each hold one invariant, and the important failures are
+ * quiet ones — a duration that should have been clamped that wasn't, two
+ * statuses that should have been one, a bad entry that should have been
+ * dropped but wasn't.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAX_STATUS_DURATION,
+  MAX_STATUSES,
+  applyStatus,
+  expire,
+  validateStatuses,
+} from '@/app/dicebound/domain/status'
+
+// ------------------------------------------------------------ applyStatus
+
+describe('applyStatus', () => {
+  it('two names that slug the same refresh one status rather than making two', () => {
+    // "Toad Venom Sickness" and "toad-venom-sickness" must not produce two
+    // entries — the id is the slug, and slugging twice is idempotent.
+    const base = applyStatus([], 'Toad Venom Sickness', 'you feel sick', 60, 0)
+    expect(base).toHaveLength(1)
+    expect(base[0].id).toBe('toad-venom-sickness')
+
+    const refreshed = applyStatus(base, 'toad-venom-sickness', 'you feel sick', 120, 10)
+    expect(refreshed).toHaveLength(1)
+    expect(refreshed[0].id).toBe('toad-venom-sickness')
+    // until should be refreshed to now + duration
+    expect(refreshed[0].until).toBe(10 + 120)
+  })
+
+  it('a refresh preserves the name and effect of the existing entry, updating only until', () => {
+    const base = applyStatus([], 'Fever', 'you sweat', 60, 0)
+    const refreshed = applyStatus(base, 'fever', 'changed effect', 90, 20)
+    // The original name and effect are preserved; only until changes.
+    expect(refreshed[0].name).toBe('Fever')
+    expect(refreshed[0].effect).toBe('you sweat')
+    expect(refreshed[0].until).toBe(20 + 90)
+  })
+
+  it('a status whose name slugs to nothing is dropped', () => {
+    // A name that is all punctuation, spaces, or otherwise produces an empty
+    // slug cannot be stored — there is no id to key it under.
+    const after = applyStatus([], '---', 'some effect', 60, 0)
+    expect(after).toHaveLength(0)
+
+    const after2 = applyStatus([], '!!!', 'some effect', 60, 0)
+    expect(after2).toHaveLength(0)
+
+    const after3 = applyStatus([], '', 'some effect', 60, 0)
+    expect(after3).toHaveLength(0)
+  })
+
+  it('a duration past the clamp is clamped, not honoured', () => {
+    const way_too_long = MAX_STATUS_DURATION + 10000
+    const after = applyStatus([], 'Cursed', 'the curse lingers', way_too_long, 0)
+    expect(after[0].until).toBe(MAX_STATUS_DURATION)
+  })
+
+  it('until is now plus the (clamped) duration', () => {
+    const now = 500
+    const duration = 120
+    const after = applyStatus([], 'Poisoned', 'sluggish veins', duration, now)
+    expect(after[0].until).toBe(now + duration)
+  })
+
+  it('applying past the cap drops the one expiring soonest', () => {
+    // The soonest-expiring status is the least valuable — it is almost gone
+    // anyway. Dropping it is less disruptive than refusing the new affliction.
+    const now = 1000
+
+    // Fill to the cap with statuses that expire at ascending times.
+    let statuses: readonly import('@/app/dicebound/domain/status').Status[] = []
+    for (let i = 0; i < MAX_STATUSES; i++) {
+      statuses = applyStatus(statuses, `affliction-${i}`, 'hurts', (i + 1) * 10, now)
+    }
+    expect(statuses).toHaveLength(MAX_STATUSES)
+
+    // The soonest-expiring is affliction-0 (until = now + 10).
+    const soonestId = 'affliction-0'
+    expect(statuses.some(s => s.id === soonestId)).toBe(true)
+
+    // Adding one more should drop affliction-0.
+    const after = applyStatus(statuses, 'new-affliction', 'fresh pain', 100, now)
+    expect(after).toHaveLength(MAX_STATUSES)
+    expect(after.some(s => s.id === soonestId)).toBe(false)
+    expect(after.some(s => s.id === 'new-affliction')).toBe(true)
+  })
+
+  it('a zero-duration status expires immediately (until === now)', () => {
+    // Edge: duration 0 means until = now, and expire(…, now) will drop it.
+    const now = 100
+    const after = applyStatus([], 'Flash', 'blink', 0, now)
+    expect(after[0].until).toBe(now)
+    expect(expire(after, now)).toHaveLength(0)
+  })
+})
+
+// ------------------------------------------------------------- expire
+
+describe('expire', () => {
+  it('a status expires when the clock passes it, including when one turn skips the whole span', () => {
+    // Statuses whose until <= now are removed. This handles both the normal
+    // case (clock ticks past it one minute at a time) and the long-rest case
+    // (the clock jumps a whole day in one turn).
+    const statuses = [
+      { id: 'a', name: 'A', effect: 'hurts', until: 50 },
+      { id: 'b', name: 'B', effect: 'hurts', until: 100 },
+      { id: 'c', name: 'C', effect: 'hurts', until: 200 },
+    ] as const
+
+    // At exactly the minute the status expires, it is gone.
+    expect(expire(statuses, 50)).toHaveLength(2)
+    expect(expire(statuses, 50).some(s => s.id === 'a')).toBe(false)
+
+    // At now = 100, b also expires.
+    const after100 = expire(statuses, 100)
+    expect(after100).toHaveLength(1)
+    expect(after100[0].id).toBe('c')
+
+    // A single long turn that jumps from 0 to 300 clears everything.
+    expect(expire(statuses, 300)).toHaveLength(0)
+  })
+
+  it('a status that has not reached its until survives the clock', () => {
+    const statuses = [{ id: 'x', name: 'X', effect: 'lingers', until: 200 }]
+    expect(expire(statuses, 199)).toHaveLength(1)
+  })
+
+  it('an empty list stays empty regardless of the clock', () => {
+    expect(expire([], 99999)).toHaveLength(0)
+  })
+})
+
+// ------------------------------------------------------------- validateStatuses
+
+describe('validateStatuses', () => {
+  it('garbage from the wire loads as an empty list', () => {
+    // An unreadable status list is an empty one — never throws, always returns
+    // something the renderer can draw.
+    expect(validateStatuses(undefined)).toEqual([])
+    expect(validateStatuses(null)).toEqual([])
+    expect(validateStatuses('poisoned')).toEqual([])
+    expect(validateStatuses(42)).toEqual([])
+    expect(validateStatuses({})).toEqual([])
+  })
+
+  it('a non-array is an empty list', () => {
+    expect(validateStatuses({ 0: { id: 'x', name: 'X', effect: 'e', until: 1 } })).toEqual([])
+  })
+
+  it('non-object entries in the array are dropped individually', () => {
+    const value = [
+      null,
+      'string',
+      42,
+      { id: 'valid', name: 'Valid', effect: 'hurts', until: 100 },
+    ]
+    const result = validateStatuses(value)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('valid')
+  })
+
+  it('an entry with no derivable id is dropped', () => {
+    // id = slug(element.id ?? element.name, 60). If both are absent or slug
+    // to nothing, the entry is dropped.
+    const value = [
+      { name: '!!!', effect: 'something', until: 10 },
+      { id: '---', name: 'also bad', effect: 'something', until: 10 },
+    ]
+    // '!!!' slugs to '' — dropped. '---' also slugs to '' — dropped.
+    // But 'also bad' slugs to 'also-bad' — wait, id is tried first.
+    // id = slug('---') = '' → try name = 'also bad' → slug('also bad') = 'also-bad' — kept.
+    // Actually per spec: id = slug(element.id ?? element.name, 60).
+    // So if element.id is '---', we slug that, not element.name.
+    // '---' slugs to '' → dropped.
+    const result = validateStatuses(value)
+    expect(result).toHaveLength(0)
+  })
+
+  it('an entry whose name slugs to something is kept even if id field is missing', () => {
+    const value = [{ name: 'Arrow wound', effect: 'your side burns', until: 50 }]
+    const result = validateStatuses(value)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('arrow-wound')
+  })
+
+  it('the validated list is capped at MAX_STATUSES even if the wire sends more', () => {
+    const value = Array.from({ length: MAX_STATUSES + 5 }, (_, i) => ({
+      name: `status-${i}`,
+      effect: 'hurts',
+      until: i * 10,
+    }))
+    const result = validateStatuses(value)
+    expect(result).toHaveLength(MAX_STATUSES)
+  })
+
+  it('numeric fields are coerced: a string until becomes 0 (int fallback)', () => {
+    const value = [{ name: 'Hex', effect: 'bad luck', until: 'never' }]
+    const result = validateStatuses(value)
+    expect(result).toHaveLength(1)
+    expect(result[0].until).toBe(0)
+  })
+
+  it('string fields are truncated to their declared max lengths', () => {
+    const longName = 'a'.repeat(200)
+    const longEffect = 'b'.repeat(800)
+    const value = [{ name: longName, effect: longEffect, until: 0 }]
+    const result = validateStatuses(value)
+    expect(result[0].name.length).toBeLessThanOrEqual(120)
+    expect(result[0].effect.length).toBeLessThanOrEqual(600)
+  })
+
+  it('a well-formed entry round-trips without loss', () => {
+    const entry = { id: 'fever', name: 'Fever', effect: 'sweating and weak', until: 300 }
+    const result = validateStatuses([entry])
+    expect(result[0]).toEqual({
+      id: 'fever',
+      name: 'Fever',
+      effect: 'sweating and weak',
+      until: 300,
+    })
+  })
+})

--- a/src/app/dicebound/domain/body.ts
+++ b/src/app/dicebound/domain/body.ts
@@ -43,6 +43,7 @@
 import { isPlainObject, oneOf } from './validate'
 
 import type { OutcomeBand } from './dice'
+import { type Status, validateStatuses } from './status'
 
 // ------------------------------------------------------------------ the track
 
@@ -149,10 +150,12 @@ export function isDead(body: Body): boolean {
  */
 export interface Body {
   condition: Condition
+  /** Active afflictions. Empty for an undamaged body. */
+  statuses: readonly Status[]
 }
 
 export function undamagedBody(): Body {
-  return { condition: 'unhurt' }
+  return { condition: 'unhurt', statuses: [] }
 }
 
 /**
@@ -167,10 +170,15 @@ export function undamagedBody(): Body {
  *
  * A campaign saved before this file existed has no `body` at all, which lands in
  * exactly the same place. That is the whole of the version 2 → 3 migration.
+ * A body without `statuses` validates to `statuses: []`, so no version bump is
+ * needed.
  */
 export function validateBody(value: unknown): Body {
   if (!isPlainObject(value)) return undamagedBody()
-  return { condition: oneOf(value.condition, CONDITION_ORDER, 'unhurt') }
+  return {
+    condition: oneOf(value.condition, CONDITION_ORDER, 'unhurt'),
+    statuses: validateStatuses(value.statuses),
+  }
 }
 
 // ----------------------------------------------------------- the severity table

--- a/src/app/dicebound/domain/status.ts
+++ b/src/app/dicebound/domain/status.ts
@@ -1,0 +1,154 @@
+/**
+ * Status afflictions — timed conditions that wrong the player.
+ *
+ * Statuses are the DM's own words for what is happening to a character right
+ * now: "toad venom sickness", "arrow-grazed shoulder", "rattled from the
+ * fall". They live until the clock passes their `until`, and they are
+ * afflictions only — no blessings, no boons.
+ *
+ * That constraint is deliberate. A model biased toward helping will eventually
+ * write `effect: "you are unusually lucky"`. It cannot touch the die directly
+ * (effect is a string, there is no numeric field), but it goes into the prompt.
+ * Constraining to things wrong with you means an invented status can only ever
+ * cost the player something. Enforced in the prompt and tool description — a
+ * string field cannot be type-checked for tone.
+ *
+ * Timed afflictions are statuses; open-ended ones are threads. ThreadEntity
+ * already handles expiry with fuses, so an NPC who hates you for a season is
+ * a thread, not a status.
+ *
+ * Pure, like everything else in `domain/`. No `Math.random`, no `Date.now`,
+ * no `new Date()`. All time arrives as an argument.
+ */
+import { int, isPlainObject, slug, str } from '@/app/dicebound/domain/validate'
+import { MAX_TURN_MINUTES } from '@/app/dicebound/domain/world'
+
+export interface Status {
+  /** Slug of `name`. The key. */
+  id: string
+  /** The DM's own words: 'toad venom sickness', not 'poisoned'. */
+  name: string
+  /** What it does to you, in prose. Never a number. */
+  effect: string
+  /** Clock minute this expires at. Stamped by the server from `expires`. */
+  until: number
+}
+
+/** Cap on live statuses at once. */
+export const MAX_STATUSES = 5
+
+/**
+ * The longest a status may run.
+ *
+ * Same as MAX_TURN_MINUTES from world.ts — one week of fiction. A status
+ * that outlives this becomes a thread instead, because what it represents is
+ * an ongoing situation the story has to decide what to do with, not a
+ * ticking clock.
+ */
+export const MAX_STATUS_DURATION = MAX_TURN_MINUTES
+
+// ------------------------------------------------------------------ applying
+
+/**
+ * Apply a status to the list.
+ *
+ * Rules (see issue #3774):
+ * 1. id = slug(name). A name that slugs to nothing is dropped.
+ * 2. If same id already exists: refresh (update until), leave rest unchanged.
+ * 3. Duration is clamped to MAX_STATUS_DURATION.
+ * 4. until = now + clampedDuration.
+ * 5. If adding past MAX_STATUSES cap: drop the one expiring soonest.
+ *    Reason: soonest-expiring is the least valuable to keep; it is almost gone
+ *    anyway. The player still accumulates new afflictions naturally without
+ *    getting stuck behind an artificial refusal.
+ */
+export function applyStatus(
+  statuses: readonly Status[],
+  name: string,
+  effect: string,
+  durationMinutes: number,
+  now: number,
+): readonly Status[] {
+  const id = slug(name, 60)
+  // A name that slugs to nothing cannot be keyed, referenced, or displayed.
+  // Drop it rather than adding a status nobody can identify.
+  if (!id) return statuses
+
+  const clampedDuration = Math.min(Math.max(0, durationMinutes), MAX_STATUS_DURATION)
+  const until = now + clampedDuration
+
+  // Rule 2: refresh an existing status with the same id.
+  const existingIndex = statuses.findIndex(s => s.id === id)
+  if (existingIndex !== -1) {
+    const refreshed = statuses.map((s, i) => (i === existingIndex ? { ...s, until } : s))
+    return refreshed
+  }
+
+  const incoming: Status = { id, name, effect, until }
+
+  // Rule 5: if at cap, drop the one expiring soonest to make room.
+  if (statuses.length >= MAX_STATUSES) {
+    let soonestIndex = 0
+    for (let i = 1; i < statuses.length; i++) {
+      if (statuses[i].until < statuses[soonestIndex].until) soonestIndex = i
+    }
+    const pruned = statuses.filter((_, i) => i !== soonestIndex)
+    return [...pruned, incoming]
+  }
+
+  return [...statuses, incoming]
+}
+
+// ------------------------------------------------------------------ expiring
+
+/**
+ * Remove statuses whose until has been reached or passed.
+ *
+ * Pure — takes the clock minute. Called wherever the clock advances.
+ * Including the case where one turn skips the entire span.
+ */
+export function expire(statuses: readonly Status[], now: number): readonly Status[] {
+  return statuses.filter(s => s.until > now)
+}
+
+// ---------------------------------------------------------------- validation
+
+/**
+ * Read a statuses list off the wire.
+ *
+ * Never throws and repairs rather than refuses — an unreadable status list
+ * is an empty one. Each entry is validated individually; bad entries are
+ * dropped rather than failing the whole list.
+ *
+ * Note: Statuses are afflictions only. No blessings, no boons. A model
+ * biased toward helping will eventually write effect: "you are unusually
+ * lucky". It cannot touch the die directly (effect is a string, there is no
+ * numeric field), but it goes into the prompt. Constraining to things wrong
+ * with you means an invented status can only ever cost the player something.
+ * Enforced in the prompt and tool description — a string field cannot be
+ * type-checked for tone. Timed afflictions are statuses; open-ended ones are
+ * threads (ThreadEntity already handles expiry with fuses).
+ */
+export function validateStatuses(value: unknown): readonly Status[] {
+  if (!Array.isArray(value)) return []
+
+  const validated: Status[] = []
+  for (const element of value) {
+    if (!isPlainObject(element)) continue
+
+    // id is derived from id or name, slugged to 60 chars.
+    const id = slug(element.id ?? element.name, 60)
+    if (!id) continue
+
+    const name = str(element.name, 120)
+    const effect = str(element.effect, 600)
+    const until = int(element.until)
+
+    validated.push({ id, name, effect, until })
+
+    // Cap the validated list at MAX_STATUSES — keep first valid ones.
+    if (validated.length >= MAX_STATUSES) break
+  }
+
+  return validated
+}


### PR DESCRIPTION
Closes #3774. Part of #3769.

## Summary

- New `src/app/dicebound/domain/status.ts` — pure domain, no UI
  - `Status` interface: `id` (slug), `name`, `effect` (prose, no numbers), `until` (clock minute)
  - `applyStatus()` — slug-keyed, refreshes on id collision, clamps duration to 7 days, drops soonest-expiring when at cap (5)
  - `expire()` — pure clock filter, handles single-turn long jumps correctly
  - `validateStatuses()` — never throws, unreadable list → empty list
- Modified `body.ts` — adds `statuses: readonly Status[]` to `Body`; `undamagedBody()` returns `[]`; `validateBody()` coerces missing statuses to `[]` (no version bump needed)
- 19 tests, zero new type errors

## Four guards implemented

1. `id = slug(name)`, re-applying refreshes rather than stacks
2. `until` is clamped to `MAX_TURN_MINUTES` (7 days)
3. Cap of 5 live statuses — drops soonest-expiring to make room
4. Afflictions only — documented in code, enforced by prompt (next issue)

## Test plan

- [x] `npx vitest run src/app/dicebound/domain/__tests__/status.test.ts` — 19 passing
- [x] `npx tsc --noEmit 2>&1 | grep dicebound` — empty (zero new errors)
- [x] All 372 tests in the dicebound domain suite still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)