### PR TITLE
feat(trivia): automated daily question pre-generation via cron endpoint

### DIFF
--- a/src/app/api/v1/trivia/daily/generate/route.ts
+++ b/src/app/api/v1/trivia/daily/generate/route.ts
@@ -1,0 +1,65 @@
+// POST /api/v1/trivia/daily/generate?lookahead=N
+// Protected by Authorization: Bearer DAILY_TRIVIA_CRON_SECRET env var
+// Generates questions for today + next N days, skipping dates already in Firestore
+// Returns { generated: string[], skipped: string[], failed: string[] }
+
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { getTodayPST } from '@/lib/dates'
+import { getDailyQuestions, setDailyQuestions } from '@/lib/trivia/dailyQuestionsDb'
+import { daysSinceEpoch, generateQuestionsForDate } from '@/lib/trivia/generateDailyQuestions'
+
+export const maxDuration = 300 // generation can take a while
+
+export async function POST(request: NextRequest) {
+  // Auth: Bearer token from env var
+  const secret = process.env.DAILY_TRIVIA_CRON_SECRET
+  if (!secret) {
+    return NextResponse.json({ error: 'DAILY_TRIVIA_CRON_SECRET not configured' }, { status: 500 })
+  }
+  const auth = request.headers.get('Authorization')
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const lookahead = Math.min(parseInt(searchParams.get('lookahead') ?? '2', 10), 7)
+
+  const today = getTodayPST()
+  const dates = Array.from({ length: lookahead + 1 }, (_, i) => {
+    const d = new Date(today + 'T12:00:00Z')
+    d.setUTCDate(d.getUTCDate() + i)
+    return d.toISOString().split('T')[0]
+  })
+
+  const generated: string[] = []
+  const skipped: string[] = []
+  const failed: string[] = []
+
+  for (const dateStr of dates) {
+    const existing = await getDailyQuestions(dateStr)
+    if (existing && existing.questions.length > 0) {
+      skipped.push(dateStr)
+      continue
+    }
+    try {
+      const questions = await generateQuestionsForDate(dateStr)
+      if (questions.length === 0) throw new Error('No questions generated')
+      const days = daysSinceEpoch(dateStr)
+      const categoryId = 9 + (days % 24)
+      await setDailyQuestions(dateStr, {
+        date: dateStr,
+        categoryId,
+        categoryName: questions[0]?.category ?? 'General Knowledge',
+        questions,
+      })
+      generated.push(dateStr)
+    } catch (err) {
+      console.error(`[trivia/daily/generate] Failed for ${dateStr}:`, err)
+      failed.push(dateStr)
+    }
+  }
+
+  console.log('[trivia/daily/generate] completed', { generated, skipped, failed })
+  return NextResponse.json({ generated, skipped, failed })
+}

--- a/src/app/api/v1/trivia/daily/route.ts
+++ b/src/app/api/v1/trivia/daily/route.ts
@@ -1,44 +1,22 @@
-import { createOpenAI } from '@ai-sdk/openai'
-import { generateObject } from 'ai'
 import { NextResponse } from 'next/server'
-import { z } from 'zod'
 
 import { dailyCache } from '@/app/trivia/lib/questionCache'
-import type { TriviaQuestion, TriviaQuestionWithAnswer } from '@/app/trivia/models/questions'
+import type { TriviaQuestion } from '@/app/trivia/models/questions'
 import { getTodayPST } from '@/lib/dates'
 import { getDailyQuestions, setDailyQuestions } from '@/lib/trivia/dailyQuestionsDb'
+import {
+  daysSinceEpoch,
+  fetchOpenTDBQuestions,
+  generateAIQuestion,
+  generateFallbackQuestions,
+} from '@/lib/trivia/generateDailyQuestions'
 
 import type { NextRequest } from 'next/server'
 
 // Re-export dailyCache so check-answer route can import it
 export { dailyCache }
 
-// HTML entity decoder
-function decodeHTML(html: string): string {
-  const entities: Record<string, string> = {
-    '&amp;': '&',
-    '&lt;': '<',
-    '&gt;': '>',
-    '&quot;': '"',
-    '&#039;': "'",
-    '&apos;': "'",
-    '&eacute;': 'é',
-    '&ouml;': 'ö',
-    '&uuml;': 'ü',
-    '&ntilde;': 'ñ',
-    '&rsquo;': "'",
-    '&lsquo;': "'",
-    '&rdquo;': '"',
-    '&ldquo;': '"',
-    '&hellip;': '…',
-    '&ndash;': '–',
-    '&mdash;': '—',
-    '&shy;': '',
-  }
-  return html.replace(/&[#\w]+;/g, (match) => entities[match] ?? match)
-}
-
-// Shuffle array deterministically using a seed
+// Shuffle array deterministically using a seed (kept inline for the fallback path in this route)
 function seededShuffle<T>(array: T[], seed: number): T[] {
   const result = [...array]
   let s = seed
@@ -48,205 +26,6 @@ function seededShuffle<T>(array: T[], seed: number): T[] {
     ;[result[i], result[j]] = [result[j], result[i]]
   }
   return result
-}
-
-// Calculate days since epoch for category rotation
-function daysSinceEpoch(dateStr: string): number {
-  const d = new Date(dateStr + 'T12:00:00-08:00')
-  return Math.floor(d.getTime() / 86400000)
-}
-
-interface OpenTDBQuestion {
-  category: string
-  type: string
-  difficulty: string
-  question: string
-  correct_answer: string
-  incorrect_answers: string[]
-}
-
-interface OpenTDBResponse {
-  response_code: number
-  results: OpenTDBQuestion[]
-}
-
-async function fetchOpenTDBQuestions(dateStr: string): Promise<TriviaQuestionWithAnswer[]> {
-  const days = daysSinceEpoch(dateStr)
-  const categoryId = 9 + (days % 24)
-
-  // Fetch 6 questions: 3 easy, 2 medium, 1 hard
-  // OpenTDB can be flaky, so we'll do separate calls per difficulty with fallbacks
-  const difficulties: Array<{ difficulty: string; count: number }> = [
-    { difficulty: 'easy', count: 3 },
-    { difficulty: 'medium', count: 2 },
-    { difficulty: 'hard', count: 1 },
-  ]
-
-  const questions: TriviaQuestionWithAnswer[] = []
-
-  for (let idx = 0; idx < difficulties.length; idx++) {
-    const { difficulty, count } = difficulties[idx]
-    try {
-      const url = `https://opentdb.com/api.php?amount=${count}&category=${categoryId}&difficulty=${difficulty}&type=multiple`
-      const res = await fetch(url)
-      if (!res.ok) throw new Error(`OpenTDB API error: ${res.status}`)
-      const data: OpenTDBResponse = await res.json()
-
-      if (data.response_code === 0 && data.results.length > 0) {
-        for (const q of data.results) {
-          const seed = days * 1000 + questions.length
-          const options = seededShuffle(
-            [q.correct_answer, ...q.incorrect_answers].map(decodeHTML),
-            seed
-          )
-
-          questions.push({
-            id: `opentdb-${dateStr}-${questions.length}`,
-            question: decodeHTML(q.question),
-            options,
-            difficulty: difficulty as 'easy' | 'medium' | 'hard',
-            category: decodeHTML(q.category),
-            source: 'opentdb',
-            correctAnswer: decodeHTML(q.correct_answer),
-          })
-        }
-      }
-
-      // Rate limit: wait between requests
-      if (idx < difficulties.length - 1) {
-        await new Promise((r) => setTimeout(r, 1000))
-      }
-    } catch (error) {
-      console.error(`Failed to fetch ${difficulty} questions from OpenTDB:`, error)
-    }
-  }
-
-  return questions
-}
-
-async function generateAIQuestion(
-  dateStr: string,
-  category: string,
-  apiKey: string
-): Promise<TriviaQuestionWithAnswer> {
-  const days = daysSinceEpoch(dateStr)
-
-  const topics = [
-    'Science',
-    'History',
-    'Geography',
-    'Literature',
-    'Art',
-    'Music',
-    'Film',
-    'Technology',
-    'Nature',
-    'Space',
-    'Philosophy',
-    'Mathematics',
-    'Language',
-    'Sports',
-    'Food',
-    'Architecture',
-    'Psychology',
-    'Economics',
-    'Medicine',
-    'Mythology',
-  ]
-  const topic = topics[days % topics.length]
-
-  const openaiClient = createOpenAI({ apiKey })
-
-  const AIQuestionSchema = z.object({
-    question: z.string().describe('An interesting, challenging trivia question'),
-    correctAnswer: z.string().describe('The correct answer (short, 1-5 words)'),
-    explanation: z.string().describe('Brief explanation of why this is the answer'),
-  })
-
-  const result = await generateObject({
-    model: openaiClient('gpt-4o-mini'),
-    schema: AIQuestionSchema,
-    prompt: `Generate a unique, challenging trivia question about ${topic}.
-The question should be thought-provoking and have a specific, concise answer (1-5 words).
-Today's date is ${dateStr} — use it as a seed for uniqueness.
-Related category context: ${category}.
-Make it interesting and educational.`,
-    temperature: 0.7,
-    maxTokens: 300,
-  })
-
-  return {
-    id: `ai-${dateStr}-0`,
-    question: result.object.question,
-    options: null,
-    difficulty: 'hard',
-    category: topic,
-    source: 'ai',
-    correctAnswer: result.object.correctAnswer,
-    explanation: result.object.explanation,
-  }
-}
-
-async function generateFallbackQuestions(
-  dateStr: string,
-  needed: number,
-  apiKey: string
-): Promise<TriviaQuestionWithAnswer[]> {
-  const days = daysSinceEpoch(dateStr)
-  const openaiClient = createOpenAI({ apiKey })
-
-  const difficultyMap = ['easy', 'easy', 'easy', 'medium', 'medium', 'hard'] as const
-  const questions: TriviaQuestionWithAnswer[] = []
-
-  for (let i = 0; i < needed; i++) {
-    const diff = difficultyMap[i] || 'medium'
-    const topics = [
-      'Science',
-      'History',
-      'Geography',
-      'Literature',
-      'Art',
-      'Music',
-      'Film',
-      'Technology',
-      'Nature',
-      'Space',
-    ]
-    const topic = topics[(days + i) % topics.length]
-
-    const schema = z.object({
-      question: z.string(),
-      correctAnswer: z.string(),
-      wrongAnswers: z.array(z.string()).length(3),
-      category: z.string(),
-    })
-
-    const result = await generateObject({
-      model: openaiClient('gpt-4o-mini'),
-      schema,
-      prompt: `Generate a ${diff} multiple choice trivia question about ${topic}. Date seed: ${dateStr}-${i}. Give exactly 3 wrong answers.`,
-      temperature: 0.7,
-      maxTokens: 300,
-    })
-
-    const seed = days * 1000 + questions.length
-    const options = seededShuffle(
-      [result.object.correctAnswer, ...result.object.wrongAnswers],
-      seed
-    )
-
-    questions.push({
-      id: `ai-fallback-${dateStr}-${i}`,
-      question: result.object.question,
-      options,
-      difficulty: diff,
-      category: result.object.category,
-      source: 'ai',
-      correctAnswer: result.object.correctAnswer,
-    })
-  }
-
-  return questions
 }
 
 export async function GET(request: NextRequest) {

--- a/src/lib/trivia/generateDailyQuestions.ts
+++ b/src/lib/trivia/generateDailyQuestions.ts
@@ -1,0 +1,282 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObject } from 'ai'
+import { z } from 'zod'
+
+import type { TriviaQuestionWithAnswer } from '@/app/trivia/models/questions'
+
+// HTML entity decoder
+function decodeHTML(html: string): string {
+  const entities: Record<string, string> = {
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&#039;': "'",
+    '&apos;': "'",
+    '&eacute;': 'é',
+    '&ouml;': 'ö',
+    '&uuml;': 'ü',
+    '&ntilde;': 'ñ',
+    '&rsquo;': "'",
+    '&lsquo;': "'",
+    '&rdquo;': '"',
+    '&ldquo;': '"',
+    '&hellip;': '…',
+    '&ndash;': '–',
+    '&mdash;': '—',
+    '&shy;': '',
+  }
+  return html.replace(/&[#\w]+;/g, (match) => entities[match] ?? match)
+}
+
+// Shuffle array deterministically using a seed
+function seededShuffle<T>(array: T[], seed: number): T[] {
+  const result = [...array]
+  let s = seed
+  for (let i = result.length - 1; i > 0; i--) {
+    s = (s * 1103515245 + 12345) & 0x7fffffff
+    const j = s % (i + 1)
+    ;[result[i], result[j]] = [result[j], result[i]]
+  }
+  return result
+}
+
+// Calculate days since epoch for category rotation
+export function daysSinceEpoch(dateStr: string): number {
+  const d = new Date(dateStr + 'T12:00:00-08:00')
+  return Math.floor(d.getTime() / 86400000)
+}
+
+interface OpenTDBQuestion {
+  category: string
+  type: string
+  difficulty: string
+  question: string
+  correct_answer: string
+  incorrect_answers: string[]
+}
+
+interface OpenTDBResponse {
+  response_code: number
+  results: OpenTDBQuestion[]
+}
+
+export async function fetchOpenTDBQuestions(dateStr: string): Promise<TriviaQuestionWithAnswer[]> {
+  const days = daysSinceEpoch(dateStr)
+  const categoryId = 9 + (days % 24)
+
+  // Fetch 6 questions: 3 easy, 2 medium, 1 hard
+  // OpenTDB can be flaky, so we'll do separate calls per difficulty with fallbacks
+  const difficulties: Array<{ difficulty: string; count: number }> = [
+    { difficulty: 'easy', count: 3 },
+    { difficulty: 'medium', count: 2 },
+    { difficulty: 'hard', count: 1 },
+  ]
+
+  const questions: TriviaQuestionWithAnswer[] = []
+
+  for (let idx = 0; idx < difficulties.length; idx++) {
+    const { difficulty, count } = difficulties[idx]
+    try {
+      const url = `https://opentdb.com/api.php?amount=${count}&category=${categoryId}&difficulty=${difficulty}&type=multiple`
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`OpenTDB API error: ${res.status}`)
+      const data: OpenTDBResponse = await res.json()
+
+      if (data.response_code === 0 && data.results.length > 0) {
+        for (const q of data.results) {
+          const seed = days * 1000 + questions.length
+          const options = seededShuffle(
+            [q.correct_answer, ...q.incorrect_answers].map(decodeHTML),
+            seed
+          )
+
+          questions.push({
+            id: `opentdb-${dateStr}-${questions.length}`,
+            question: decodeHTML(q.question),
+            options,
+            difficulty: difficulty as 'easy' | 'medium' | 'hard',
+            category: decodeHTML(q.category),
+            source: 'opentdb',
+            correctAnswer: decodeHTML(q.correct_answer),
+          })
+        }
+      }
+
+      // Rate limit: wait between requests
+      if (idx < difficulties.length - 1) {
+        await new Promise((r) => setTimeout(r, 1000))
+      }
+    } catch (error) {
+      console.error(`Failed to fetch ${difficulty} questions from OpenTDB:`, error)
+    }
+  }
+
+  return questions
+}
+
+export async function generateAIQuestion(
+  dateStr: string,
+  category: string,
+  apiKey: string
+): Promise<TriviaQuestionWithAnswer> {
+  const days = daysSinceEpoch(dateStr)
+
+  const topics = [
+    'Science',
+    'History',
+    'Geography',
+    'Literature',
+    'Art',
+    'Music',
+    'Film',
+    'Technology',
+    'Nature',
+    'Space',
+    'Philosophy',
+    'Mathematics',
+    'Language',
+    'Sports',
+    'Food',
+    'Architecture',
+    'Psychology',
+    'Economics',
+    'Medicine',
+    'Mythology',
+  ]
+  const topic = topics[days % topics.length]
+
+  const openaiClient = createOpenAI({ apiKey })
+
+  const AIQuestionSchema = z.object({
+    question: z.string().describe('An interesting, challenging trivia question'),
+    correctAnswer: z.string().describe('The correct answer (short, 1-5 words)'),
+    explanation: z.string().describe('Brief explanation of why this is the answer'),
+  })
+
+  const result = await generateObject({
+    model: openaiClient('gpt-4o-mini'),
+    schema: AIQuestionSchema,
+    prompt: `Generate a unique, challenging trivia question about ${topic}.
+The question should be thought-provoking and have a specific, concise answer (1-5 words).
+Today's date is ${dateStr} — use it as a seed for uniqueness.
+Related category context: ${category}.
+Make it interesting and educational.`,
+    temperature: 0.7,
+    maxTokens: 300,
+  })
+
+  return {
+    id: `ai-${dateStr}-0`,
+    question: result.object.question,
+    options: null,
+    difficulty: 'hard',
+    category: topic,
+    source: 'ai',
+    correctAnswer: result.object.correctAnswer,
+    explanation: result.object.explanation,
+  }
+}
+
+export async function generateFallbackQuestions(
+  dateStr: string,
+  needed: number,
+  apiKey: string
+): Promise<TriviaQuestionWithAnswer[]> {
+  const days = daysSinceEpoch(dateStr)
+  const openaiClient = createOpenAI({ apiKey })
+
+  const difficultyMap = ['easy', 'easy', 'easy', 'medium', 'medium', 'hard'] as const
+  const questions: TriviaQuestionWithAnswer[] = []
+
+  for (let i = 0; i < needed; i++) {
+    const diff = difficultyMap[i] || 'medium'
+    const topics = [
+      'Science',
+      'History',
+      'Geography',
+      'Literature',
+      'Art',
+      'Music',
+      'Film',
+      'Technology',
+      'Nature',
+      'Space',
+    ]
+    const topic = topics[(days + i) % topics.length]
+
+    const schema = z.object({
+      question: z.string(),
+      correctAnswer: z.string(),
+      wrongAnswers: z.array(z.string()).length(3),
+      category: z.string(),
+    })
+
+    const result = await generateObject({
+      model: openaiClient('gpt-4o-mini'),
+      schema,
+      prompt: `Generate a ${diff} multiple choice trivia question about ${topic}. Date seed: ${dateStr}-${i}. Give exactly 3 wrong answers.`,
+      temperature: 0.7,
+      maxTokens: 300,
+    })
+
+    const seed = days * 1000 + questions.length
+    const options = seededShuffle(
+      [result.object.correctAnswer, ...result.object.wrongAnswers],
+      seed
+    )
+
+    questions.push({
+      id: `ai-fallback-${dateStr}-${i}`,
+      question: result.object.question,
+      options,
+      difficulty: diff,
+      category: result.object.category,
+      source: 'ai',
+      correctAnswer: result.object.correctAnswer,
+    })
+  }
+
+  return questions
+}
+
+export async function generateQuestionsForDate(
+  dateStr: string
+): Promise<TriviaQuestionWithAnswer[]> {
+  const apiKey = process.env.OPENAI_API_KEY
+
+  // Fetch OpenTDB questions
+  let opentdbQuestions = await fetchOpenTDBQuestions(dateStr)
+
+  // If OpenTDB failed or returned too few, use AI fallback
+  if (opentdbQuestions.length < 6 && apiKey) {
+    const fallbacks = await generateFallbackQuestions(
+      dateStr,
+      6 - opentdbQuestions.length,
+      apiKey
+    )
+    opentdbQuestions = [...opentdbQuestions, ...fallbacks]
+  }
+
+  // Generate AI question
+  let allQuestions = [...opentdbQuestions]
+  if (apiKey) {
+    try {
+      const aiQuestion = await generateAIQuestion(
+        dateStr,
+        opentdbQuestions[0]?.category || 'General Knowledge',
+        apiKey
+      )
+      allQuestions.push(aiQuestion)
+    } catch (error) {
+      console.error('Failed to generate AI question:', error)
+      // Continue without AI question
+    }
+  }
+
+  // Shuffle question order deterministically
+  const seed = daysSinceEpoch(dateStr)
+  allQuestions = seededShuffle(allQuestions, seed)
+
+  return allQuestions
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/trivia/daily/generate?lookahead=N` cron endpoint (Bearer-token protected)
- Adds `.github/workflows/generate-daily-trivia.yml` running nightly at 23:55 PST (see setup note below)
- Extracts shared generation helpers into `src/lib/trivia/generateDailyQuestions.ts`

## Setup required

Two secrets must be configured for this to work:
- **Vercel**: Add `DAILY_TRIVIA_CRON_SECRET=<random-string>` to environment variables
- **GitHub**: Add `DAILY_TRIVIA_CRON_SECRET=<same-string>` to repository secrets (`Settings → Secrets → Actions`)

### Note on workflow file
The GitHub Actions workflow file (`.github/workflows/generate-daily-trivia.yml`) was created locally but could not be pushed via the automation token (which lacks `workflow` scope). To add it, you can:
1. Push the pending commit manually: `git push origin feat/trivia-daily-cron` from a terminal with a token that has `workflow` scope, OR
2. Create the workflow file directly via the GitHub UI in Settings → Actions

The workflow content is:
```yaml
name: Generate Daily Trivia

on:
  schedule:
    - cron: '55 7 * * *'   # 23:55 UTC-8 (PST) = 07:55 UTC
  workflow_dispatch:         # allow manual trigger

jobs:
  generate:
    runs-on: ubuntu-latest
    timeout-minutes: 10
    steps:
      - name: Pre-generate trivia questions (today + tomorrow)
        env:
          CRON_SECRET: ${{ secrets.DAILY_TRIVIA_CRON_SECRET }}
          SITE_URL: https://comet-cave.vercel.app
        run: |
          RESPONSE=$(curl -s -o /tmp/response.json -w "%{http_code}" \
            -X POST "${SITE_URL}/api/v1/trivia/daily/generate?lookahead=2" \
            -H "Authorization: Bearer ${CRON_SECRET}" \
            -H "Content-Type: application/json")
          BODY=$(cat /tmp/response.json)
          echo "HTTP Status: ${RESPONSE}"
          echo "Response: ${BODY}"
          if [ "${RESPONSE}" != "200" ]; then
            echo "::error::Generation failed with HTTP ${RESPONSE}"
            exit 1
          fi
```

## How it works

The nightly cron calls the generate endpoint for today + 2 days ahead. Dates already in Firestore are skipped (idempotent). On failure, the existing lazy-generation fallback in `GET /api/v1/trivia/daily` still kicks in.

## Test plan

- [ ] `POST /api/v1/trivia/daily/generate?lookahead=0` with correct token → returns `{ generated: [today], skipped: [], failed: [] }` (or `skipped` if already generated)
- [ ] Same call without token → 401
- [ ] Already-generated date → skipped, not re-generated
- [ ] GitHub Actions workflow_dispatch trigger → runs successfully

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)