### PR TITLE
feat(tap-tap-adventure): LLM-generated quest flavor text

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/quest/generate/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/quest/generate/route.ts
@@ -1,0 +1,89 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObject } from 'ai'
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { FantasyCharacterSchema } from '@/app/tap-tap-adventure/models/character'
+import { generateTimedQuest } from '@/app/tap-tap-adventure/lib/questGenerator'
+
+export const maxDuration = 30
+
+export async function POST(request: NextRequest) {
+  let character: unknown
+
+  try {
+    const body = await request.json()
+    character = body.character
+
+    const parseResult = FantasyCharacterSchema.safeParse(character)
+    if (!parseResult.success) {
+      return NextResponse.json({ error: 'Invalid character data' }, { status: 400 })
+    }
+
+    const validatedCharacter = parseResult.data
+
+    // Generate mechanical quest (synchronous, no LLM)
+    const quest = generateTimedQuest(validatedCharacter)
+
+    // Enhance with LLM narrative
+    const apiKey = process.env.OPENAI_API_KEY
+    if (!apiKey) {
+      // No API key configured — return static quest
+      return NextResponse.json(quest)
+    }
+
+    const openaiClient = createOpenAI({ apiKey })
+
+    const region = validatedCharacter.currentRegion ?? 'unknown lands'
+    const className = validatedCharacter.class ?? 'adventurer'
+
+    const QuestNarrativeSchema = z.object({
+      title: z.string().max(60).describe('Short atmospheric quest title (max 8 words)'),
+      description: z.string().max(200).describe('1-2 sentence quest description in cosmic-narrator voice'),
+    })
+
+    const result = await generateObject({
+      model: openaiClient('gpt-4o-mini'),
+      schema: QuestNarrativeSchema,
+      prompt: `You are the cosmic narrator of a surreal fantasy adventure game. Rewrite this quest notice board posting in your voice — mysterious, poetic, intelligent.
+
+Character: Level ${validatedCharacter.level} ${className} in ${region}
+Quest type: ${quest.type}
+Mechanical goal: ${quest.description}
+
+Write a short title (max 8 words) and 1-2 sentence description that:
+- Captures the essence of the quest mechanically (the player needs to know WHAT to do)
+- Uses cosmic-narrator voice (surreal, specific, evocative — not generic fantasy clichés)
+- Feels like it came from the notice board of a strange, knowing universe
+- Does NOT say "cosmic" or "surreal" or break the fourth wall
+
+Examples of the voice:
+- "The road demands km 300. The road remembers every step."
+- "Seven lairs. Seven endings. The cave is keeping score."
+- "Gold doesn't care who holds it, but the merchants here remember faces."`,
+      temperature: 0.8,
+      maxTokens: 200,
+    })
+
+    return NextResponse.json({
+      ...quest,
+      title: result.object.title,
+      description: result.object.description,
+    })
+  } catch (error) {
+    console.error('[quest/generate] Failed:', error)
+
+    // Fallback: return a synchronously-generated quest (no LLM) on error
+    try {
+      const parseResult = FantasyCharacterSchema.safeParse(character)
+      if (parseResult.success) {
+        const fallbackQuest = generateTimedQuest(parseResult.data)
+        return NextResponse.json(fallbackQuest)
+      }
+    } catch {
+      // ignore nested error
+    }
+
+    return NextResponse.json({ error: 'Failed to generate quest' }, { status: 500 })
+  }
+}

--- a/src/app/tap-tap-adventure/components/NoticeBoard.tsx
+++ b/src/app/tap-tap-adventure/components/NoticeBoard.tsx
@@ -71,11 +71,29 @@ function generateRumors(character: FantasyCharacter): string[] {
 
 export function NoticeBoard({ character, activeQuest, onAcceptQuest, onClose }: NoticeBoardProps) {
   const [generatedQuest, setGeneratedQuest] = useState<TimedQuest | null>(null)
+  const [isLoading, setIsLoading] = useState(!activeQuest)
 
   useEffect(() => {
-    if (!activeQuest) {
-      setGeneratedQuest(generateTimedQuest(character))
-    }
+    if (activeQuest) return
+
+    setIsLoading(true)
+    fetch('/api/v1/tap-tap-adventure/quest/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ character }),
+    })
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json()
+      })
+      .then((data: TimedQuest) => {
+        setGeneratedQuest(data)
+        setIsLoading(false)
+      })
+      .catch(() => {
+        setGeneratedQuest(generateTimedQuest(character))
+        setIsLoading(false)
+      })
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -126,6 +144,10 @@ export function NoticeBoard({ character, activeQuest, onAcceptQuest, onClose }: 
                 ? 'Quest expired!'
                 : `${activeQuest.deadlineDay - currentDay} day(s) remaining`}
             </div>
+          </div>
+        ) : isLoading ? (
+          <div className="bg-[#252638] border border-indigo-700/20 rounded p-2">
+            <div className="text-sm text-slate-400 italic">The board considers your request…</div>
           </div>
         ) : generatedQuest ? (
           <div className="bg-[#252638] border border-indigo-700/40 rounded p-2 space-y-1.5">


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/tap-tap-adventure/quest/generate` endpoint that enriches quest titles/descriptions with GPT-4o-mini flavor text
- Updates NoticeBoard to fetch quests asynchronously with a "board considers…" loading state
- Falls back to static quest generation if the LLM call fails — no degradation in reliability

## Test plan

- [ ] Open Notice Board when no active quest → shows loading placeholder briefly, then quest with narrative title/description
- [ ] Quest description still clearly communicates the mechanical goal (travel distance, win combat, etc.)
- [ ] Titles are ≤60 chars and feel evocative, not generic
- [ ] LLM failure: quest still appears with static fallback (test by temporarily removing OPENAI_API_KEY)
- [ ] Active quest display unaffected

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)