### PR TITLE
feat(trivia): play existing custom-category questions from the library

### DIFF
--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -28,6 +28,11 @@ export async function GET(request: NextRequest) {
     ? customCategoryParam.trim()
     : null
 
+  // When sampleExistingOnly=1, custom-category runs sample from the existing
+  // question pool instead of generating fresh questions. On exhaustion the
+  // route returns 204 (no new generation).
+  const sampleExistingOnly = searchParams.get('sampleExistingOnly') === '1'
+
   // Parse optional categoryIds (comma-separated). Legacy single
   // ?categoryId= is honored too. Ignored when customCategory is set.
   const categoryIdsParam = searchParams.get('categoryIds')
@@ -42,16 +47,35 @@ export async function GET(request: NextRequest) {
     .filter((n) => !isNaN(n) && n in CATEGORY_META)
 
   try {
-    // Custom category runs always generate fresh questions — no pre-existing
-    // question pool exists for arbitrary topics.
-    let question = customCategory ? null : await sampleNextQuestion({
-      uid: auth.claims.uid,
-      streak: parsedStreak,
-      type: 'free-text',
-      categoryIds,
-    })
+    // When sampleExistingOnly is set with a customCategory: sample from the
+    // existing question pool for that topic. Returns null if exhausted, which
+    // triggers 204 (end the run) rather than generation.
+    // Without sampleExistingOnly: custom category runs always generate fresh
+    // questions (no pre-existing pool to draw from in the normal flow).
+    let question = (customCategory && sampleExistingOnly)
+      ? await sampleNextQuestion({
+          uid: auth.claims.uid,
+          streak: parsedStreak,
+          type: 'free-text',
+          customCategory,
+        })
+      : customCategory
+        ? null  // existing behavior: always generate for custom topics
+        : await sampleNextQuestion({
+            uid: auth.claims.uid,
+            streak: parsedStreak,
+            type: 'free-text',
+            categoryIds,
+          })
 
     if (question === null) {
+      // When playing existing-only from the library, a null sample means the
+      // player has seen all questions for this custom topic — end the run
+      // cleanly without generating new questions.
+      if (customCategory && sampleExistingOnly) {
+        return new NextResponse(null, { status: 204 })
+      }
+
       // Pool exhausted for this player — generate a fresh question on demand,
       // gated by a per-uid rate limit so a single client can't burn the
       // OpenAI budget by hammering /next.

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -25,15 +25,18 @@ interface Props {
   onViewStats?: () => void
   onViewLeaderboard?: () => void
   mode?: InfiniteMode
+  initialCustomCategory?: string | null
+  sampleExistingOnly?: boolean
 }
 
-export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 'scored' }: Props) {
+export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 'scored', initialCustomCategory, sampleExistingOnly = false }: Props) {
   const { user, loading: authLoading } = useAuth()
   const { state, startRun, submitAnswer, nextQuestion, confirmReady, skipQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const timerStartRef = useRef<number>(0)
   const hasStartedRef = useRef(false)
+  const autoStartedRef = useRef(false)
   const [showPreGame, setShowPreGame] = useState(true)
   // Empty set = "All Categories" (no filter). Players toggle individual
   // tiles to build up a multi-category selection.
@@ -55,6 +58,15 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   }))
 
   const { byCategoryId: medalsByCategoryId } = useCategoryMedals()
+
+  // Auto-start when launched from the question library with a custom topic.
+  // Wait for auth to resolve before firing so the run fetch has credentials.
+  useEffect(() => {
+    if (!initialCustomCategory || autoStartedRef.current || authLoading) return
+    autoStartedRef.current = true
+    setShowPreGame(false)
+    startRun(mode === 'practice' ? 'practice' : 'scored', [], initialCustomCategory, sampleExistingOnly)
+  }, [initialCustomCategory, sampleExistingOnly, mode, startRun, authLoading])
 
   const handleStart = useCallback((chosenMode: InfiniteMode) => {
     if (typeof window !== 'undefined') {

--- a/src/app/trivia/components/QuestionLibrary.tsx
+++ b/src/app/trivia/components/QuestionLibrary.tsx
@@ -390,24 +390,56 @@ export function QuestionLibrary({ onBack }: QuestionLibraryProps) {
                 </div>
               </div>
 
-              {/* Custom view: dropdown to pick which custom label. */}
+              {/* Custom view: dropdown to pick which custom label, plus a
+                  "Play this topic" button to start a run from existing
+                  questions for the selected topic. */}
               {view.kind === 'custom' && (
-                <div className="flex items-center gap-1.5">
-                  <label className="text-xs text-on-surface/50 uppercase tracking-widest whitespace-nowrap">
-                    Topic
-                  </label>
-                  <DarkSelect
-                    value={selectedCustomLabel}
-                    onChange={(e) => setSelectedCustomLabel(e.target.value)}
-                    className="max-w-full"
-                  >
-                    {grouped.customLabels.map(({ label, count }) => (
-                      <option key={label} value={label}>
-                        {label} ({count})
-                      </option>
-                    ))}
-                  </DarkSelect>
-                </div>
+                <>
+                  <div className="flex items-center gap-1.5">
+                    <label className="text-xs text-on-surface/50 uppercase tracking-widest whitespace-nowrap">
+                      Topic
+                    </label>
+                    <DarkSelect
+                      value={selectedCustomLabel}
+                      onChange={(e) => setSelectedCustomLabel(e.target.value)}
+                      className="max-w-full"
+                    >
+                      {grouped.customLabels.map(({ label, count }) => (
+                        <option key={label} value={label}>
+                          {label} ({count})
+                        </option>
+                      ))}
+                    </DarkSelect>
+                  </div>
+                  {selectedCustomLabel && (() => {
+                    const selectedCount = grouped.customLabels.find(
+                      ({ label }) => label === selectedCustomLabel
+                    )?.count ?? 0
+                    const tooFew = selectedCount < 5
+                    return (
+                      <div className="flex flex-col gap-1">
+                        {tooFew && selectedCount > 0 && (
+                          <p className="text-xs text-amber-400">
+                            Only {selectedCount} question{selectedCount !== 1 ? 's' : ''} available — more may be generated as others play.
+                          </p>
+                        )}
+                        <ChunkyButton
+                          variant="primary"
+                          disabled={selectedCount === 0}
+                          onClick={() => {
+                            const url = new URL('/trivia/infinite', window.location.origin)
+                            url.searchParams.set('customCategory', selectedCustomLabel)
+                            url.searchParams.set('existing', '1')
+                            window.location.href = url.toString()
+                          }}
+                          className="self-start"
+                        >
+                          ▶ Play {selectedCustomLabel}
+                        </ChunkyButton>
+                      </div>
+                    )
+                  })()}
+                </>
               )}
 
               {/* Tab toggle: All vs Mine */}

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -29,6 +29,8 @@ export interface InfiniteRunState {
   categoryIds: number[]
   // Custom topic for on-the-fly question generation. Mutually exclusive with categoryIds.
   customCategory: string | null
+  // When true, custom-category runs sample from existing questions only (no generation).
+  sampleExistingOnly: boolean
   runId: string | null
   question: InfiniteQuestion | null
   livesRemaining: number
@@ -68,6 +70,7 @@ export function useInfiniteRun() {
     mode: 'scored',
     categoryIds: [],
     customCategory: null,
+    sampleExistingOnly: false,
     runId: null,
     question: null,
     livesRemaining: LIVES_START,
@@ -135,7 +138,7 @@ export function useInfiniteRun() {
     prefetchPromiseRef.current = null
   }, [])
 
-  const startPrefetch = useCallback((streak: number, categoryIds: number[], customCategory: string | null) => {
+  const startPrefetch = useCallback((streak: number, categoryIds: number[], customCategory: string | null, sampleExistingOnly = false) => {
     cancelPrefetch()
     const controller = new AbortController()
     prefetchAbortRef.current = controller
@@ -148,6 +151,7 @@ export function useInfiniteRun() {
         } else if (categoryIds.length > 0) {
           params.set('categoryIds', categoryIds.join(','))
         }
+        if (sampleExistingOnly) params.set('sampleExistingOnly', '1')
         const qRes = await fetch(`/api/v1/trivia/infinite/next?${params.toString()}`, {
           headers,
           signal: controller.signal,
@@ -168,9 +172,9 @@ export function useInfiniteRun() {
     prefetchPromiseRef.current = promise
   }, [cancelPrefetch, getAuthHeaders])
 
-  const startRun = useCallback(async (mode: InfiniteMode = 'scored', categoryIds: number[] = [], customCategory: string | null = null) => {
+  const startRun = useCallback(async (mode: InfiniteMode = 'scored', categoryIds: number[] = [], customCategory: string | null = null, sampleExistingOnly = false) => {
     cancelPrefetch()
-    setState(s => ({ ...s, phase: 'loading', mode, categoryIds, customCategory, error: null }))
+    setState(s => ({ ...s, phase: 'loading', mode, categoryIds, customCategory, sampleExistingOnly, error: null }))
     try {
       const headers = await getAuthHeaders()
       const body: Record<string, unknown> = { mode, categoryIds }
@@ -190,6 +194,7 @@ export function useInfiniteRun() {
       } else if (categoryIds.length > 0) {
         firstParams.set('categoryIds', categoryIds.join(','))
       }
+      if (sampleExistingOnly) firstParams.set('sampleExistingOnly', '1')
       const qRes = await fetch(`/api/v1/trivia/infinite/next?${firstParams.toString()}`, { headers })
       if (qRes.status === 204) {
         setState(s => ({ ...s, phase: 'exhausted', runId: data.runId }))
@@ -210,6 +215,7 @@ export function useInfiniteRun() {
         mode,
         categoryIds,
         customCategory,
+        sampleExistingOnly,
         runId: data.runId,
         question,
         livesRemaining: data.livesRemaining,
@@ -262,7 +268,7 @@ export function useInfiniteRun() {
       // Kick off the next question fetch in the background while the player
       // reads their feedback — only when the run is continuing.
       if (!result.runOver) {
-        startPrefetch(result.currentStreak, state.categoryIds, state.customCategory)
+        startPrefetch(result.currentStreak, state.categoryIds, state.customCategory, state.sampleExistingOnly)
       }
 
       // If this was a correct answer in scored mode, increment the live
@@ -306,7 +312,7 @@ export function useInfiniteRun() {
       console.error('[infinite] submitAnswer failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))
     }
-  }, [state.phase, state.runId, state.question, state.categoryIds, state.customCategory, getAuthHeaders, startPrefetch, cancelPrefetch])
+  }, [state.phase, state.runId, state.question, state.categoryIds, state.customCategory, state.sampleExistingOnly, getAuthHeaders, startPrefetch, cancelPrefetch])
 
   const nextQuestion = useCallback(async () => {
     if (state.phase !== 'answered' || !state.runId) return
@@ -379,6 +385,7 @@ export function useInfiniteRun() {
         } else if (state.categoryIds.length > 0) {
           nextParams.set('categoryIds', state.categoryIds.join(','))
         }
+        if (state.sampleExistingOnly) nextParams.set('sampleExistingOnly', '1')
         const qRes = await fetch(`/api/v1/trivia/infinite/next?${nextParams.toString()}`, { headers })
         if (qRes.status === 204) {
           setState(s => ({ ...s, phase: 'exhausted' }))
@@ -399,7 +406,7 @@ export function useInfiniteRun() {
     } finally {
       nextQuestionInFlightRef.current = false
     }
-  }, [state.phase, state.runId, state.currentStreak, state.categoryIds, state.customCategory, getAuthHeaders, cancelPrefetch, detachPrefetch])
+  }, [state.phase, state.runId, state.currentStreak, state.categoryIds, state.customCategory, state.sampleExistingOnly, getAuthHeaders, cancelPrefetch, detachPrefetch])
 
   // Player clicked "Ready" on the gated loading screen — start the
   // per-question timer now and reveal the question.

--- a/src/app/trivia/infinite/page.tsx
+++ b/src/app/trivia/infinite/page.tsx
@@ -9,12 +9,23 @@ function InfiniteTriviaPageInner() {
   const searchParams = useSearchParams()
   const modeParam = searchParams.get('mode')
   const mode: InfiniteMode = modeParam === 'practice' ? 'practice' : 'scored'
+
+  // Optional custom-category launch from the question library.
+  // ?customCategory=<topic>&existing=1 means "play existing questions for this topic".
+  const customCategoryParam = searchParams.get('customCategory')
+  const initialCustomCategory = customCategoryParam && customCategoryParam.trim().length >= 3
+    ? customCategoryParam.trim()
+    : null
+  const sampleExistingOnly = searchParams.get('existing') === '1'
+
   return (
     <InfiniteGame
       onBack={() => router.push('/trivia')}
       onViewStats={() => router.push('/trivia/stats?tab=infinite')}
       onViewLeaderboard={() => router.push('/trivia/leaderboard?tab=infinite')}
       mode={mode}
+      initialCustomCategory={initialCustomCategory}
+      sampleExistingOnly={sampleExistingOnly}
     />
   )
 }

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -18,6 +18,10 @@ export interface SamplerOptions {
   // List of category ids to draw from. Empty/undefined = all categories.
   // Single-element arrays behave the same as the old single-category mode.
   categoryIds?: number[]
+  // Free-form topic string for custom category runs. Mutually exclusive
+  // with categoryIds — when set, questions are sampled directly from the
+  // aiQuestions collection filtered by this exact category string.
+  customCategory?: string
 }
 
 // Number of candidates to fetch around a random cursor on the all-
@@ -88,10 +92,14 @@ function freshnessWeight(timesShown: number): number {
 
 // Build the base candidate query (status + type + optional category filter).
 // Returned as a Query so callers can layer ordering/cursors on top.
+// When customCategory is set, it takes precedence over categoryIds and the
+// query is filtered by that exact category string (custom topics are stored
+// verbatim in the aiQuestions collection, not mapped to CATEGORY_META ids).
 function buildCandidateQuery(
   db: FirebaseFirestore.Firestore,
   type: 'free-text',
   categoryIds: number[] | undefined,
+  customCategory?: string,
 ): FirebaseFirestore.Query {
   // `status == 'active'` is the flag filter: when any user flags a
   // question, the flag route flips status to 'flagged' atomically with
@@ -102,6 +110,13 @@ function buildCandidateQuery(
     .collection('aiQuestions')
     .where('status', '==', 'active')
     .where('type', '==', type)
+
+  // Custom-category filter: the topic string is stored verbatim on the
+  // question doc; filter by exact match. Mutually exclusive with the
+  // preset categoryIds path below.
+  if (customCategory) {
+    return query.where('category', '==', customCategory)
+  }
 
   // Resolve the optional category filter to category-name strings.
   // Questions are stored with the OpenTDB-prefixed name (e.g.
@@ -236,7 +251,7 @@ function pickFromPool(
 }
 
 export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQuestion | null> {
-  const { uid, streak, type = 'free-text', categoryIds } = options
+  const { uid, streak, type = 'free-text', categoryIds, customCategory } = options
   const normalizedCategoryIds = categoryIds ?? []
   const db = getFirestoreDb()
 
@@ -249,6 +264,21 @@ export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQue
     state = await ensureMigratedTriviaState(uid)
   }
   const seenSet = new Set(state.recentSeen)
+
+  // Custom-category sampling: bypass pool cache, fetch directly.
+  // These pools are small (user-generated per topic) and not worth caching
+  // per-player — a direct query is cheaper than maintaining a per-user
+  // cache keyed on an arbitrary string, and avoids cache-key collisions.
+  if (customCategory) {
+    const query = buildCandidateQuery(db, type, undefined, customCategory)
+    const candidates = await fetchSingleCategoryCandidates(query, SINGLE_CATEGORY_FETCH)
+    const unseen = candidates.filter((q) => !seenSet.has(q.id))
+    const selected = pickFromPool(unseen.map(toPoolEntry), streak)
+    if (!selected) return null
+    const doc = await db.collection('aiQuestions').doc(selected.id).get()
+    if (!doc.exists) return null
+    return { id: doc.id, ...(doc.data() as Omit<AIQuestion, 'id'>) }
+  }
 
   // 2. Decide whether to use the cached unanswered pool or rebuild it.
   //    Rebuild when:


### PR DESCRIPTION
## Summary

- Adds a **"Play this topic"** button to the custom topics view in the question library
- Launches an infinite run that samples only from **existing** questions for that topic — no AI generation
- Shows a low-count warning when fewer than 5 questions are available

## How it works

- `?customCategory=X&existing=1` URL params launch an auto-started run
- A new `sampleExistingOnly` mode in the sampler queries `aiQuestions` filtered by the exact category string, rather than always generating
- When all questions for a topic are exhausted, the run ends naturally (204 → `exhausted` phase) instead of generating new ones

## Test plan

- [ ] Open question library → Custom Topics → pick a topic with 5+ questions → click "Play" → run starts with that topic's existing questions
- [ ] Low-count warning appears when topic has < 5 questions
- [ ] "Play" button is disabled when topic has 0 questions
- [ ] Run ends with "exhausted" screen after seeing all questions in the topic
- [ ] Normal custom-category generation (typing a new topic in infinite mode) is unaffected

Closes #1291

🤖 Generated with [Claude Code](https://claude.com/claude-code)