### PR TITLE
feat(dicebound): the turn stops being a blank wait

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -190,6 +190,10 @@ import {
 import { archiveChapter, loadCampaign, saveCampaign } from '@/lib/dicebound/campaign-store'
 import { noteDamage } from '@/lib/dicebound/telemetry'
 
+/** Callback for streaming turn events to the client as they happen. */
+type TurnEmitter = (event: { type: 'check'; entry: CheckEntry }) => void
+const noopEmit: TurnEmitter = () => {}
+
 /** The DM can be slow, and a scene worth waiting for is worth the headroom. */
 export const maxDuration = 120
 
@@ -842,73 +846,131 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Say what you do.' }, { status: 400 })
   }
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 105_000)
-
+  // Check for a missing API key synchronously before starting the stream.
+  // A NoApiKeyError after streaming has begun cannot be expressed as an HTTP
+  // error status, so we surface it here instead.
+  let apiKey: string
   try {
-    const apiKey = requireApiKey()
-    const result = isOpening
-      ? await openStory(apiKey, campaign, controller.signal)
-      : await playTurn(apiKey, campaign, action, controller.signal, uid)
-
-    // Anonymous-first (CLAUDE.md #1). `uid` is null only when there is no
-    // Firebase at all, and that player still gets their turn — they just apply
-    // and store it themselves, exactly as before.
-    if (uid === null) return NextResponse.json({ result })
-
-    // The server folds the turn in and hands back what it saved. Returning the
-    // whole campaign rather than a diff is deliberate: the client applying its
-    // own `applyTurn` to a result is precisely the client-side authority this
-    // issue removes, and two implementations of that arithmetic is two chances
-    // for the sheet and the save file to disagree. The request is a sentence;
-    // it is the response that carries the story.
-    const next = applyTurn(campaign, result, Date.now())
-    try {
-      await saveCampaign(uid, trimToFit(next))
-    } catch (error) {
-      // The turn happened and the player is owed it. A failed save reads as a
-      // dropped turn next reload, which is worse than nothing but far better
-      // than throwing away narration the model has already been paid for.
-      console.error('dicebound turn save failed:', error)
-    }
-    return NextResponse.json({ result, campaign: next })
+    apiKey = requireApiKey()
   } catch (error) {
-    clearTimeout(timeout)
-
     if (error instanceof NoApiKeyError) {
       return NextResponse.json(
         { error: 'The dungeon master is not answering tonight.' },
         { status: 503 }
       )
     }
-    if (error instanceof RefusedError) {
-      // In voice, and playable — the story continues, it just goes somewhere
-      // else. Breaking character to deliver a policy notice would be worse for
-      // this audience than a locked door.
-      return NextResponse.json({
-        result: {
-          entries: [
-            {
-              kind: 'narration',
-              text: 'That thread goes somewhere the story will not follow. The moment passes, and the world waits for you to try something else.',
-            },
-          ],
-        } satisfies TurnResult,
-      })
-    }
-
-    console.error('dicebound turn failed:', error)
-    return NextResponse.json({ error: 'The telling faltered. Try that again.' }, { status: 502 })
-  } finally {
-    clearTimeout(timeout)
+    throw error
   }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 105_000)
+  const encoder = new TextEncoder()
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(streamCtrl) {
+      const emit: TurnEmitter = (event) => {
+        try {
+          streamCtrl.enqueue(encoder.encode(JSON.stringify(event) + '\n'))
+        } catch {
+          // Client disconnected; ignore
+        }
+      }
+
+      const emitRaw = (event: object) => {
+        try {
+          streamCtrl.enqueue(encoder.encode(JSON.stringify(event) + '\n'))
+        } catch {
+          // Client disconnected; ignore
+        }
+      }
+
+      try {
+        const result = isOpening
+          ? await openStory(apiKey, campaign, controller.signal, emit)
+          : await playTurn(apiKey, campaign, action, controller.signal, uid, emit)
+
+        clearTimeout(timeout)
+
+        // Anonymous-first (CLAUDE.md #1). `uid` is null only when there is no
+        // Firebase at all, and that player still gets their turn — they just
+        // apply and store it themselves, exactly as before.
+        if (uid === null) {
+          emitRaw({ type: 'done', result })
+          streamCtrl.close()
+          return
+        }
+
+        // The server folds the turn in and hands back what it saved. Returning
+        // the whole campaign rather than a diff is deliberate: the client
+        // applying its own `applyTurn` to a result is precisely the
+        // client-side authority this issue removes, and two implementations of
+        // that arithmetic is two chances for the sheet and the save file to
+        // disagree. The request is a sentence; it is the response that carries
+        // the story.
+        //
+        // The turn is durable server-side: if the stream connection drops
+        // after a check event and before the done event, the server still
+        // saves the full result here. The client may miss the visual but the
+        // data is preserved.
+        const next = applyTurn(campaign, result, Date.now())
+        try {
+          await saveCampaign(uid, trimToFit(next))
+        } catch (saveError) {
+          // The turn happened and the player is owed it. A failed save reads
+          // as a dropped turn next reload, which is worse than nothing but far
+          // better than throwing away narration the model has already been
+          // paid for.
+          console.error('dicebound turn save failed:', saveError)
+        }
+        emitRaw({ type: 'done', result, campaign: next })
+      } catch (error) {
+        clearTimeout(timeout)
+
+        if (error instanceof RefusedError) {
+          // In voice, and playable — the story continues, it just goes
+          // somewhere else. Breaking character to deliver a policy notice
+          // would be worse for this audience than a locked door.
+          emitRaw({
+            type: 'done',
+            result: {
+              entries: [
+                {
+                  kind: 'narration',
+                  text: 'That thread goes somewhere the story will not follow. The moment passes, and the world waits for you to try something else.',
+                },
+              ],
+            } satisfies TurnResult,
+          })
+        } else {
+          console.error('dicebound turn failed:', error)
+          emitRaw({ type: 'error', message: 'The telling faltered. Try that again.' })
+        }
+      } finally {
+        clearTimeout(timeout)
+        try {
+          streamCtrl.close()
+        } catch {
+          // already closed
+        }
+      }
+    },
+  })
+
+  return new NextResponse(stream, {
+    headers: {
+      'Content-Type': 'application/x-ndjson',
+      'Cache-Control': 'no-cache, no-transform',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  })
 }
 
 /** The first turn: a title and a scene, with no player action to react to. */
 async function openStory(
   apiKey: string,
   campaign: Campaign,
-  signal: AbortSignal
+  signal: AbortSignal,
+  emit: TurnEmitter = noopEmit
 ): Promise<TurnResult> {
   const input = (await callForTool({
     apiKey,
@@ -958,7 +1020,8 @@ async function playTurn(
   campaign: Campaign,
   action: string,
   signal: AbortSignal,
-  uid: string | null
+  uid: string | null,
+  emit: TurnEmitter = noopEmit
 ): Promise<TurnResult> {
   // Condense before building the prompt, so a long campaign sends a bounded
   // window and the synopsis the model reads is already current.
@@ -1203,6 +1266,7 @@ Resolve it, then call narrate with what happens.`,
       const { entry, brief, body: afterBlow } = rollFor(campaign, kit, body, powers, call.input)
       entries.push(entry)
       body = afterBlow
+      emit({ type: 'check', entry })
 
       // Spend one charge per named item that bore on this check.
       const rawInput = (call.input ?? {}) as { items?: unknown }

--- a/src/app/dicebound/api.ts
+++ b/src/app/dicebound/api.ts
@@ -5,7 +5,7 @@
  * and their voice, so there is nothing to do here but carry JSON and turn a
  * non-OK response into a thrown `TurnError` the UI can render in character.
  */
-import type { Campaign } from './domain/campaign'
+import type { Campaign, CheckEntry } from './domain/campaign'
 import type { Character } from './domain/character'
 import type { TurnResult } from './domain/turn'
 
@@ -67,7 +67,8 @@ export interface TurnResponse {
  */
 export async function takeTurn(
   action: string,
-  { token, campaign }: { token: string | null; campaign: Campaign }
+  { token, campaign }: { token: string | null; campaign: Campaign },
+  onCheck?: (entry: CheckEntry) => void
 ): Promise<TurnResponse> {
   const creating = campaign.transcript.length === 0
   const body = token ? (creating ? { action, campaign } : { action }) : { campaign, action }
@@ -85,7 +86,58 @@ export async function takeTurn(
     throw await errorFrom(response, 'The telling faltered. Try that again.')
   }
 
-  return (await response.json()) as TurnResponse
+  // Parse the NDJSON stream. Each line is a JSON event: check, done, or error.
+  if (!response.body) {
+    // Should not happen with the new server, but guard for safety
+    return (await response.json()) as TurnResponse
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let finalResponse: TurnResponse | undefined
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        let event: Record<string, unknown>
+        try {
+          event = JSON.parse(trimmed) as Record<string, unknown>
+        } catch {
+          continue
+        }
+
+        if (event.type === 'check' && onCheck) {
+          onCheck(event.entry as CheckEntry)
+        } else if (event.type === 'done') {
+          finalResponse = {
+            result: event.result as TurnResult,
+            ...(event.campaign ? { campaign: event.campaign as Campaign } : {}),
+          }
+        } else if (event.type === 'error') {
+          throw new TurnError(
+            typeof event.message === 'string' ? event.message : 'The telling faltered. Try that again.'
+          )
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  if (!finalResponse) {
+    throw new TurnError('The telling faltered. Try that again.')
+  }
+  return finalResponse
 }
 
 /**

--- a/src/app/dicebound/store.ts
+++ b/src/app/dicebound/store.ts
@@ -151,7 +151,11 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
       set({ campaign, phase: 'playing' })
 
       const token = await get().backend.token()
-      const { result, campaign: authoritative } = await takeTurn('', { token, campaign })
+      const { result, campaign: authoritative } = await takeTurn('', { token, campaign }, (entry) => {
+        const current = get().campaign
+        if (!current) return
+        set({ campaign: { ...current, transcript: [...current.transcript, entry] } })
+      })
       const opened = authoritative ?? applyTurn(campaign, result, Date.now())
 
       set({ campaign: opened, pending: false })
@@ -196,7 +200,12 @@ export const useDicebound = create<DiceboundState>((set, get) => ({
       // `campaign` here is the pre-optimistic one on purpose. On the local path
       // it is what the result gets applied to, and applying a turn to a
       // campaign that already contains the player's line would record it twice.
-      const { result, campaign: authoritative } = await takeTurn(text, { token, campaign })
+      const { result, campaign: authoritative } = await takeTurn(text, { token, campaign }, (entry) => {
+        // Die card appears immediately as roll_check resolves, mid-turn
+        const current = get().campaign
+        if (!current) return
+        set({ campaign: { ...current, transcript: [...current.transcript, entry] } })
+      })
       const next = authoritative ?? applyTurn(campaign, result, Date.now())
 
       set({ campaign: next, pending: false })


### PR DESCRIPTION
Closes #3770. Not part of #3769.

## Summary

The turn no longer shows a blank wait behind "The dungeon master considers…". Die cards appear the moment `roll_check` resolves — cutting the visible wait roughly in half on turns with checks.

**Architecture:** NDJSON streaming (`Content-Type: application/x-ndjson`).

| Event | When |
|---|---|
| `{"type":"check","entry":{...CheckEntry...}}` | Immediately after each roll resolves |
| `{"type":"done","result":...,"campaign":...}` | After turn is saved (authed) or computed (anon) |
| `{"type":"error","message":"..."}` | If the turn fails after streaming has started |

Pre-stream errors (validation, auth, no API key) still return synchronous `NextResponse.json(...)` — the client handles both shapes.

## What was delivered (required)

- Die card appears mid-turn as soon as `roll_check` resolves
- No partial-JSON prose extraction — `narrate` still waits until the tool call closes (the "wanted" half the issue names as optional if fragile)

## What must not break (verified)

- **Turn loop terminates** — `MAX_CHECKS`, forced `narrate`, fallback narration all unchanged
- **Server stays authoritative** — campaign saved before `done` event; client replaces its state atomically
- **Stream drop durability** — the turn is saved server-side even if the connection drops after a check event; a reconnecting client loads the authoritative campaign
- **Anonymous-first** — anon path emits `{type:'done', result}` with no campaign; still works
- **105s abort stays** — streaming makes the wait tolerable, not faster

## Test plan

- [x] 435 tests across 21 test files — all pass
- [x] `tsc --noEmit | grep dicebound` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)