### PR TITLE
feat(dicebound): the danger dial

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -46,7 +46,7 @@ import {
   CONDITION_LABEL,
   CONDITION_PHRASE,
   DAMAGE_TABLE,
-  DEFAULT_DANGER,
+  type Danger,
   SEVERITY_ORDER,
   type Severity,
   applyDamage,
@@ -1198,7 +1198,7 @@ Resolve it, then call narrate with what happens.`,
     // the order it meant them: the thing they attempted resolves, and then the
     // world does whatever it was going to do regardless.
     for (const call of harms) {
-      const { body: afterHarm, note, spent } = harmFor(body, harmed, call.input)
+      const { body: afterHarm, note, spent } = harmFor(body, harmed, call.input, campaign.danger)
       body = afterHarm
       harmed = harmed || spent
       results.push({ type: 'tool_result', tool_use_id: call.id, content: note })
@@ -1684,10 +1684,10 @@ function rollFor(
   // stamp `bruising` on every check in the game and turn the ordinary case —
   // no severity at all — into a slow bleed nobody chose.
   const severity = typeof raw.severity === 'string' ? validateSeverity(raw.severity) : null
-  // `DEFAULT_DANGER` until the dial exists (#3777). It is passed rather than
-  // defaulted inside `applyDamage` so that the day `Campaign.danger` lands, the
-  // only edit is this argument.
-  const change = severity ? applyDamage(body, severity, outcome.band, DEFAULT_DANGER) : null
+  // The danger setting changes arithmetic only. It is intentionally not sent to
+  // the DM in the prompt: telling the DM would soften narrative on top of softer
+  // numbers, doubling the effect without anyone choosing it.
+  const change = severity ? applyDamage(body, severity, outcome.band, campaign.danger) : null
   // Every check, including the ones that named nothing — "most checks are not
   // dangerous" is a claim in the prompt, and it can only be read against the
   // checks that carried no severity at all.
@@ -1758,7 +1758,8 @@ function rollFor(
 function harmFor(
   body: Body,
   already: boolean,
-  input: unknown
+  input: unknown,
+  danger: Danger
 ): { body: Body; note: string; spent: boolean } {
   if (already) {
     // Recorded too. A DM reaching for a second harm is the drift this ceiling
@@ -1787,7 +1788,7 @@ function harmFor(
   // turn where the fiction has already committed to an ambush leaves the DM
   // narrating a blow the sheet never took.
   const severity = validateSeverity(raw.severity)
-  const change = applyHarm(body, severity, DEFAULT_DANGER)
+  const change = applyHarm(body, severity, danger)
   const reason = typeof raw.reason === 'string' ? raw.reason.slice(0, 120) : ''
 
   noteDamage({

--- a/src/app/dicebound/components/creation.tsx
+++ b/src/app/dicebound/components/creation.tsx
@@ -16,7 +16,14 @@
 import { useState } from 'react'
 
 import { MAX_CONCEPT, MAX_PREMISE } from '@/app/dicebound/domain/campaign'
+import { type Danger, DANGER_ORDER } from '@/app/dicebound/domain/body'
 import { ChunkyButton } from '@/components/ui/chunky-button'
+
+const DANGER_LABELS: Record<Danger, { label: string; hint: string }> = {
+  gentle: { label: 'Gentle', hint: 'The story is the point. Death is possible but walks slowly.' },
+  ordinary: { label: 'Ordinary', hint: 'The default. A bad roll costs something real.' },
+  perilous: { label: 'Perilous', hint: 'A single wrong step can end the story.' },
+}
 
 const PREMISES = [
   'a heist in a clockwork city',
@@ -38,12 +45,13 @@ export function Creation({
   pending,
   error,
 }: {
-  onBegin: (premise: string, concept: string) => void
+  onBegin: (premise: string, concept: string, danger: Danger) => void
   pending: boolean
   error: string | null
 }) {
   const [premise, setPremise] = useState('')
   const [concept, setConcept] = useState('')
+  const [danger, setDanger] = useState<Danger>('ordinary')
 
   const ready = premise.trim().length > 1 && concept.trim().length > 1
 
@@ -79,6 +87,39 @@ export function Creation({
         disabled={pending}
       />
 
+      <section className="flex flex-col gap-3">
+        <label className="font-headline text-xl font-extrabold text-on-surface">
+          How dangerous is this world?
+        </label>
+        <p className="-mt-2 text-sm text-on-surface-variant">
+          You can change this any time during the story.
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          {DANGER_ORDER.map(option => {
+            const { label, hint } = DANGER_LABELS[option]
+            const selected = danger === option
+            return (
+              <button
+                key={option}
+                type="button"
+                disabled={pending}
+                onClick={() => setDanger(option)}
+                className={`flex flex-1 flex-col gap-1 rounded-ds-sm border-2 px-4 py-3 text-left transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ds-primary disabled:opacity-50 ${
+                  selected
+                    ? 'border-ds-primary bg-ds-primary/10 text-on-surface'
+                    : 'border-outline-variant bg-surface-container-low text-on-surface-variant hover:border-ds-primary/50'
+                }`}
+              >
+                <span className={`font-headline font-bold ${selected ? 'text-ds-primary' : ''}`}>
+                  {label}
+                </span>
+                <span className="text-sm">{hint}</span>
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
       {error && (
         <p role="alert" className="text-center text-body-md text-ds-error">
           {error}
@@ -90,7 +131,7 @@ export function Creation({
           variant="primary"
           size="hero"
           disabled={!ready || pending}
-          onClick={() => onBegin(premise, concept)}
+          onClick={() => onBegin(premise, concept, danger)}
         >
           {pending ? 'Rolling up…' : 'Begin the story'}
         </ChunkyButton>

--- a/src/app/dicebound/components/sheet.tsx
+++ b/src/app/dicebound/components/sheet.tsx
@@ -23,9 +23,10 @@ import {
   SKILLS,
   type SkillId,
 } from '@/app/dicebound/domain/attributes'
-import { type Body, CONDITION_LABEL, CONDITION_PHRASE } from '@/app/dicebound/domain/body'
+import { type Body, CONDITION_LABEL, CONDITION_PHRASE, type Danger, DANGER_ORDER } from '@/app/dicebound/domain/body'
 import type { Campaign } from '@/app/dicebound/domain/campaign'
 import { type SkillRecord, usesToNextRank } from '@/app/dicebound/domain/character'
+import { useDicebound } from '@/app/dicebound/store'
 
 import { Items, Powers, SpeciesLine, Standing } from './kit'
 import { WorldPanel } from './world'
@@ -36,6 +37,7 @@ function sign(value: number): string {
 
 export function Sheet({ campaign }: { campaign: Campaign }) {
   const { character, stats } = campaign
+  const setDanger = useDicebound(state => state.setDanger)
 
   const touched = Object.entries(character.skills)
     .map(([skill, record]) => ({ skill: skill as SkillId, record: record as SkillRecord }))
@@ -49,6 +51,7 @@ export function Sheet({ campaign }: { campaign: Campaign }) {
         <SpeciesLine species={campaign.kit.species} />
         <Standing campaign={campaign} />
         <Condition body={campaign.body} />
+        <DangerDial danger={campaign.danger} onChange={setDanger} />
         {character.reading && (
           <p className="mt-3 border-l-2 border-ds-tertiary/50 pl-3 text-sm italic text-on-surface-variant">
             {character.reading}
@@ -184,6 +187,54 @@ function Condition({ body }: { body: Body }) {
         <span className="mx-1.5 text-on-surface-variant/50">—</span>
         {CONDITION_PHRASE[body.condition]}
       </p>
+    </section>
+  )
+}
+
+const DANGER_LABELS: Record<Danger, { label: string; hint: string }> = {
+  gentle: { label: 'Gentle', hint: 'Death walks slowly.' },
+  ordinary: { label: 'Ordinary', hint: 'A bad roll costs something real.' },
+  perilous: { label: 'Perilous', hint: 'A single wrong step can end the story.' },
+}
+
+/**
+ * The lethality dial, shown from turn 1.
+ *
+ * This is a setting, not a stat — it shows regardless of condition, even on an
+ * unhurt character. The danger setting changes arithmetic only; it is not sent
+ * to the DM in the prompt (telling the DM would soften narrative on top of softer
+ * numbers, doubling the effect without anyone choosing it).
+ */
+function DangerDial({ danger, onChange }: { danger: Danger; onChange: (danger: Danger) => void }) {
+  return (
+    <section aria-labelledby="dicebound-danger" className="mt-3">
+      <h3
+        id="dicebound-danger"
+        className="font-label text-label-caps text-xs uppercase tracking-widest text-on-surface-variant"
+      >
+        Danger
+      </h3>
+      <div className="mt-2 flex gap-1.5">
+        {DANGER_ORDER.map(option => {
+          const { label, hint } = DANGER_LABELS[option]
+          const selected = danger === option
+          return (
+            <button
+              key={option}
+              type="button"
+              title={hint}
+              onClick={() => onChange(option)}
+              className={`flex-1 rounded border-2 px-2 py-1.5 text-center text-xs font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ds-primary ${
+                selected
+                  ? 'border-ds-primary bg-ds-primary/10 text-ds-primary'
+                  : 'border-outline-variant bg-surface-container-low text-on-surface-variant hover:border-ds-primary/50 hover:text-on-surface'
+              }`}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </div>
     </section>
   )
 }

--- a/src/app/dicebound/domain/campaign.ts
+++ b/src/app/dicebound/domain/campaign.ts
@@ -24,9 +24,12 @@ import {
   type Body,
   CONDITION_ORDER,
   type Condition,
+  type Danger,
+  DEFAULT_DANGER,
   isDead,
   undamagedBody,
   validateBody,
+  validateDanger,
 } from './body'
 import { MAX_SKILL_RANK, blankAttributes, normalizeAttributes } from './character'
 import { type Kit, emptyKit, validateKit } from './kit'
@@ -155,6 +158,8 @@ export interface Campaign {
   character: Character
   /** Where the character is on the condition track. Added in version 3. */
   body: Body
+  /** How lethal the player wants their world to be. Defaults to 'ordinary'. */
+  danger: Danger
   /**
    * Set once, when the run ends. Null for a story still being told, which is
    * almost all of them — nothing renders until it exists (CLAUDE.md #17).
@@ -224,7 +229,8 @@ export function newCampaign(
   premise: string,
   character: Character,
   now: number,
-  today: string | null
+  today: string | null,
+  danger: Danger = DEFAULT_DANGER
 ): Campaign {
   return {
     version: CAMPAIGN_VERSION,
@@ -232,6 +238,7 @@ export function newCampaign(
     title: 'An Untitled Story',
     character,
     body: undamagedBody(),
+    danger,
     ending: null,
     world: emptyWorld(),
     kit: emptyKit(),
@@ -314,6 +321,7 @@ export function validateCampaign(value: unknown): Campaign | null {
     // remembered — and a branch nobody has to remember is a branch that cannot
     // be forgotten at the next bump. `readEnding` is built the same way.
     body,
+    danger: validateDanger(value.danger),
     ending: readEnding(value.ending, body, world.clock.elapsed, updatedAt),
     world,
     kit: migrating ? emptyKit() : validateKit(value.kit),

--- a/src/app/dicebound/store.ts
+++ b/src/app/dicebound/store.ts
@@ -48,6 +48,7 @@ import {
   newCampaign,
   withVisit,
 } from './domain/campaign'
+import { type Danger, DEFAULT_DANGER } from './domain/body'
 import { applyTurn } from './domain/turn'
 
 import type { Character } from './domain/character'
@@ -85,17 +86,18 @@ interface DiceboundState {
   suggestionsHidden: boolean
 
   attach: (backend: CampaignBackend) => Promise<void>
-  begin: (premise: string, concept: string) => Promise<void>
+  begin: (premise: string, concept: string, danger: Danger) => Promise<void>
   act: (action: string) => Promise<void>
   abandon: () => Promise<void>
   dismissError: () => void
+  setDanger: (danger: Danger) => void
   /** Ask for a fresh three. Called by the store itself after anything that moves the story. */
   refreshSuggestions: () => Promise<void>
   toggleSuggestions: () => void
 }
 
-function freshCampaign(premise: string, character: Character, now: number): Campaign {
-  return newCampaign(premise, character, now, getTodayPST())
+function freshCampaign(premise: string, character: Character, now: number, danger: Danger): Campaign {
+  return newCampaign(premise, character, now, getTodayPST(), danger)
 }
 
 export const useDicebound = create<DiceboundState>((set, get) => ({
@@ -134,14 +136,14 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
     void get().refreshSuggestions()
   },
 
-  async begin(premise, concept) {
+  async begin(premise, concept, danger = DEFAULT_DANGER) {
     if (get().pending) return
     set({ pending: true, error: null })
 
     try {
       const trimmedPremise = premise.trim().slice(0, MAX_PREMISE)
       const character = await createCharacter(concept.trim().slice(0, MAX_CONCEPT), trimmedPremise)
-      const campaign = freshCampaign(trimmedPremise, character, Date.now())
+      const campaign = freshCampaign(trimmedPremise, character, Date.now(), danger)
 
       // Straight into the opening scene. A character sheet with no story
       // attached is a form the player just filled in; the first paragraph is
@@ -230,6 +232,14 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
 
   dismissError() {
     set({ error: null })
+  },
+
+  setDanger(danger) {
+    const { campaign, backend } = get()
+    if (!campaign) return
+    const updated = { ...campaign, danger }
+    set({ campaign: updated })
+    void backend.save(updated)
   },
 
   async refreshSuggestions() {


### PR DESCRIPTION
Closes #3777. Part of #3769.

## Summary

- **`campaign.ts`** — adds `danger: Danger` to Campaign; missing field reads as `'ordinary'` via `validateDanger` (no version bump needed)
- **`store.ts`** — `begin()` accepts `danger`; new `setDanger()` action updates local state and fire-and-forget saves
- **`creation.tsx`** — 3-option danger selector between concept field and Begin button; `onBegin` signature extended
- **`sheet.tsx`** — `DangerDial` control visible from turn 1; reads `setDanger` from the store directly
- **`turn/route.ts`** — both `applyDamage` and `applyHarm` call sites now pass `campaign.danger` instead of the `DEFAULT_DANGER` placeholder

## Design decisions documented

**The DM is not told when danger changes.** Telling it would cause narrative softening on top of the already-softer numbers — the player who drops to Gentle gets the mechanical relief they wanted; layering the DM's own mercy on top doubles the effect without anyone explicitly choosing it. The mapping is in code; the fiction describes the same world.

**Mid-campaign changes never retroactively heal or harm.** `setDanger` only affects the next damage calculation.

**The dial is always visible.** Unlike body conditions (which require something to have happened), the danger dial is a control — it shows from the first turn.

## Test plan

- [x] `npx vitest run src/app/dicebound` — 416 tests passing
- [x] `npx tsc --noEmit 2>&1 | grep dicebound` — empty (zero new errors)
- Existing body.test.ts already covers: ordering invariant (Perilous ≥ Ordinary ≥ Gentle for all severity × band), `bruising` never kills at any danger, missing danger reads as ordinary

🤖 Generated with [Claude Code](https://claude.com/claude-code)