### PR TITLE
feat(trivia): shareable runs with head-to-head replay

### DIFF
--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -73,8 +73,10 @@ export async function GET(request: NextRequest) {
         return new NextResponse(null, { status: 204 })
       }
 
+      const qData = qSnap.data() as Record<string, unknown>
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { correctAnswer, seed, ...safeQuestion } = { id: qSnap.id, ...(qSnap.data() as Record<string, unknown>) }
+      const { correctAnswer, seed, ...rest } = qData
+      const safeQuestion = { id: qSnap.id, ...rest }
       return NextResponse.json(safeQuestion)
     } catch (err) {
       console.error('[trivia/infinite/next] replay fetch failed:', err)

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -7,6 +7,7 @@ import { saveAIQuestion } from '@/lib/trivia/aiQuestions'
 import { CATEGORY_META } from '@/lib/trivia/categories'
 import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
 import { MAX_GENERATIONS_PER_WINDOW, WINDOW_MS, checkAndIncrementGenerationLimit } from '@/lib/trivia/generationLimit'
+import { getFirestoreDb } from '@/lib/firebase/server'
 import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import { trackExhaustion } from '@/lib/trivia/triviaStats'
 import { warmQuestionPoolForUser } from '@/lib/trivia/warmQuestionPool'
@@ -28,6 +29,9 @@ export async function GET(request: NextRequest) {
     ? customCategoryParam.trim()
     : null
 
+  const replayRunIdParam = searchParams.get('replayRunId')
+  const replayRunId = replayRunIdParam && replayRunIdParam.trim() ? replayRunIdParam.trim() : null
+
   // When sampleExistingOnly=1, custom-category runs sample from the existing
   // question pool instead of generating fresh questions. On exhaustion the
   // route returns 204 (no new generation).
@@ -45,6 +49,38 @@ export async function GET(request: NextRequest) {
   const categoryIds = rawIds
     .map((s) => parseInt(s, 10))
     .filter((n) => !isNaN(n) && n in CATEGORY_META)
+
+  // Replay mode: serve questions in the exact sequence of the original run.
+  // Uses the run doc's replayQuestionIds array, indexed by current answers.length.
+  if (replayRunId) {
+    try {
+      const db = getFirestoreDb()
+      const runRef = db.doc(`users/${auth.claims.uid}/triviaInfinite/${replayRunId}`)
+      const runSnap = await runRef.get()
+      if (!runSnap.exists) return NextResponse.json({ error: 'Replay run not found' }, { status: 404 })
+      const runData = runSnap.data()!
+      const replayQuestionIds: string[] = runData.replayQuestionIds ?? []
+      const position = (runData.answers?.length ?? 0)
+
+      if (position >= replayQuestionIds.length) {
+        return new NextResponse(null, { status: 204 })
+      }
+
+      const questionId = replayQuestionIds[position]
+      const qSnap = await db.collection('aiQuestions').doc(questionId).get()
+      if (!qSnap.exists) {
+        // Question deleted/removed — skip to next one by returning 204 to end naturally
+        return new NextResponse(null, { status: 204 })
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { correctAnswer, seed, ...safeQuestion } = { id: qSnap.id, ...(qSnap.data() as Record<string, unknown>) }
+      return NextResponse.json(safeQuestion)
+    } catch (err) {
+      console.error('[trivia/infinite/next] replay fetch failed:', err)
+      return NextResponse.json({ error: 'Failed to fetch replay question' }, { status: 500 })
+    }
+  }
 
   try {
     // When sampleExistingOnly is set with a customCategory: sample from the

--- a/src/app/api/v1/trivia/infinite/runs/[runId]/public/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/public/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import { getRunByIdPublic } from '@/lib/trivia/infiniteRuns'
+import { CATEGORY_META } from '@/lib/trivia/categories'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ runId: string }> }
+) {
+  const { runId } = await params
+  const result = await getRunByIdPublic(runId)
+  if (!result) return NextResponse.json({ error: 'Run not found' }, { status: 404 })
+
+  const { run } = result
+  // Build a category label
+  let categoryLabel = 'All Categories'
+  if (run.customCategory) {
+    categoryLabel = run.customCategory
+  } else if (run.categoryFilters && run.categoryFilters.length === 1) {
+    categoryLabel = CATEGORY_META[run.categoryFilters[0]]?.name ?? 'Custom'
+  } else if (run.categoryFilters && run.categoryFilters.length > 1) {
+    categoryLabel = `${run.categoryFilters.length} Categories`
+  }
+
+  return NextResponse.json({
+    score: run.score,
+    longestStreak: run.longestStreak,
+    questionsAnswered: run.answers?.length ?? 0,
+    mode: run.mode,
+    categoryLabel,
+  })
+}

--- a/src/app/api/v1/trivia/infinite/runs/[runId]/replay/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/replay/route.ts
@@ -1,0 +1,37 @@
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { NextResponse } from 'next/server'
+import { getRunByIdPublic, startRun } from '@/lib/trivia/infiniteRuns'
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ runId: string }> }
+) {
+  const auth = await verifyRequestAuth(request as import('next/server').NextRequest)
+  if ('error' in auth) return auth.error
+
+  const { runId } = await params
+  const result = await getRunByIdPublic(runId)
+  if (!result) return NextResponse.json({ error: 'Run not found' }, { status: 404 })
+
+  const { run } = result
+  // Need at least 1 answered question to replay
+  if (!run.answers || run.answers.length === 0) {
+    return NextResponse.json({ error: 'Run has no questions to replay' }, { status: 400 })
+  }
+
+  const questionIds = run.answers.map((a) => a.questionId)
+
+  try {
+    const newRun = await startRun(
+      auth.claims.uid,
+      run.mode,
+      run.categoryFilters ?? [],
+      run.customCategory ?? null,
+      { challengeSourceRunId: runId, replayQuestionIds: questionIds }
+    )
+    return NextResponse.json({ replayRunId: newRun.runId, questionsCount: questionIds.length })
+  } catch (err) {
+    console.error('[replay] Failed to create replay run:', err)
+    return NextResponse.json({ error: 'Failed to create replay run' }, { status: 500 })
+  }
+}

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -27,16 +27,19 @@ interface Props {
   mode?: InfiniteMode
   initialCustomCategory?: string | null
   sampleExistingOnly?: boolean
+  replayRunId?: string | null
+  replaySourceRunId?: string | null
 }
 
-export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 'scored', initialCustomCategory, sampleExistingOnly = false }: Props) {
+export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 'scored', initialCustomCategory, sampleExistingOnly = false, replayRunId, replaySourceRunId }: Props) {
   const { user, loading: authLoading } = useAuth()
-  const { state, startRun, submitAnswer, nextQuestion, confirmReady, skipQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
+  const { state, startRun, startReplayRun, submitAnswer, nextQuestion, confirmReady, skipQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const timerStartRef = useRef<number>(0)
   const hasStartedRef = useRef(false)
   const autoStartedRef = useRef(false)
+  const replayStartedRef = useRef(false)
   const [showPreGame, setShowPreGame] = useState(true)
   // Empty set = "All Categories" (no filter). Players toggle individual
   // tiles to build up a multi-category selection.
@@ -67,6 +70,14 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
     setShowPreGame(false)
     startRun(mode === 'practice' ? 'practice' : 'scored', [], initialCustomCategory, sampleExistingOnly)
   }, [initialCustomCategory, sampleExistingOnly, mode, startRun, authLoading])
+
+  // Auto-start when launched from a shared run link (replay mode).
+  useEffect(() => {
+    if (!replayRunId || replayStartedRef.current || authLoading) return
+    replayStartedRef.current = true
+    setShowPreGame(false)
+    startReplayRun(replayRunId, replaySourceRunId ?? '')
+  }, [replayRunId, replaySourceRunId, startReplayRun, authLoading])
 
   const handleStart = useCallback((chosenMode: InfiniteMode) => {
     if (typeof window !== 'undefined') {
@@ -407,7 +418,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
 
   // End of run
   if (state.phase === 'ended') {
-    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} onViewStats={onViewStats} onViewLeaderboard={onViewLeaderboard} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} ratings={ratingsRef.current} />
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} onViewStats={onViewStats} onViewLeaderboard={onViewLeaderboard} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} ratings={ratingsRef.current} replaySourceRunId={state.replaySourceRunId} />
   }
 
   // Playing or answered

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -25,6 +25,7 @@ interface Props {
   runId?: string | null
   onFlagged?: (questionId: string, result: FlagResult) => void
   ratings?: Map<string, 'up' | 'down'>
+  replaySourceRunId?: string | null
 }
 
 function formatTime(ms: number): string {
@@ -44,12 +45,29 @@ const ANSWERS_PAGE_SIZE = 20
 
 type AnswerEntry = InfiniteRunState['answers'][number]
 
-export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, onViewLeaderboard, mode = 'scored', runId, onFlagged, ratings }: Props) {
+export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, onViewLeaderboard, mode = 'scored', runId, onFlagged, ratings, replaySourceRunId }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const [showAllAnswers, setShowAllAnswers] = useState(false)
   const [detailFor, setDetailFor] = useState<AnswerEntry | null>(null)
+
+  const [originalRun, setOriginalRun] = useState<{
+    score: number
+    longestStreak: number
+    questionsAnswered: number
+    categoryLabel: string
+  } | null>(null)
+
+  useEffect(() => {
+    if (!replaySourceRunId) return
+    fetch(`/api/v1/trivia/infinite/runs/${encodeURIComponent(replaySourceRunId)}/public`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data) setOriginalRun(data)
+      })
+      .catch(() => {})
+  }, [replaySourceRunId])
 
   useEffect(() => () => { clearTimeout(copiedTimerRef.current) }, [])
 
@@ -128,6 +146,31 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, on
         <Pill tone="hot" icon="local_fire_department">
           {state.longestStreak} streak!
         </Pill>
+      )}
+
+      {originalRun && (
+        <ChunkyCard variant="surface-variant" className="w-full">
+          <ChunkyCardContent className="pt-4 pb-4">
+            <h3 className="font-headline text-sm text-on-surface/60 uppercase tracking-widest mb-3 text-center">
+              Head to Head
+            </h3>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="text-center">
+                <div className="text-2xl font-bold text-on-surface">{state.score.toLocaleString()}</div>
+                <div className="text-xs text-on-surface/50 mb-1">Your Score</div>
+                <div className="text-sm text-on-surface/70">🔥 {state.longestStreak} streak</div>
+              </div>
+              <div className="text-center opacity-60">
+                <div className="text-2xl font-bold text-on-surface">{originalRun.score.toLocaleString()}</div>
+                <div className="text-xs text-on-surface/50 mb-1">Their Score</div>
+                <div className="text-sm text-on-surface/70">🔥 {originalRun.longestStreak} streak</div>
+              </div>
+            </div>
+            <div className="text-center mt-3 font-headline text-sm">
+              {state.score > originalRun.score ? '🏆 You win!' : state.score < originalRun.score ? 'They win! Better luck next time.' : 'It\'s a tie!'}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
       )}
 
       {/* Per-question breakdown */}

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -31,6 +31,9 @@ export interface InfiniteRunState {
   customCategory: string | null
   // When true, custom-category runs sample from existing questions only (no generation).
   sampleExistingOnly: boolean
+  // Set when playing a replay run (challenge from another player's shared run)
+  replayRunId: string | null
+  replaySourceRunId: string | null
   runId: string | null
   question: InfiniteQuestion | null
   livesRemaining: number
@@ -71,6 +74,8 @@ export function useInfiniteRun() {
     categoryIds: [],
     customCategory: null,
     sampleExistingOnly: false,
+    replayRunId: null,
+    replaySourceRunId: null,
     runId: null,
     question: null,
     livesRemaining: LIVES_START,
@@ -138,7 +143,7 @@ export function useInfiniteRun() {
     prefetchPromiseRef.current = null
   }, [])
 
-  const startPrefetch = useCallback((streak: number, categoryIds: number[], customCategory: string | null, sampleExistingOnly = false) => {
+  const startPrefetch = useCallback((streak: number, categoryIds: number[], customCategory: string | null, sampleExistingOnly = false, replayRunId: string | null = null) => {
     cancelPrefetch()
     const controller = new AbortController()
     prefetchAbortRef.current = controller
@@ -146,7 +151,9 @@ export function useInfiniteRun() {
       try {
         const headers = await getAuthHeaders()
         const params = new URLSearchParams({ streak: String(streak) })
-        if (customCategory) {
+        if (replayRunId) {
+          params.set('replayRunId', replayRunId)
+        } else if (customCategory) {
           params.set('customCategory', customCategory)
         } else if (categoryIds.length > 0) {
           params.set('categoryIds', categoryIds.join(','))
@@ -238,6 +245,47 @@ export function useInfiniteRun() {
     }
   }, [getAuthHeaders, cancelPrefetch])
 
+  const startReplayRun = useCallback(async (replayRunId: string, replaySourceRunId: string) => {
+    cancelPrefetch()
+    setState(s => ({ ...s, phase: 'loading', replayRunId, replaySourceRunId, error: null }))
+    try {
+      const headers = await getAuthHeaders()
+      // Fetch first question
+      const qRes = await fetch(`/api/v1/trivia/infinite/next?replayRunId=${encodeURIComponent(replayRunId)}&streak=0`, { headers })
+      if (qRes.status === 204) {
+        setState(s => ({ ...s, phase: 'exhausted', runId: replayRunId }))
+        return
+      }
+      if (!qRes.ok) throw new Error('Failed to fetch first replay question')
+      const question = await qRes.json()
+
+      setState(s => ({
+        ...s,
+        phase: 'awaiting-ready',
+        runId: replayRunId,
+        replayRunId,
+        replaySourceRunId,
+        question,
+        livesRemaining: LIVES_START,
+        currentStreak: 0,
+        longestStreak: 0,
+        score: 0,
+        questionsAnswered: 0,
+        trailblazes: 0,
+        bonusLivesEarned: 0,
+        skipsRemaining: SKIPS_PER_RUN,
+        skipsUsed: 0,
+        flaggedQuestionIds: [],
+        lastAnswer: null,
+        correctsByCategoryThisRun: {},
+        answers: [],
+      }))
+    } catch (err) {
+      console.error('[infinite] startReplayRun failed:', err)
+      setState(s => ({ ...s, phase: 'error', error: 'Failed to start replay.' }))
+    }
+  }, [getAuthHeaders, cancelPrefetch])
+
   const submitAnswer = useCallback(async (answer: string) => {
     if (state.phase !== 'playing' || !state.runId || !state.question) return
 
@@ -268,7 +316,7 @@ export function useInfiniteRun() {
       // Kick off the next question fetch in the background while the player
       // reads their feedback — only when the run is continuing.
       if (!result.runOver) {
-        startPrefetch(result.currentStreak, state.categoryIds, state.customCategory, state.sampleExistingOnly)
+        startPrefetch(result.currentStreak, state.categoryIds, state.customCategory, state.sampleExistingOnly, state.replayRunId)
       }
 
       // If this was a correct answer in scored mode, increment the live
@@ -312,7 +360,7 @@ export function useInfiniteRun() {
       console.error('[infinite] submitAnswer failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))
     }
-  }, [state.phase, state.runId, state.question, state.categoryIds, state.customCategory, state.sampleExistingOnly, getAuthHeaders, startPrefetch, cancelPrefetch])
+  }, [state.phase, state.runId, state.question, state.categoryIds, state.customCategory, state.sampleExistingOnly, state.replayRunId, getAuthHeaders, startPrefetch, cancelPrefetch])
 
   const nextQuestion = useCallback(async () => {
     if (state.phase !== 'answered' || !state.runId) return
@@ -380,7 +428,9 @@ export function useInfiniteRun() {
       try {
         const headers = await getAuthHeaders()
         const nextParams = new URLSearchParams({ streak: String(state.currentStreak) })
-        if (state.customCategory) {
+        if (state.replayRunId) {
+          nextParams.set('replayRunId', state.replayRunId)
+        } else if (state.customCategory) {
           nextParams.set('customCategory', state.customCategory)
         } else if (state.categoryIds.length > 0) {
           nextParams.set('categoryIds', state.categoryIds.join(','))
@@ -406,7 +456,7 @@ export function useInfiniteRun() {
     } finally {
       nextQuestionInFlightRef.current = false
     }
-  }, [state.phase, state.runId, state.currentStreak, state.categoryIds, state.customCategory, state.sampleExistingOnly, getAuthHeaders, cancelPrefetch, detachPrefetch])
+  }, [state.phase, state.runId, state.currentStreak, state.categoryIds, state.customCategory, state.sampleExistingOnly, state.replayRunId, getAuthHeaders, cancelPrefetch, detachPrefetch])
 
   // Player clicked "Ready" on the gated loading screen — start the
   // per-question timer now and reveal the question.
@@ -524,5 +574,5 @@ export function useInfiniteRun() {
     })
   }, [])
 
-  return { state, startRun, submitAnswer, nextQuestion, confirmReady, skipQuestion, endRun, handleQuestionFlagged }
+  return { state, startRun, startReplayRun, submitAnswer, nextQuestion, confirmReady, skipQuestion, endRun, handleQuestionFlagged }
 }

--- a/src/app/trivia/infinite/page.tsx
+++ b/src/app/trivia/infinite/page.tsx
@@ -18,6 +18,11 @@ function InfiniteTriviaPageInner() {
     : null
   const sampleExistingOnly = searchParams.get('existing') === '1'
 
+  const replayRunIdParam = searchParams.get('replayRunId')
+  const replayRunId = replayRunIdParam && replayRunIdParam.trim() ? replayRunIdParam.trim() : null
+  const replaySourceRunIdParam = searchParams.get('replaySourceRunId')
+  const replaySourceRunId = replaySourceRunIdParam && replaySourceRunIdParam.trim() ? replaySourceRunIdParam.trim() : null
+
   return (
     <InfiniteGame
       onBack={() => router.push('/trivia')}
@@ -26,6 +31,8 @@ function InfiniteTriviaPageInner() {
       mode={mode}
       initialCustomCategory={initialCustomCategory}
       sampleExistingOnly={sampleExistingOnly}
+      replayRunId={replayRunId}
+      replaySourceRunId={replaySourceRunId}
     />
   )
 }

--- a/src/app/trivia/runs/[runId]/RunSharePage.tsx
+++ b/src/app/trivia/runs/[runId]/RunSharePage.tsx
@@ -1,28 +1,59 @@
 'use client'
+import { useState } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { Pill } from '@/components/ui/pill'
 
 interface RunData {
+  runId: string
   longestStreak: number
   score: number
   questionsAnswered: number
   trailblazes: number
   mode: 'scored' | 'practice'
+  categoryLabel: string
 }
 
 export function RunSharePage({ run }: { run: RunData }) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handlePlayThisRun = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/v1/trivia/infinite/runs/${run.runId}/replay`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error ?? 'Failed to start replay')
+      }
+      const data = await res.json()
+      window.location.href = `/trivia/infinite?replayRunId=${encodeURIComponent(data.replayRunId)}&replaySourceRunId=${encodeURIComponent(run.runId)}`
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong')
+      setLoading(false)
+    }
+  }
+
   return (
     <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-10 px-4">
       <div className="text-center">
         <h1 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-2">
           CometCave Trivia
         </h1>
-        <p className="text-on-surface/50 text-sm">A traveler completed this run</p>
+        <p className="text-on-surface/50 text-sm">A traveler completed this run — can you beat them?</p>
       </div>
 
       <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
         <ChunkyCardContent className="pt-6">
+          {run.categoryLabel && (
+            <div className="flex justify-center mb-3">
+              <Pill tone="info" size="sm">{run.categoryLabel}</Pill>
+            </div>
+          )}
           <div className="text-center mb-4">
             <div className="text-6xl font-bold text-ds-tertiary">
               🔥 {run.longestStreak}
@@ -53,13 +84,26 @@ export function RunSharePage({ run }: { run: RunData }) {
         </ChunkyCardContent>
       </ChunkyCard>
 
+      {error && (
+        <p className="text-error text-sm text-center">{error}</p>
+      )}
+
       <ChunkyButton
         variant="primary"
         size="hero"
         className="w-full"
+        onClick={handlePlayThisRun}
+        disabled={loading}
+      >
+        {loading ? 'Starting…' : `Play this run (${run.questionsAnswered} questions)`}
+      </ChunkyButton>
+
+      <ChunkyButton
+        variant="secondary"
+        className="w-full"
         onClick={() => window.location.href = '/trivia'}
       >
-        Play Now
+        Play a New Run
       </ChunkyButton>
 
       <p className="text-on-surface/30 text-xs text-center">

--- a/src/app/trivia/runs/[runId]/page.tsx
+++ b/src/app/trivia/runs/[runId]/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { getRunByIdPublic } from '@/lib/trivia/infiniteRuns'
+import { CATEGORY_META } from '@/lib/trivia/categories'
 import { RunSharePage } from './RunSharePage'
 
 interface PageProps {
@@ -36,11 +37,23 @@ export default async function Page({ params }: PageProps) {
   const result = await getRunByIdPublic(runId)
   if (!result) notFound()
   const { run } = result
+
+  let categoryLabel = ''
+  if (run.customCategory) {
+    categoryLabel = run.customCategory
+  } else if (run.categoryFilters && run.categoryFilters.length === 1) {
+    categoryLabel = CATEGORY_META[run.categoryFilters[0]]?.name ?? ''
+  } else if (run.categoryFilters && run.categoryFilters.length > 1) {
+    categoryLabel = `${run.categoryFilters.length} Categories`
+  }
+
   return <RunSharePage run={{
+    runId,
     longestStreak: run.longestStreak,
     score: run.score,
     questionsAnswered: run.answers.length,
     trailblazes: run.trailblazes,
     mode: run.mode,
+    categoryLabel,
   }} />
 }

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -27,6 +27,10 @@ export interface RunDoc {
   // When set, the run generates questions about this custom topic on-the-fly.
   // Mutually exclusive with categoryFilters (stored as [] when customCategory is set).
   customCategory?: string | null
+  // Set on replay runs to link back to the original shared run
+  challengeSourceRunId?: string
+  // Ordered question IDs for replay mode (set on replay runs only)
+  replayQuestionIds?: string[]
   score: number
   livesRemaining: number
   currentStreak: number
@@ -53,7 +57,8 @@ export async function startRun(
   uid: string,
   mode: 'scored' | 'practice' = 'scored',
   categoryIds: number[] = [],
-  customCategory?: string | null
+  customCategory?: string | null,
+  opts?: { challengeSourceRunId?: string; replayQuestionIds?: string[] }
 ): Promise<{ runId: string; livesRemaining: number; currentStreak: number }> {
   const db = getFirestoreDb()
   const runRef = db.collection(`users/${uid}/triviaInfinite`).doc()
@@ -80,6 +85,8 @@ export async function startRun(
   if (customCategory) {
     docData.customCategory = customCategory
   }
+  if (opts?.challengeSourceRunId) docData.challengeSourceRunId = opts.challengeSourceRunId
+  if (opts?.replayQuestionIds) docData.replayQuestionIds = opts.replayQuestionIds
   await runRef.set(docData)
   return { runId: runRef.id, livesRemaining: LIVES_START, currentStreak: 0 }
 }


### PR DESCRIPTION
## Summary

- Players can share a run link after finishing; recipients play the **exact same questions in the same order**
- After the replay finishes, a **"Head to Head" card** shows both scores and declares a winner
- Share page now shows category label, question count, and challenge framing ("can you beat them?")

## How it works

1. `POST /runs/[runId]/replay` — creates a new run with the original's question IDs stored as `replayQuestionIds`
2. `GET /next?replayRunId=<id>` — serves questions from `replayQuestionIds[answers.length]` instead of sampling; 204 when sequence ends
3. `GET /runs/[runId]/public` — unauthenticated endpoint for fetching original run stats for the comparison card
4. `InfiniteGame` accepts `replayRunId` + `replaySourceRunId` URL params and auto-starts the replay
5. `InfiniteRunSummary` fetches the original run stats and renders the comparison card

## Test plan

- [ ] Finish a run → share link copied to clipboard includes URL
- [ ] Open share link → see rival's stats + "Play this run (N questions)" button
- [ ] Click play → auto-starts with the same questions in the same order
- [ ] After finishing replay → "Head to Head" card shows both scores, correct winner declared
- [ ] Share page shows category label (custom topic, single category, or "All Categories")
- [ ] Anonymous users can play a replay (no sign-in required)
- [ ] Normal (non-replay) runs are unaffected

Closes #1290

🤖 Generated with [Claude Code](https://claude.com/claude-code)