### PR TITLE
B-0.2 — Vendor the static Pokémon dataset

### DIFF
--- a/scripts/badge-run-fetch-data.ts
+++ b/scripts/badge-run-fetch-data.ts
@@ -1,0 +1,443 @@
+/**
+ * One-time script to vendor the static Pokémon dataset for Badge Run.
+ *
+ * Fetches from PokéAPI (https://pokeapi.co/api/v2/) and writes:
+ *   src/app/badge-run/domain/data/units.json
+ *   src/app/badge-run/domain/data/type-chart.json
+ *
+ * Scope: Kanto Pokémon dexIds 1–149 only (excludes Mewtwo #150 and Mew #151).
+ *
+ * Usage:
+ *   npx tsx scripts/badge-run-fetch-data.ts
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface Unit {
+  dexId: number
+  name: string
+  types: string[]
+  baseStats: {
+    hp: number
+    attack: number
+    defense: number
+    specialAttack: number
+    specialDefense: number
+    speed: number
+  }
+  eggGroups: string[]
+  evolvesTo: number | null
+  signatureMove: string | null
+}
+
+/** type-chart.json: { "Fire": { "Grass": 2, "Water": 0.5, ... }, ... }
+ *  Only non-1 values are stored. */
+type TypeChart = Record<string, Record<string, number>>
+
+// ── PokéAPI response shapes (partial) ─────────────────────────────────────────
+
+interface PokeApiNamedResource {
+  name: string
+  url: string
+}
+
+interface PokeApiPokemon {
+  id: number
+  name: string
+  types: Array<{ slot: number; type: PokeApiNamedResource }>
+  stats: Array<{ base_stat: number; stat: PokeApiNamedResource }>
+  moves: Array<{
+    move: PokeApiNamedResource
+    version_group_details: Array<{
+      level_learned_at: number
+      move_learn_method: PokeApiNamedResource
+      version_group: PokeApiNamedResource
+    }>
+  }>
+}
+
+interface PokeApiSpecies {
+  egg_groups: Array<{ name: string; url: string }>
+  evolution_chain: { url: string }
+}
+
+interface PokeApiEvolutionChain {
+  chain: EvolutionChainLink
+}
+
+interface EvolutionChainLink {
+  species: PokeApiNamedResource
+  evolves_to: EvolutionChainLink[]
+}
+
+interface PokeApiMove {
+  power: number | null
+}
+
+interface PokeApiType {
+  name: string
+  damage_relations: {
+    double_damage_to: PokeApiNamedResource[]
+    half_damage_to: PokeApiNamedResource[]
+    no_damage_to: PokeApiNamedResource[]
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function capitalize(s: string): string {
+  if (!s) return s
+  // Handle hyphenated names like "special-attack" → handle each word
+  return s
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('-')
+}
+
+/** Capitalize first letter only (for types, egg groups) */
+function cap(s: string): string {
+  if (!s) return s
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+/** Sleep for the given number of milliseconds */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+const BASE_URL = 'https://pokeapi.co/api/v2'
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} for ${url}`)
+  }
+  return response.json() as Promise<T>
+}
+
+/** Extract dex ID from a species URL like https://pokeapi.co/api/v2/pokemon-species/4/ */
+function dexIdFromSpeciesUrl(url: string): number {
+  const match = url.match(/\/(\d+)\/$/)
+  if (!match) throw new Error(`Cannot parse dex ID from ${url}`)
+  return parseInt(match[1], 10)
+}
+
+// ── Evolution chain traversal ─────────────────────────────────────────────────
+
+/**
+ * Walk an evolution chain and build a map of dexId → evolvesTo dexId.
+ * Only maps direct (next) evolutions.
+ */
+function walkChain(
+  link: EvolutionChainLink,
+  result: Map<number, number>
+): void {
+  const fromId = dexIdFromSpeciesUrl(link.species.url)
+  for (const next of link.evolves_to) {
+    const toId = dexIdFromSpeciesUrl(next.species.url)
+    // Only track Kanto scope (1-149)
+    if (fromId >= 1 && fromId <= 149 && toId >= 1 && toId <= 149) {
+      result.set(fromId, toId)
+    }
+    walkChain(next, result)
+  }
+}
+
+// ── Move power cache ──────────────────────────────────────────────────────────
+
+const movePowerCache = new Map<string, number | null>()
+let movesFetched = 0
+
+async function getMovePower(moveName: string): Promise<number | null> {
+  if (movePowerCache.has(moveName)) {
+    return movePowerCache.get(moveName)!
+  }
+  try {
+    const data = await fetchJson<PokeApiMove>(`${BASE_URL}/move/${moveName}`)
+    const power = data.power ?? null
+    movePowerCache.set(moveName, power)
+    movesFetched++
+    // Small delay to be respectful
+    await sleep(50)
+    return power
+  } catch (error) {
+    console.warn(`    Could not fetch move "${moveName}": ${String(error)}`)
+    movePowerCache.set(moveName, null)
+    return null
+  }
+}
+
+// ── Stat name mapping ─────────────────────────────────────────────────────────
+
+const STAT_MAP: Record<string, keyof Unit['baseStats']> = {
+  hp: 'hp',
+  attack: 'attack',
+  defense: 'defense',
+  'special-attack': 'specialAttack',
+  'special-defense': 'specialDefense',
+  speed: 'speed',
+}
+
+// ── Type chart ────────────────────────────────────────────────────────────────
+
+const ALL_TYPES = [
+  'normal', 'fire', 'water', 'electric', 'grass', 'ice',
+  'fighting', 'poison', 'ground', 'flying', 'psychic', 'bug',
+  'rock', 'ghost', 'dragon', 'dark', 'steel', 'fairy',
+]
+
+async function buildTypeChart(): Promise<TypeChart> {
+  console.log('Building type chart...')
+  const chart: TypeChart = {}
+
+  for (let i = 0; i < ALL_TYPES.length; i++) {
+    const typeName = ALL_TYPES[i]
+    console.log(`  Fetching type ${i + 1}/${ALL_TYPES.length}: ${typeName}`)
+    try {
+      const data = await fetchJson<PokeApiType>(`${BASE_URL}/type/${typeName}`)
+      const attackerKey = cap(typeName)
+      chart[attackerKey] = {}
+
+      for (const defender of data.damage_relations.double_damage_to) {
+        chart[attackerKey][cap(defender.name)] = 2
+      }
+      for (const defender of data.damage_relations.half_damage_to) {
+        chart[attackerKey][cap(defender.name)] = 0.5
+      }
+      for (const defender of data.damage_relations.no_damage_to) {
+        chart[attackerKey][cap(defender.name)] = 0
+      }
+    } catch (error) {
+      console.error(`  ERROR fetching type ${typeName}: ${String(error)}`)
+    }
+    await sleep(100)
+  }
+
+  return chart
+}
+
+// ── Main fetch loop ───────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log('Badge Run data fetch — Kanto Pokémon dex IDs 1-149')
+  console.log('='.repeat(60))
+
+  // Step 1: Build type chart
+  const typeChart = await buildTypeChart()
+  console.log(`Type chart built with ${Object.keys(typeChart).length} types.\n`)
+
+  // Step 2: Collect all species/evolution chain URLs we'll need
+  const evolutionChainUrls = new Set<string>()
+  const pokemonDataMap = new Map<number, PokeApiPokemon>()
+  const speciesDataMap = new Map<number, PokeApiSpecies>()
+
+  // Fetch in batches of 10 with a pause between batches
+  const BATCH_SIZE = 10
+  const BATCH_PAUSE = 500 // ms between batches
+  const DEX_IDS = Array.from({ length: 149 }, (_, i) => i + 1) // 1..149
+
+  console.log('Fetching Pokémon data (batches of 10)...')
+  for (let batchStart = 0; batchStart < DEX_IDS.length; batchStart += BATCH_SIZE) {
+    const batchIds = DEX_IDS.slice(batchStart, batchStart + BATCH_SIZE)
+    const batchNum = Math.floor(batchStart / BATCH_SIZE) + 1
+    const totalBatches = Math.ceil(DEX_IDS.length / BATCH_SIZE)
+    console.log(`  Batch ${batchNum}/${totalBatches}: dex IDs ${batchIds[0]}–${batchIds[batchIds.length - 1]}`)
+
+    await Promise.all(
+      batchIds.map(async id => {
+        try {
+          const [pokemon, species] = await Promise.all([
+            fetchJson<PokeApiPokemon>(`${BASE_URL}/pokemon/${id}`),
+            fetchJson<PokeApiSpecies>(`${BASE_URL}/pokemon-species/${id}`),
+          ])
+          pokemonDataMap.set(id, pokemon)
+          speciesDataMap.set(id, species)
+          evolutionChainUrls.add(species.evolution_chain.url)
+        } catch (error) {
+          console.error(`    ERROR for dex #${id}: ${String(error)}`)
+        }
+      })
+    )
+
+    if (batchStart + BATCH_SIZE < DEX_IDS.length) {
+      await sleep(BATCH_PAUSE)
+    }
+  }
+
+  console.log(`\nFetched ${pokemonDataMap.size} Pokémon, ${evolutionChainUrls.size} evolution chains.`)
+
+  // Step 3: Fetch all evolution chains
+  console.log('\nFetching evolution chains...')
+  const evolvesToMap = new Map<number, number>() // dexId → next evolution dexId
+
+  const chainUrls = Array.from(evolutionChainUrls)
+  for (let i = 0; i < chainUrls.length; i++) {
+    const url = chainUrls[i]
+    if (i % 5 === 0) {
+      console.log(`  Chain ${i + 1}/${chainUrls.length}...`)
+    }
+    try {
+      const chainData = await fetchJson<PokeApiEvolutionChain>(url)
+      walkChain(chainData.chain, evolvesToMap)
+    } catch (error) {
+      console.error(`  ERROR fetching evolution chain ${url}: ${String(error)}`)
+    }
+    await sleep(100)
+  }
+
+  console.log(`Evolution map built: ${evolvesToMap.size} entries.`)
+
+  // Step 4: Build units with signature moves
+  console.log('\nBuilding units and resolving signature moves...')
+  const units: Unit[] = []
+
+  for (const id of DEX_IDS) {
+    const pokemon = pokemonDataMap.get(id)
+    const species = speciesDataMap.get(id)
+    if (!pokemon || !species) {
+      console.warn(`  Skipping dex #${id}: missing data`)
+      continue
+    }
+
+    // Parse types
+    const types = pokemon.types
+      .sort((a, b) => a.slot - b.slot)
+      .map(t => cap(t.type.name))
+
+    // Parse base stats
+    const baseStats: Unit['baseStats'] = {
+      hp: 0, attack: 0, defense: 0,
+      specialAttack: 0, specialDefense: 0, speed: 0,
+    }
+    for (const stat of pokemon.stats) {
+      const key = STAT_MAP[stat.stat.name]
+      if (key) baseStats[key] = stat.base_stat
+    }
+
+    // Parse egg groups
+    const eggGroups = species.egg_groups.map(g => cap(g.name))
+
+    // evolves to
+    const evolvesTo = evolvesToMap.get(id) ?? null
+
+    // Signature move: highest base-power level-up move matching primary type,
+    // falling back to highest base-power level-up move of any type.
+    const levelUpMoves = pokemon.moves
+      .filter(m =>
+        m.version_group_details.some(
+          d => d.move_learn_method.name === 'level-up'
+        )
+      )
+      .map(m => m.move.name)
+
+    let signatureMove: string | null = null
+
+    if (levelUpMoves.length > 0) {
+      // Fetch power for all level-up moves (uses cache heavily)
+      const movePowers: Array<{ name: string; power: number }> = []
+
+      for (const moveName of levelUpMoves) {
+        const power = await getMovePower(moveName)
+        if (power !== null && power > 0) {
+          movePowers.push({ name: moveName, power })
+        }
+      }
+
+      if (movePowers.length > 0) {
+        const primaryType = types[0].toLowerCase()
+
+        // Try to find a STAB move first
+        // We need to know what type each move is — but fetching all move types would be too
+        // expensive. For simplicity, we use the cached move data.
+        // Since we already fetched move power, we can check if the move is STAB
+        // by checking if the move's type matches the Pokémon's primary type.
+        // However, the move power endpoint also has a `type` field.
+        // We'll look up the move type from the cache-enriched data.
+
+        // Get move types for STAB check
+        const movesWithType: Array<{ name: string; power: number; typeName: string | null }> = []
+        for (const { name, power } of movePowers) {
+          // Fetch the full move data to get its type (already cached)
+          try {
+            const moveData = await fetchJson<PokeApiMove & { type?: PokeApiNamedResource }>(
+              `${BASE_URL}/move/${name}`
+            )
+            const typeName = (moveData as { type?: PokeApiNamedResource }).type?.name ?? null
+            movesWithType.push({ name, power, typeName })
+          } catch {
+            movesWithType.push({ name, power, typeName: null })
+          }
+        }
+
+        // Sort descending by power
+        movesWithType.sort((a, b) => b.power - a.power)
+
+        // Prefer STAB
+        const stabMove = movesWithType.find(m => m.typeName === primaryType)
+        signatureMove = stabMove ? stabMove.name : movesWithType[0]?.name ?? null
+      }
+    }
+
+    // Format move name for display (e.g., "flamethrower" → "Flamethrower")
+    const formattedSignatureMove = signatureMove
+      ? signatureMove
+          .split('-')
+          .map(word => cap(word))
+          .join(' ')
+      : null
+
+    const unit: Unit = {
+      dexId: id,
+      name: cap(pokemon.name),
+      types,
+      baseStats,
+      eggGroups,
+      evolvesTo,
+      signatureMove: formattedSignatureMove,
+    }
+
+    units.push(unit)
+
+    if (id % 25 === 0 || id === 149) {
+      console.log(`  Processed up to dex #${id} (${units.length} units so far, ${movesFetched} moves fetched)`)
+    }
+  }
+
+  console.log(`\nBuilt ${units.length} units total.`)
+
+  // Step 5: Write output files
+  const dataDir = path.join(
+    path.dirname(new URL(import.meta.url).pathname),
+    '../src/app/badge-run/domain/data'
+  )
+  fs.mkdirSync(dataDir, { recursive: true })
+
+  const unitsPath = path.join(dataDir, 'units.json')
+  const typeChartPath = path.join(dataDir, 'type-chart.json')
+
+  fs.writeFileSync(unitsPath, JSON.stringify(units, null, 2))
+  console.log(`\nWrote ${units.length} units to ${unitsPath}`)
+
+  fs.writeFileSync(typeChartPath, JSON.stringify(typeChart, null, 2))
+  console.log(`Wrote type chart to ${typeChartPath}`)
+
+  // Sanity check
+  const typeCount = Object.keys(typeChart).length
+  console.log(`\nSanity check: ${typeCount} types in chart, ${units.length} Pokémon in units.`)
+  if (typeCount !== 18) {
+    console.warn(`WARNING: Expected 18 types, got ${typeCount}`)
+  }
+  if (units.length < 140) {
+    console.warn(`WARNING: Expected at least 140 units, got ${units.length}`)
+  }
+
+  console.log('\nDone.')
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})

--- a/src/app/badge-run/domain/data/__tests__/units.test.ts
+++ b/src/app/badge-run/domain/data/__tests__/units.test.ts
@@ -1,0 +1,25 @@
+import units from '../units.json'
+import typeChart from '../type-chart.json'
+
+describe('Badge Run unit data', () => {
+  it('has the right number of units', () => {
+    expect(units.length).toBeGreaterThanOrEqual(140)
+    expect(units.length).toBeLessThanOrEqual(151)
+  })
+
+  it('every unit has required fields', () => {
+    for (const u of units) {
+      expect(u.dexId).toBeGreaterThan(0)
+      expect(u.name).toBeTruthy()
+      expect(Array.isArray(u.types)).toBe(true)
+      expect(u.types.length).toBeGreaterThan(0)
+      expect(u.baseStats.hp).toBeGreaterThan(0)
+      expect(Array.isArray(u.eggGroups)).toBe(true)
+    }
+  })
+
+  it('type chart has all 18 types', () => {
+    const types = Object.keys(typeChart)
+    expect(types.length).toBe(18)
+  })
+})

--- a/src/app/badge-run/domain/data/type-chart.json
+++ b/src/app/badge-run/domain/data/type-chart.json
@@ -1,0 +1,158 @@
+{
+  "Normal": {
+    "Rock": 0.5,
+    "Steel": 0.5,
+    "Ghost": 0
+  },
+  "Fire": {
+    "Bug": 2,
+    "Steel": 2,
+    "Grass": 2,
+    "Ice": 2,
+    "Rock": 0.5,
+    "Fire": 0.5,
+    "Water": 0.5,
+    "Dragon": 0.5
+  },
+  "Water": {
+    "Ground": 2,
+    "Rock": 2,
+    "Fire": 2,
+    "Water": 0.5,
+    "Grass": 0.5,
+    "Dragon": 0.5
+  },
+  "Electric": {
+    "Flying": 2,
+    "Water": 2,
+    "Grass": 0.5,
+    "Electric": 0.5,
+    "Dragon": 0.5,
+    "Ground": 0
+  },
+  "Grass": {
+    "Ground": 2,
+    "Rock": 2,
+    "Water": 2,
+    "Flying": 0.5,
+    "Poison": 0.5,
+    "Bug": 0.5,
+    "Steel": 0.5,
+    "Fire": 0.5,
+    "Grass": 0.5,
+    "Dragon": 0.5
+  },
+  "Ice": {
+    "Flying": 2,
+    "Ground": 2,
+    "Grass": 2,
+    "Dragon": 2,
+    "Steel": 0.5,
+    "Fire": 0.5,
+    "Water": 0.5,
+    "Ice": 0.5
+  },
+  "Fighting": {
+    "Normal": 2,
+    "Rock": 2,
+    "Steel": 2,
+    "Ice": 2,
+    "Dark": 2,
+    "Flying": 0.5,
+    "Poison": 0.5,
+    "Bug": 0.5,
+    "Psychic": 0.5,
+    "Fairy": 0.5,
+    "Ghost": 0
+  },
+  "Poison": {
+    "Grass": 2,
+    "Fairy": 2,
+    "Poison": 0.5,
+    "Ground": 0.5,
+    "Rock": 0.5,
+    "Ghost": 0.5,
+    "Steel": 0
+  },
+  "Ground": {
+    "Poison": 2,
+    "Rock": 2,
+    "Steel": 2,
+    "Fire": 2,
+    "Electric": 2,
+    "Bug": 0.5,
+    "Grass": 0.5,
+    "Flying": 0
+  },
+  "Flying": {
+    "Fighting": 2,
+    "Bug": 2,
+    "Grass": 2,
+    "Rock": 0.5,
+    "Steel": 0.5,
+    "Electric": 0.5
+  },
+  "Psychic": {
+    "Fighting": 2,
+    "Poison": 2,
+    "Steel": 0.5,
+    "Psychic": 0.5,
+    "Dark": 0
+  },
+  "Bug": {
+    "Grass": 2,
+    "Psychic": 2,
+    "Dark": 2,
+    "Fighting": 0.5,
+    "Flying": 0.5,
+    "Poison": 0.5,
+    "Ghost": 0.5,
+    "Steel": 0.5,
+    "Fire": 0.5,
+    "Fairy": 0.5
+  },
+  "Rock": {
+    "Flying": 2,
+    "Bug": 2,
+    "Fire": 2,
+    "Ice": 2,
+    "Fighting": 0.5,
+    "Ground": 0.5,
+    "Steel": 0.5
+  },
+  "Ghost": {
+    "Ghost": 2,
+    "Psychic": 2,
+    "Dark": 0.5,
+    "Normal": 0
+  },
+  "Dragon": {
+    "Dragon": 2,
+    "Steel": 0.5,
+    "Fairy": 0
+  },
+  "Dark": {
+    "Ghost": 2,
+    "Psychic": 2,
+    "Fighting": 0.5,
+    "Dark": 0.5,
+    "Fairy": 0.5
+  },
+  "Steel": {
+    "Rock": 2,
+    "Ice": 2,
+    "Fairy": 2,
+    "Steel": 0.5,
+    "Fire": 0.5,
+    "Water": 0.5,
+    "Electric": 0.5
+  },
+  "Fairy": {
+    "Fighting": 2,
+    "Dragon": 2,
+    "Dark": 2,
+    "Poison": 0.5,
+    "Steel": 0.5,
+    "Fire": 0.5
+  }
+}

--- a/src/app/badge-run/domain/data/units.json
+++ b/src/app/badge-run/domain/data/units.json
@@ -1,0 +1,3089 @@
+[
+  {
+    "dexId": 1,
+    "name": "Bulbasaur",
+    "types": [
+      "Grass",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 45,
+      "attack": 49,
+      "defense": 49,
+      "specialAttack": 65,
+      "specialDefense": 65,
+      "speed": 45
+    },
+    "eggGroups": [
+      "Monster",
+      "Plant"
+    ],
+    "evolvesTo": 2,
+    "signatureMove": "Solar Beam"
+  },
+  {
+    "dexId": 2,
+    "name": "Ivysaur",
+    "types": [
+      "Grass",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 62,
+      "defense": 63,
+      "specialAttack": 80,
+      "specialDefense": 80,
+      "speed": 60
+    },
+    "eggGroups": [
+      "Monster",
+      "Plant"
+    ],
+    "evolvesTo": 3,
+    "signatureMove": "Solar Beam"
+  },
+  {
+    "dexId": 3,
+    "name": "Venusaur",
+    "types": [
+      "Grass",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 80,
+      "attack": 82,
+      "defense": 83,
+      "specialAttack": 100,
+      "specialDefense": 100,
+      "speed": 80
+    },
+    "eggGroups": [
+      "Monster",
+      "Plant"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Solar Beam"
+  },
+  {
+    "dexId": 4,
+    "name": "Charmander",
+    "types": [
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 39,
+      "attack": 52,
+      "defense": 43,
+      "specialAttack": 60,
+      "specialDefense": 50,
+      "speed": 65
+    },
+    "eggGroups": [
+      "Monster",
+      "Dragon"
+    ],
+    "evolvesTo": 5,
+    "signatureMove": "Flare Blitz"
+  },
+  {
+    "dexId": 5,
+    "name": "Charmeleon",
+    "types": [
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 58,
+      "attack": 64,
+      "defense": 58,
+      "specialAttack": 80,
+      "specialDefense": 65,
+      "speed": 80
+    },
+    "eggGroups": [
+      "Monster",
+      "Dragon"
+    ],
+    "evolvesTo": 6,
+    "signatureMove": "Flare Blitz"
+  },
+  {
+    "dexId": 6,
+    "name": "Charizard",
+    "types": [
+      "Fire",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 78,
+      "attack": 84,
+      "defense": 78,
+      "specialAttack": 109,
+      "specialDefense": 85,
+      "speed": 100
+    },
+    "eggGroups": [
+      "Monster",
+      "Dragon"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Flare Blitz"
+  },
+  {
+    "dexId": 7,
+    "name": "Squirtle",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 44,
+      "attack": 48,
+      "defense": 65,
+      "specialAttack": 50,
+      "specialDefense": 64,
+      "speed": 43
+    },
+    "eggGroups": [
+      "Monster",
+      "Water1"
+    ],
+    "evolvesTo": 8,
+    "signatureMove": "Wave Crash"
+  },
+  {
+    "dexId": 8,
+    "name": "Wartortle",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 59,
+      "attack": 63,
+      "defense": 80,
+      "specialAttack": 65,
+      "specialDefense": 80,
+      "speed": 58
+    },
+    "eggGroups": [
+      "Monster",
+      "Water1"
+    ],
+    "evolvesTo": 9,
+    "signatureMove": "Wave Crash"
+  },
+  {
+    "dexId": 9,
+    "name": "Blastoise",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 79,
+      "attack": 83,
+      "defense": 100,
+      "specialAttack": 85,
+      "specialDefense": 105,
+      "speed": 78
+    },
+    "eggGroups": [
+      "Monster",
+      "Water1"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Wave Crash"
+  },
+  {
+    "dexId": 10,
+    "name": "Caterpie",
+    "types": [
+      "Bug"
+    ],
+    "baseStats": {
+      "hp": 45,
+      "attack": 30,
+      "defense": 35,
+      "specialAttack": 20,
+      "specialDefense": 20,
+      "speed": 45
+    },
+    "eggGroups": [
+      "Bug"
+    ],
+    "evolvesTo": 11,
+    "signatureMove": "Bug Bite"
+  },
+  {
+    "dexId": 11,
+    "name": "Metapod",
+    "types": [
+      "Bug"
+    ],
+    "baseStats": {
+      "hp": 50,
+      "attack": 20,
+      "defense": 55,
+      "specialAttack": 25,
+      "specialDefense": 25,
+      "speed": 30
+    },
+    "eggGroups": [
+      "Bug"
+    ],
+    "evolvesTo": 12,
+    "signatureMove": null
+  },
+  {
+    "dexId": 12,
+    "name": "Butterfree",
+    "types": [
+      "Bug",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 45,
+      "defense": 50,
+      "specialAttack": 90,
+      "specialDefense": 80,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Bug"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Bug Buzz"
+  },
+  {
+    "dexId": 13,
+    "name": "Weedle",
+    "types": [
+      "Bug",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 35,
+      "defense": 30,
+      "specialAttack": 20,
+      "specialDefense": 20,
+      "speed": 50
+    },
+    "eggGroups": [
+      "Bug"
+    ],
+    "evolvesTo": 14,
+    "signatureMove": "Bug Bite"
+  },
+  {
+    "dexId": 14,
+    "name": "Kakuna",
+    "types": [
+      "Bug",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 45,
+      "attack": 25,
+      "defense": 50,
+      "specialAttack": 25,
+      "specialDefense": 25,
+      "speed": 35
+    },
+    "eggGroups": [
+      "Bug"
+    ],
+    "evolvesTo": 15,
+    "signatureMove": null
+  },
+  {
+    "dexId": 15,
+    "name": "Beedrill",
+    "types": [
+      "Bug",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 90,
+      "defense": 40,
+      "specialAttack": 45,
+      "specialDefense": 80,
+      "speed": 75
+    },
+    "eggGroups": [
+      "Bug"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Bug Bite"
+  },
+  {
+    "dexId": 16,
+    "name": "Pidgey",
+    "types": [
+      "Normal",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 45,
+      "defense": 40,
+      "specialAttack": 35,
+      "specialDefense": 35,
+      "speed": 56
+    },
+    "eggGroups": [
+      "Flying"
+    ],
+    "evolvesTo": 17,
+    "signatureMove": "Razor Wind"
+  },
+  {
+    "dexId": 17,
+    "name": "Pidgeotto",
+    "types": [
+      "Normal",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 63,
+      "attack": 60,
+      "defense": 55,
+      "specialAttack": 50,
+      "specialDefense": 50,
+      "speed": 71
+    },
+    "eggGroups": [
+      "Flying"
+    ],
+    "evolvesTo": 18,
+    "signatureMove": "Razor Wind"
+  },
+  {
+    "dexId": 18,
+    "name": "Pidgeot",
+    "types": [
+      "Normal",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 83,
+      "attack": 80,
+      "defense": 75,
+      "specialAttack": 70,
+      "specialDefense": 70,
+      "speed": 101
+    },
+    "eggGroups": [
+      "Flying"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Razor Wind"
+  },
+  {
+    "dexId": 19,
+    "name": "Rattata",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 30,
+      "attack": 56,
+      "defense": 35,
+      "specialAttack": 25,
+      "specialDefense": 35,
+      "speed": 72
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": 20,
+    "signatureMove": "Double Edge"
+  },
+  {
+    "dexId": 20,
+    "name": "Raticate",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 55,
+      "attack": 81,
+      "defense": 60,
+      "specialAttack": 50,
+      "specialDefense": 70,
+      "speed": 97
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Double Edge"
+  },
+  {
+    "dexId": 21,
+    "name": "Spearow",
+    "types": [
+      "Normal",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 60,
+      "defense": 30,
+      "specialAttack": 31,
+      "specialDefense": 31,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Flying"
+    ],
+    "evolvesTo": 22,
+    "signatureMove": "Take Down"
+  },
+  {
+    "dexId": 22,
+    "name": "Fearow",
+    "types": [
+      "Normal",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 90,
+      "defense": 65,
+      "specialAttack": 61,
+      "specialDefense": 61,
+      "speed": 100
+    },
+    "eggGroups": [
+      "Flying"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Take Down"
+  },
+  {
+    "dexId": 23,
+    "name": "Ekans",
+    "types": [
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 35,
+      "attack": 60,
+      "defense": 44,
+      "specialAttack": 40,
+      "specialDefense": 54,
+      "speed": 55
+    },
+    "eggGroups": [
+      "Ground",
+      "Dragon"
+    ],
+    "evolvesTo": 24,
+    "signatureMove": "Gunk Shot"
+  },
+  {
+    "dexId": 24,
+    "name": "Arbok",
+    "types": [
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 95,
+      "defense": 69,
+      "specialAttack": 65,
+      "specialDefense": 79,
+      "speed": 80
+    },
+    "eggGroups": [
+      "Ground",
+      "Dragon"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Gunk Shot"
+  },
+  {
+    "dexId": 25,
+    "name": "Pikachu",
+    "types": [
+      "Electric"
+    ],
+    "baseStats": {
+      "hp": 35,
+      "attack": 55,
+      "defense": 40,
+      "specialAttack": 50,
+      "specialDefense": 50,
+      "speed": 90
+    },
+    "eggGroups": [
+      "Ground",
+      "Fairy"
+    ],
+    "evolvesTo": 26,
+    "signatureMove": "Thunder"
+  },
+  {
+    "dexId": 26,
+    "name": "Raichu",
+    "types": [
+      "Electric"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 90,
+      "defense": 55,
+      "specialAttack": 90,
+      "specialDefense": 80,
+      "speed": 110
+    },
+    "eggGroups": [
+      "Ground",
+      "Fairy"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Thunder"
+  },
+  {
+    "dexId": 27,
+    "name": "Sandshrew",
+    "types": [
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 50,
+      "attack": 75,
+      "defense": 85,
+      "specialAttack": 20,
+      "specialDefense": 30,
+      "speed": 40
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": 28,
+    "signatureMove": "Earthquake"
+  },
+  {
+    "dexId": 28,
+    "name": "Sandslash",
+    "types": [
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 75,
+      "attack": 100,
+      "defense": 110,
+      "specialAttack": 45,
+      "specialDefense": 55,
+      "speed": 65
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Earthquake"
+  },
+  {
+    "dexId": 29,
+    "name": "Nidoran-f",
+    "types": [
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 55,
+      "attack": 47,
+      "defense": 52,
+      "specialAttack": 40,
+      "specialDefense": 40,
+      "speed": 41
+    },
+    "eggGroups": [
+      "Monster",
+      "Ground"
+    ],
+    "evolvesTo": 30,
+    "signatureMove": "Poison Fang"
+  },
+  {
+    "dexId": 30,
+    "name": "Nidorina",
+    "types": [
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 70,
+      "attack": 62,
+      "defense": 67,
+      "specialAttack": 55,
+      "specialDefense": 55,
+      "speed": 56
+    },
+    "eggGroups": [
+      "No-eggs"
+    ],
+    "evolvesTo": 31,
+    "signatureMove": "Poison Fang"
+  },
+  {
+    "dexId": 31,
+    "name": "Nidoqueen",
+    "types": [
+      "Poison",
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 90,
+      "attack": 92,
+      "defense": 87,
+      "specialAttack": 75,
+      "specialDefense": 85,
+      "speed": 76
+    },
+    "eggGroups": [
+      "No-eggs"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Sludge Wave"
+  },
+  {
+    "dexId": 32,
+    "name": "Nidoran-m",
+    "types": [
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 46,
+      "attack": 57,
+      "defense": 40,
+      "specialAttack": 40,
+      "specialDefense": 40,
+      "speed": 50
+    },
+    "eggGroups": [
+      "Monster",
+      "Ground"
+    ],
+    "evolvesTo": 33,
+    "signatureMove": "Poison Jab"
+  },
+  {
+    "dexId": 33,
+    "name": "Nidorino",
+    "types": [
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 61,
+      "attack": 72,
+      "defense": 57,
+      "specialAttack": 55,
+      "specialDefense": 55,
+      "speed": 65
+    },
+    "eggGroups": [
+      "Monster",
+      "Ground"
+    ],
+    "evolvesTo": 34,
+    "signatureMove": "Poison Jab"
+  },
+  {
+    "dexId": 34,
+    "name": "Nidoking",
+    "types": [
+      "Poison",
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 81,
+      "attack": 102,
+      "defense": 77,
+      "specialAttack": 85,
+      "specialDefense": 75,
+      "speed": 85
+    },
+    "eggGroups": [
+      "Monster",
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Sludge Wave"
+  },
+  {
+    "dexId": 35,
+    "name": "Clefairy",
+    "types": [
+      "Fairy"
+    ],
+    "baseStats": {
+      "hp": 70,
+      "attack": 45,
+      "defense": 48,
+      "specialAttack": 60,
+      "specialDefense": 65,
+      "speed": 35
+    },
+    "eggGroups": [
+      "Fairy"
+    ],
+    "evolvesTo": 36,
+    "signatureMove": "Moonblast"
+  },
+  {
+    "dexId": 36,
+    "name": "Clefable",
+    "types": [
+      "Fairy"
+    ],
+    "baseStats": {
+      "hp": 95,
+      "attack": 70,
+      "defense": 73,
+      "specialAttack": 95,
+      "specialDefense": 90,
+      "speed": 60
+    },
+    "eggGroups": [
+      "Fairy"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Moonblast"
+  },
+  {
+    "dexId": 37,
+    "name": "Vulpix",
+    "types": [
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 38,
+      "attack": 41,
+      "defense": 40,
+      "specialAttack": 50,
+      "specialDefense": 65,
+      "speed": 65
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": 38,
+    "signatureMove": "Fire Blast"
+  },
+  {
+    "dexId": 38,
+    "name": "Ninetales",
+    "types": [
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 73,
+      "attack": 76,
+      "defense": 75,
+      "specialAttack": 81,
+      "specialDefense": 100,
+      "speed": 100
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Fire Blast"
+  },
+  {
+    "dexId": 39,
+    "name": "Jigglypuff",
+    "types": [
+      "Normal",
+      "Fairy"
+    ],
+    "baseStats": {
+      "hp": 115,
+      "attack": 45,
+      "defense": 20,
+      "specialAttack": 45,
+      "specialDefense": 25,
+      "speed": 20
+    },
+    "eggGroups": [
+      "Fairy"
+    ],
+    "evolvesTo": 40,
+    "signatureMove": "Double Edge"
+  },
+  {
+    "dexId": 40,
+    "name": "Wigglytuff",
+    "types": [
+      "Normal",
+      "Fairy"
+    ],
+    "baseStats": {
+      "hp": 140,
+      "attack": 70,
+      "defense": 45,
+      "specialAttack": 85,
+      "specialDefense": 50,
+      "speed": 45
+    },
+    "eggGroups": [
+      "Fairy"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Double Edge"
+  },
+  {
+    "dexId": 41,
+    "name": "Zubat",
+    "types": [
+      "Poison",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 45,
+      "defense": 35,
+      "specialAttack": 30,
+      "specialDefense": 40,
+      "speed": 55
+    },
+    "eggGroups": [
+      "Flying"
+    ],
+    "evolvesTo": 42,
+    "signatureMove": "Cross Poison"
+  },
+  {
+    "dexId": 42,
+    "name": "Golbat",
+    "types": [
+      "Poison",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 75,
+      "attack": 80,
+      "defense": 70,
+      "specialAttack": 65,
+      "specialDefense": 75,
+      "speed": 90
+    },
+    "eggGroups": [
+      "Flying"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Cross Poison"
+  },
+  {
+    "dexId": 43,
+    "name": "Oddish",
+    "types": [
+      "Grass",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 45,
+      "attack": 50,
+      "defense": 55,
+      "specialAttack": 75,
+      "specialDefense": 65,
+      "speed": 30
+    },
+    "eggGroups": [
+      "Plant"
+    ],
+    "evolvesTo": 44,
+    "signatureMove": "Solar Beam"
+  },
+  {
+    "dexId": 44,
+    "name": "Gloom",
+    "types": [
+      "Grass",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 65,
+      "defense": 70,
+      "specialAttack": 85,
+      "specialDefense": 75,
+      "speed": 40
+    },
+    "eggGroups": [
+      "Plant"
+    ],
+    "evolvesTo": 45,
+    "signatureMove": "Solar Beam"
+  },
+  {
+    "dexId": 45,
+    "name": "Vileplume",
+    "types": [
+      "Grass",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 75,
+      "attack": 80,
+      "defense": 85,
+      "specialAttack": 110,
+      "specialDefense": 90,
+      "speed": 50
+    },
+    "eggGroups": [
+      "Plant"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Solar Beam"
+  },
+  {
+    "dexId": 46,
+    "name": "Paras",
+    "types": [
+      "Bug",
+      "Grass"
+    ],
+    "baseStats": {
+      "hp": 35,
+      "attack": 70,
+      "defense": 55,
+      "specialAttack": 45,
+      "specialDefense": 55,
+      "speed": 25
+    },
+    "eggGroups": [
+      "Bug",
+      "Plant"
+    ],
+    "evolvesTo": 47,
+    "signatureMove": "Leech Life"
+  },
+  {
+    "dexId": 47,
+    "name": "Parasect",
+    "types": [
+      "Bug",
+      "Grass"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 95,
+      "defense": 80,
+      "specialAttack": 60,
+      "specialDefense": 80,
+      "speed": 30
+    },
+    "eggGroups": [
+      "Bug",
+      "Plant"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Leech Life"
+  },
+  {
+    "dexId": 48,
+    "name": "Venonat",
+    "types": [
+      "Bug",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 55,
+      "defense": 50,
+      "specialAttack": 40,
+      "specialDefense": 55,
+      "speed": 45
+    },
+    "eggGroups": [
+      "Bug"
+    ],
+    "evolvesTo": 49,
+    "signatureMove": "Bug Buzz"
+  },
+  {
+    "dexId": 49,
+    "name": "Venomoth",
+    "types": [
+      "Bug",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 70,
+      "attack": 65,
+      "defense": 60,
+      "specialAttack": 90,
+      "specialDefense": 75,
+      "speed": 90
+    },
+    "eggGroups": [
+      "Bug"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Bug Buzz"
+  },
+  {
+    "dexId": 50,
+    "name": "Diglett",
+    "types": [
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 10,
+      "attack": 55,
+      "defense": 25,
+      "specialAttack": 35,
+      "specialDefense": 45,
+      "speed": 95
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": 51,
+    "signatureMove": "Earthquake"
+  },
+  {
+    "dexId": 51,
+    "name": "Dugtrio",
+    "types": [
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 35,
+      "attack": 100,
+      "defense": 50,
+      "specialAttack": 50,
+      "specialDefense": 70,
+      "speed": 120
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Earthquake"
+  },
+  {
+    "dexId": 52,
+    "name": "Meowth",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 45,
+      "defense": 35,
+      "specialAttack": 40,
+      "specialDefense": 40,
+      "speed": 90
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": 53,
+    "signatureMove": "Slash"
+  },
+  {
+    "dexId": 53,
+    "name": "Persian",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 70,
+      "defense": 60,
+      "specialAttack": 65,
+      "specialDefense": 65,
+      "speed": 115
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Slash"
+  },
+  {
+    "dexId": 54,
+    "name": "Psyduck",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 50,
+      "attack": 52,
+      "defense": 48,
+      "specialAttack": 65,
+      "specialDefense": 50,
+      "speed": 55
+    },
+    "eggGroups": [
+      "Water1",
+      "Ground"
+    ],
+    "evolvesTo": 55,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 55,
+    "name": "Golduck",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 80,
+      "attack": 82,
+      "defense": 78,
+      "specialAttack": 95,
+      "specialDefense": 80,
+      "speed": 85
+    },
+    "eggGroups": [
+      "Water1",
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 56,
+    "name": "Mankey",
+    "types": [
+      "Fighting"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 80,
+      "defense": 35,
+      "specialAttack": 35,
+      "specialDefense": 45,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": 57,
+    "signatureMove": "Close Combat"
+  },
+  {
+    "dexId": 57,
+    "name": "Primeape",
+    "types": [
+      "Fighting"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 105,
+      "defense": 60,
+      "specialAttack": 60,
+      "specialDefense": 70,
+      "speed": 95
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Close Combat"
+  },
+  {
+    "dexId": 58,
+    "name": "Growlithe",
+    "types": [
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 55,
+      "attack": 70,
+      "defense": 45,
+      "specialAttack": 70,
+      "specialDefense": 50,
+      "speed": 60
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": 59,
+    "signatureMove": "Flare Blitz"
+  },
+  {
+    "dexId": 59,
+    "name": "Arcanine",
+    "types": [
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 90,
+      "attack": 110,
+      "defense": 80,
+      "specialAttack": 100,
+      "specialDefense": 80,
+      "speed": 95
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Burn Up"
+  },
+  {
+    "dexId": 60,
+    "name": "Poliwag",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 50,
+      "defense": 40,
+      "specialAttack": 40,
+      "specialDefense": 40,
+      "speed": 90
+    },
+    "eggGroups": [
+      "Water1"
+    ],
+    "evolvesTo": 61,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 61,
+    "name": "Poliwhirl",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 65,
+      "defense": 65,
+      "specialAttack": 50,
+      "specialDefense": 50,
+      "speed": 90
+    },
+    "eggGroups": [
+      "Water1"
+    ],
+    "evolvesTo": 62,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 62,
+    "name": "Poliwrath",
+    "types": [
+      "Water",
+      "Fighting"
+    ],
+    "baseStats": {
+      "hp": 90,
+      "attack": 95,
+      "defense": 95,
+      "specialAttack": 70,
+      "specialDefense": 90,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Water1"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 63,
+    "name": "Abra",
+    "types": [
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 25,
+      "attack": 20,
+      "defense": 15,
+      "specialAttack": 105,
+      "specialDefense": 55,
+      "speed": 90
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": 64,
+    "signatureMove": null
+  },
+  {
+    "dexId": 64,
+    "name": "Kadabra",
+    "types": [
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 35,
+      "defense": 30,
+      "specialAttack": 120,
+      "specialDefense": 70,
+      "speed": 105
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": 65,
+    "signatureMove": "Future Sight"
+  },
+  {
+    "dexId": 65,
+    "name": "Alakazam",
+    "types": [
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 55,
+      "attack": 50,
+      "defense": 45,
+      "specialAttack": 135,
+      "specialDefense": 95,
+      "speed": 120
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Future Sight"
+  },
+  {
+    "dexId": 66,
+    "name": "Machop",
+    "types": [
+      "Fighting"
+    ],
+    "baseStats": {
+      "hp": 70,
+      "attack": 80,
+      "defense": 50,
+      "specialAttack": 35,
+      "specialDefense": 35,
+      "speed": 35
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": 67,
+    "signatureMove": "Superpower"
+  },
+  {
+    "dexId": 67,
+    "name": "Machoke",
+    "types": [
+      "Fighting"
+    ],
+    "baseStats": {
+      "hp": 80,
+      "attack": 100,
+      "defense": 70,
+      "specialAttack": 50,
+      "specialDefense": 60,
+      "speed": 45
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": 68,
+    "signatureMove": "Superpower"
+  },
+  {
+    "dexId": 68,
+    "name": "Machamp",
+    "types": [
+      "Fighting"
+    ],
+    "baseStats": {
+      "hp": 90,
+      "attack": 130,
+      "defense": 80,
+      "specialAttack": 65,
+      "specialDefense": 85,
+      "speed": 55
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Superpower"
+  },
+  {
+    "dexId": 69,
+    "name": "Bellsprout",
+    "types": [
+      "Grass",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 50,
+      "attack": 75,
+      "defense": 35,
+      "specialAttack": 70,
+      "specialDefense": 30,
+      "speed": 40
+    },
+    "eggGroups": [
+      "Plant"
+    ],
+    "evolvesTo": 70,
+    "signatureMove": "Power Whip"
+  },
+  {
+    "dexId": 70,
+    "name": "Weepinbell",
+    "types": [
+      "Grass",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 90,
+      "defense": 50,
+      "specialAttack": 85,
+      "specialDefense": 45,
+      "speed": 55
+    },
+    "eggGroups": [
+      "Plant"
+    ],
+    "evolvesTo": 71,
+    "signatureMove": "Power Whip"
+  },
+  {
+    "dexId": 71,
+    "name": "Victreebel",
+    "types": [
+      "Grass",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 80,
+      "attack": 105,
+      "defense": 65,
+      "specialAttack": 100,
+      "specialDefense": 70,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Plant"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Leaf Storm"
+  },
+  {
+    "dexId": 72,
+    "name": "Tentacool",
+    "types": [
+      "Water",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 40,
+      "defense": 35,
+      "specialAttack": 50,
+      "specialDefense": 100,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Water3"
+    ],
+    "evolvesTo": 73,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 73,
+    "name": "Tentacruel",
+    "types": [
+      "Water",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 80,
+      "attack": 70,
+      "defense": 65,
+      "specialAttack": 80,
+      "specialDefense": 120,
+      "speed": 100
+    },
+    "eggGroups": [
+      "Water3"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 74,
+    "name": "Geodude",
+    "types": [
+      "Rock",
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 80,
+      "defense": 100,
+      "specialAttack": 30,
+      "specialDefense": 30,
+      "speed": 20
+    },
+    "eggGroups": [
+      "Mineral"
+    ],
+    "evolvesTo": 75,
+    "signatureMove": "Stone Edge"
+  },
+  {
+    "dexId": 75,
+    "name": "Graveler",
+    "types": [
+      "Rock",
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 55,
+      "attack": 95,
+      "defense": 115,
+      "specialAttack": 45,
+      "specialDefense": 45,
+      "speed": 35
+    },
+    "eggGroups": [
+      "Mineral"
+    ],
+    "evolvesTo": 76,
+    "signatureMove": "Stone Edge"
+  },
+  {
+    "dexId": 76,
+    "name": "Golem",
+    "types": [
+      "Rock",
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 80,
+      "attack": 120,
+      "defense": 130,
+      "specialAttack": 55,
+      "specialDefense": 65,
+      "speed": 45
+    },
+    "eggGroups": [
+      "Mineral"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Stone Edge"
+  },
+  {
+    "dexId": 77,
+    "name": "Ponyta",
+    "types": [
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 50,
+      "attack": 85,
+      "defense": 55,
+      "specialAttack": 65,
+      "specialDefense": 65,
+      "speed": 90
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": 78,
+    "signatureMove": "Flare Blitz"
+  },
+  {
+    "dexId": 78,
+    "name": "Rapidash",
+    "types": [
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 100,
+      "defense": 70,
+      "specialAttack": 80,
+      "specialDefense": 80,
+      "speed": 105
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Flare Blitz"
+  },
+  {
+    "dexId": 79,
+    "name": "Slowpoke",
+    "types": [
+      "Water",
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 90,
+      "attack": 65,
+      "defense": 65,
+      "specialAttack": 40,
+      "specialDefense": 40,
+      "speed": 15
+    },
+    "eggGroups": [
+      "Monster",
+      "Water1"
+    ],
+    "evolvesTo": 80,
+    "signatureMove": "Surf"
+  },
+  {
+    "dexId": 80,
+    "name": "Slowbro",
+    "types": [
+      "Water",
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 95,
+      "attack": 75,
+      "defense": 110,
+      "specialAttack": 100,
+      "specialDefense": 80,
+      "speed": 30
+    },
+    "eggGroups": [
+      "Monster",
+      "Water1"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Surf"
+  },
+  {
+    "dexId": 81,
+    "name": "Magnemite",
+    "types": [
+      "Electric",
+      "Steel"
+    ],
+    "baseStats": {
+      "hp": 25,
+      "attack": 35,
+      "defense": 70,
+      "specialAttack": 95,
+      "specialDefense": 55,
+      "speed": 45
+    },
+    "eggGroups": [
+      "Mineral"
+    ],
+    "evolvesTo": 82,
+    "signatureMove": "Zap Cannon"
+  },
+  {
+    "dexId": 82,
+    "name": "Magneton",
+    "types": [
+      "Electric",
+      "Steel"
+    ],
+    "baseStats": {
+      "hp": 50,
+      "attack": 60,
+      "defense": 95,
+      "specialAttack": 120,
+      "specialDefense": 70,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Mineral"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Zap Cannon"
+  },
+  {
+    "dexId": 83,
+    "name": "Farfetchd",
+    "types": [
+      "Normal",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 52,
+      "attack": 90,
+      "defense": 55,
+      "specialAttack": 58,
+      "specialDefense": 62,
+      "speed": 60
+    },
+    "eggGroups": [
+      "Flying",
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Slash"
+  },
+  {
+    "dexId": 84,
+    "name": "Doduo",
+    "types": [
+      "Normal",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 35,
+      "attack": 85,
+      "defense": 45,
+      "specialAttack": 35,
+      "specialDefense": 35,
+      "speed": 75
+    },
+    "eggGroups": [
+      "Flying"
+    ],
+    "evolvesTo": 85,
+    "signatureMove": "Thrash"
+  },
+  {
+    "dexId": 85,
+    "name": "Dodrio",
+    "types": [
+      "Normal",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 110,
+      "defense": 70,
+      "specialAttack": 60,
+      "specialDefense": 60,
+      "speed": 110
+    },
+    "eggGroups": [
+      "Flying"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Thrash"
+  },
+  {
+    "dexId": 86,
+    "name": "Seel",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 45,
+      "defense": 55,
+      "specialAttack": 45,
+      "specialDefense": 70,
+      "speed": 45
+    },
+    "eggGroups": [
+      "Water1",
+      "Ground"
+    ],
+    "evolvesTo": 87,
+    "signatureMove": "Aqua Tail"
+  },
+  {
+    "dexId": 87,
+    "name": "Dewgong",
+    "types": [
+      "Water",
+      "Ice"
+    ],
+    "baseStats": {
+      "hp": 90,
+      "attack": 70,
+      "defense": 80,
+      "specialAttack": 70,
+      "specialDefense": 95,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Water1",
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Aqua Tail"
+  },
+  {
+    "dexId": 88,
+    "name": "Grimer",
+    "types": [
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 80,
+      "attack": 80,
+      "defense": 50,
+      "specialAttack": 40,
+      "specialDefense": 50,
+      "speed": 25
+    },
+    "eggGroups": [
+      "Indeterminate"
+    ],
+    "evolvesTo": 89,
+    "signatureMove": "Gunk Shot"
+  },
+  {
+    "dexId": 89,
+    "name": "Muk",
+    "types": [
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 105,
+      "attack": 105,
+      "defense": 75,
+      "specialAttack": 65,
+      "specialDefense": 100,
+      "speed": 50
+    },
+    "eggGroups": [
+      "Indeterminate"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Gunk Shot"
+  },
+  {
+    "dexId": 90,
+    "name": "Shellder",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 30,
+      "attack": 65,
+      "defense": 100,
+      "specialAttack": 45,
+      "specialDefense": 25,
+      "speed": 40
+    },
+    "eggGroups": [
+      "Water3"
+    ],
+    "evolvesTo": 91,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 91,
+    "name": "Cloyster",
+    "types": [
+      "Water",
+      "Ice"
+    ],
+    "baseStats": {
+      "hp": 50,
+      "attack": 95,
+      "defense": 180,
+      "specialAttack": 85,
+      "specialDefense": 45,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Water3"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 92,
+    "name": "Gastly",
+    "types": [
+      "Ghost",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 30,
+      "attack": 35,
+      "defense": 30,
+      "specialAttack": 100,
+      "specialDefense": 35,
+      "speed": 80
+    },
+    "eggGroups": [
+      "Indeterminate"
+    ],
+    "evolvesTo": 93,
+    "signatureMove": "Shadow Ball"
+  },
+  {
+    "dexId": 93,
+    "name": "Haunter",
+    "types": [
+      "Ghost",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 45,
+      "attack": 50,
+      "defense": 45,
+      "specialAttack": 115,
+      "specialDefense": 55,
+      "speed": 95
+    },
+    "eggGroups": [
+      "Indeterminate"
+    ],
+    "evolvesTo": 94,
+    "signatureMove": "Shadow Ball"
+  },
+  {
+    "dexId": 94,
+    "name": "Gengar",
+    "types": [
+      "Ghost",
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 65,
+      "defense": 60,
+      "specialAttack": 130,
+      "specialDefense": 75,
+      "speed": 110
+    },
+    "eggGroups": [
+      "Indeterminate"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Shadow Ball"
+  },
+  {
+    "dexId": 95,
+    "name": "Onix",
+    "types": [
+      "Rock",
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 35,
+      "attack": 45,
+      "defense": 160,
+      "specialAttack": 30,
+      "specialDefense": 45,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Mineral"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Stone Edge"
+  },
+  {
+    "dexId": 96,
+    "name": "Drowzee",
+    "types": [
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 48,
+      "defense": 45,
+      "specialAttack": 43,
+      "specialDefense": 90,
+      "speed": 42
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": 97,
+    "signatureMove": "Future Sight"
+  },
+  {
+    "dexId": 97,
+    "name": "Hypno",
+    "types": [
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 85,
+      "attack": 73,
+      "defense": 70,
+      "specialAttack": 73,
+      "specialDefense": 115,
+      "speed": 67
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Future Sight"
+  },
+  {
+    "dexId": 98,
+    "name": "Krabby",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 30,
+      "attack": 105,
+      "defense": 90,
+      "specialAttack": 25,
+      "specialDefense": 25,
+      "speed": 50
+    },
+    "eggGroups": [
+      "Water3"
+    ],
+    "evolvesTo": 99,
+    "signatureMove": "Crabhammer"
+  },
+  {
+    "dexId": 99,
+    "name": "Kingler",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 55,
+      "attack": 130,
+      "defense": 115,
+      "specialAttack": 50,
+      "specialDefense": 50,
+      "speed": 75
+    },
+    "eggGroups": [
+      "Water3"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Crabhammer"
+  },
+  {
+    "dexId": 100,
+    "name": "Voltorb",
+    "types": [
+      "Electric"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 30,
+      "defense": 50,
+      "specialAttack": 55,
+      "specialDefense": 55,
+      "speed": 100
+    },
+    "eggGroups": [
+      "Mineral"
+    ],
+    "evolvesTo": 101,
+    "signatureMove": "Thunderbolt"
+  },
+  {
+    "dexId": 101,
+    "name": "Electrode",
+    "types": [
+      "Electric"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 50,
+      "defense": 70,
+      "specialAttack": 80,
+      "specialDefense": 80,
+      "speed": 150
+    },
+    "eggGroups": [
+      "Mineral"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Thunderbolt"
+  },
+  {
+    "dexId": 102,
+    "name": "Exeggcute",
+    "types": [
+      "Grass",
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 40,
+      "defense": 80,
+      "specialAttack": 60,
+      "specialDefense": 45,
+      "speed": 40
+    },
+    "eggGroups": [
+      "Plant"
+    ],
+    "evolvesTo": 103,
+    "signatureMove": "Solar Beam"
+  },
+  {
+    "dexId": 103,
+    "name": "Exeggutor",
+    "types": [
+      "Grass",
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 95,
+      "attack": 95,
+      "defense": 85,
+      "specialAttack": 125,
+      "specialDefense": 75,
+      "speed": 55
+    },
+    "eggGroups": [
+      "Plant"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Leaf Storm"
+  },
+  {
+    "dexId": 104,
+    "name": "Cubone",
+    "types": [
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 50,
+      "attack": 50,
+      "defense": 95,
+      "specialAttack": 40,
+      "specialDefense": 50,
+      "speed": 35
+    },
+    "eggGroups": [
+      "Monster"
+    ],
+    "evolvesTo": 105,
+    "signatureMove": "Stomping Tantrum"
+  },
+  {
+    "dexId": 105,
+    "name": "Marowak",
+    "types": [
+      "Ground"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 80,
+      "defense": 110,
+      "specialAttack": 50,
+      "specialDefense": 80,
+      "speed": 45
+    },
+    "eggGroups": [
+      "Monster"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Stomping Tantrum"
+  },
+  {
+    "dexId": 106,
+    "name": "Hitmonlee",
+    "types": [
+      "Fighting"
+    ],
+    "baseStats": {
+      "hp": 50,
+      "attack": 120,
+      "defense": 53,
+      "specialAttack": 35,
+      "specialDefense": 110,
+      "speed": 87
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "High Jump Kick"
+  },
+  {
+    "dexId": 107,
+    "name": "Hitmonchan",
+    "types": [
+      "Fighting"
+    ],
+    "baseStats": {
+      "hp": 50,
+      "attack": 105,
+      "defense": 79,
+      "specialAttack": 35,
+      "specialDefense": 110,
+      "speed": 76
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Focus Punch"
+  },
+  {
+    "dexId": 108,
+    "name": "Lickitung",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 90,
+      "attack": 55,
+      "defense": 75,
+      "specialAttack": 60,
+      "specialDefense": 75,
+      "speed": 30
+    },
+    "eggGroups": [
+      "Monster"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Giga Impact"
+  },
+  {
+    "dexId": 109,
+    "name": "Koffing",
+    "types": [
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 65,
+      "defense": 95,
+      "specialAttack": 60,
+      "specialDefense": 45,
+      "speed": 35
+    },
+    "eggGroups": [
+      "Indeterminate"
+    ],
+    "evolvesTo": 110,
+    "signatureMove": "Belch"
+  },
+  {
+    "dexId": 110,
+    "name": "Weezing",
+    "types": [
+      "Poison"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 90,
+      "defense": 120,
+      "specialAttack": 85,
+      "specialDefense": 70,
+      "speed": 60
+    },
+    "eggGroups": [
+      "Indeterminate"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Belch"
+  },
+  {
+    "dexId": 111,
+    "name": "Rhyhorn",
+    "types": [
+      "Ground",
+      "Rock"
+    ],
+    "baseStats": {
+      "hp": 80,
+      "attack": 85,
+      "defense": 95,
+      "specialAttack": 30,
+      "specialDefense": 30,
+      "speed": 25
+    },
+    "eggGroups": [
+      "Monster",
+      "Ground"
+    ],
+    "evolvesTo": 112,
+    "signatureMove": "Earthquake"
+  },
+  {
+    "dexId": 112,
+    "name": "Rhydon",
+    "types": [
+      "Ground",
+      "Rock"
+    ],
+    "baseStats": {
+      "hp": 105,
+      "attack": 130,
+      "defense": 120,
+      "specialAttack": 45,
+      "specialDefense": 45,
+      "speed": 40
+    },
+    "eggGroups": [
+      "Monster",
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Earthquake"
+  },
+  {
+    "dexId": 113,
+    "name": "Chansey",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 250,
+      "attack": 5,
+      "defense": 5,
+      "specialAttack": 35,
+      "specialDefense": 105,
+      "speed": 50
+    },
+    "eggGroups": [
+      "Fairy"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Last Resort"
+  },
+  {
+    "dexId": 114,
+    "name": "Tangela",
+    "types": [
+      "Grass"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 55,
+      "defense": 115,
+      "specialAttack": 100,
+      "specialDefense": 40,
+      "speed": 60
+    },
+    "eggGroups": [
+      "Plant"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Power Whip"
+  },
+  {
+    "dexId": 115,
+    "name": "Kangaskhan",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 105,
+      "attack": 95,
+      "defense": 80,
+      "specialAttack": 40,
+      "specialDefense": 80,
+      "speed": 90
+    },
+    "eggGroups": [
+      "Monster"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Last Resort"
+  },
+  {
+    "dexId": 116,
+    "name": "Horsea",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 30,
+      "attack": 40,
+      "defense": 70,
+      "specialAttack": 70,
+      "specialDefense": 25,
+      "speed": 60
+    },
+    "eggGroups": [
+      "Water1",
+      "Dragon"
+    ],
+    "evolvesTo": 117,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 117,
+    "name": "Seadra",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 55,
+      "attack": 65,
+      "defense": 95,
+      "specialAttack": 95,
+      "specialDefense": 45,
+      "speed": 85
+    },
+    "eggGroups": [
+      "Water1",
+      "Dragon"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 118,
+    "name": "Goldeen",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 45,
+      "attack": 67,
+      "defense": 60,
+      "specialAttack": 35,
+      "specialDefense": 50,
+      "speed": 63
+    },
+    "eggGroups": [
+      "Water2"
+    ],
+    "evolvesTo": 119,
+    "signatureMove": "Waterfall"
+  },
+  {
+    "dexId": 119,
+    "name": "Seaking",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 80,
+      "attack": 92,
+      "defense": 65,
+      "specialAttack": 65,
+      "specialDefense": 80,
+      "speed": 68
+    },
+    "eggGroups": [
+      "Water2"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Waterfall"
+  },
+  {
+    "dexId": 120,
+    "name": "Staryu",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 30,
+      "attack": 45,
+      "defense": 55,
+      "specialAttack": 70,
+      "specialDefense": 55,
+      "speed": 85
+    },
+    "eggGroups": [
+      "Water3"
+    ],
+    "evolvesTo": 121,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 121,
+    "name": "Starmie",
+    "types": [
+      "Water",
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 75,
+      "defense": 85,
+      "specialAttack": 100,
+      "specialDefense": 85,
+      "speed": 115
+    },
+    "eggGroups": [
+      "Water3"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 122,
+    "name": "Mr-mime",
+    "types": [
+      "Psychic",
+      "Fairy"
+    ],
+    "baseStats": {
+      "hp": 40,
+      "attack": 45,
+      "defense": 65,
+      "specialAttack": 100,
+      "specialDefense": 120,
+      "speed": 90
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Psychic"
+  },
+  {
+    "dexId": 123,
+    "name": "Scyther",
+    "types": [
+      "Bug",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 70,
+      "attack": 110,
+      "defense": 80,
+      "specialAttack": 55,
+      "specialDefense": 80,
+      "speed": 105
+    },
+    "eggGroups": [
+      "Bug"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "X Scissor"
+  },
+  {
+    "dexId": 124,
+    "name": "Jynx",
+    "types": [
+      "Ice",
+      "Psychic"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 50,
+      "defense": 35,
+      "specialAttack": 115,
+      "specialDefense": 95,
+      "speed": 95
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Blizzard"
+  },
+  {
+    "dexId": 125,
+    "name": "Electabuzz",
+    "types": [
+      "Electric"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 83,
+      "defense": 57,
+      "specialAttack": 95,
+      "specialDefense": 85,
+      "speed": 105
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Thunder"
+  },
+  {
+    "dexId": 126,
+    "name": "Magmar",
+    "types": [
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 95,
+      "defense": 57,
+      "specialAttack": 100,
+      "specialDefense": 85,
+      "speed": 93
+    },
+    "eggGroups": [
+      "Humanshape"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Fire Blast"
+  },
+  {
+    "dexId": 127,
+    "name": "Pinsir",
+    "types": [
+      "Bug"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 125,
+      "defense": 100,
+      "specialAttack": 55,
+      "specialDefense": 70,
+      "speed": 85
+    },
+    "eggGroups": [
+      "Bug"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "X Scissor"
+  },
+  {
+    "dexId": 128,
+    "name": "Tauros",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 75,
+      "attack": 100,
+      "defense": 95,
+      "specialAttack": 40,
+      "specialDefense": 70,
+      "speed": 110
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Giga Impact"
+  },
+  {
+    "dexId": 129,
+    "name": "Magikarp",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 20,
+      "attack": 10,
+      "defense": 55,
+      "specialAttack": 15,
+      "specialDefense": 20,
+      "speed": 80
+    },
+    "eggGroups": [
+      "Water2",
+      "Dragon"
+    ],
+    "evolvesTo": 130,
+    "signatureMove": "Tackle"
+  },
+  {
+    "dexId": 130,
+    "name": "Gyarados",
+    "types": [
+      "Water",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 95,
+      "attack": 125,
+      "defense": 79,
+      "specialAttack": 60,
+      "specialDefense": 100,
+      "speed": 81
+    },
+    "eggGroups": [
+      "Water2",
+      "Dragon"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 131,
+    "name": "Lapras",
+    "types": [
+      "Water",
+      "Ice"
+    ],
+    "baseStats": {
+      "hp": 130,
+      "attack": 85,
+      "defense": 80,
+      "specialAttack": 85,
+      "specialDefense": 95,
+      "speed": 60
+    },
+    "eggGroups": [
+      "Monster",
+      "Water1"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 132,
+    "name": "Ditto",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 48,
+      "attack": 48,
+      "defense": 48,
+      "specialAttack": 48,
+      "specialDefense": 48,
+      "speed": 48
+    },
+    "eggGroups": [
+      "Ditto"
+    ],
+    "evolvesTo": null,
+    "signatureMove": null
+  },
+  {
+    "dexId": 133,
+    "name": "Eevee",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 55,
+      "attack": 55,
+      "defense": 50,
+      "specialAttack": 45,
+      "specialDefense": 65,
+      "speed": 55
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": 136,
+    "signatureMove": "Last Resort"
+  },
+  {
+    "dexId": 134,
+    "name": "Vaporeon",
+    "types": [
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 130,
+      "attack": 65,
+      "defense": 60,
+      "specialAttack": 110,
+      "specialDefense": 95,
+      "speed": 65
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hydro Pump"
+  },
+  {
+    "dexId": 135,
+    "name": "Jolteon",
+    "types": [
+      "Electric"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 65,
+      "defense": 60,
+      "specialAttack": 110,
+      "specialDefense": 95,
+      "speed": 130
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Thunder"
+  },
+  {
+    "dexId": 136,
+    "name": "Flareon",
+    "types": [
+      "Fire"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 130,
+      "defense": 60,
+      "specialAttack": 95,
+      "specialDefense": 110,
+      "speed": 65
+    },
+    "eggGroups": [
+      "Ground"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Flare Blitz"
+  },
+  {
+    "dexId": 137,
+    "name": "Porygon",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 65,
+      "attack": 60,
+      "defense": 70,
+      "specialAttack": 85,
+      "specialDefense": 75,
+      "speed": 40
+    },
+    "eggGroups": [
+      "Mineral"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hyper Beam"
+  },
+  {
+    "dexId": 138,
+    "name": "Omanyte",
+    "types": [
+      "Rock",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 35,
+      "attack": 40,
+      "defense": 100,
+      "specialAttack": 90,
+      "specialDefense": 55,
+      "speed": 35
+    },
+    "eggGroups": [
+      "Water1",
+      "Water3"
+    ],
+    "evolvesTo": 139,
+    "signatureMove": "Rock Slide"
+  },
+  {
+    "dexId": 139,
+    "name": "Omastar",
+    "types": [
+      "Rock",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 70,
+      "attack": 60,
+      "defense": 125,
+      "specialAttack": 115,
+      "specialDefense": 70,
+      "speed": 55
+    },
+    "eggGroups": [
+      "Water1",
+      "Water3"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Rock Slide"
+  },
+  {
+    "dexId": 140,
+    "name": "Kabuto",
+    "types": [
+      "Rock",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 30,
+      "attack": 80,
+      "defense": 90,
+      "specialAttack": 55,
+      "specialDefense": 45,
+      "speed": 55
+    },
+    "eggGroups": [
+      "Water1",
+      "Water3"
+    ],
+    "evolvesTo": 141,
+    "signatureMove": "Stone Edge"
+  },
+  {
+    "dexId": 141,
+    "name": "Kabutops",
+    "types": [
+      "Rock",
+      "Water"
+    ],
+    "baseStats": {
+      "hp": 60,
+      "attack": 115,
+      "defense": 105,
+      "specialAttack": 65,
+      "specialDefense": 70,
+      "speed": 80
+    },
+    "eggGroups": [
+      "Water1",
+      "Water3"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Stone Edge"
+  },
+  {
+    "dexId": 142,
+    "name": "Aerodactyl",
+    "types": [
+      "Rock",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 80,
+      "attack": 105,
+      "defense": 65,
+      "specialAttack": 60,
+      "specialDefense": 75,
+      "speed": 130
+    },
+    "eggGroups": [
+      "Flying"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Stone Edge"
+  },
+  {
+    "dexId": 143,
+    "name": "Snorlax",
+    "types": [
+      "Normal"
+    ],
+    "baseStats": {
+      "hp": 160,
+      "attack": 110,
+      "defense": 65,
+      "specialAttack": 65,
+      "specialDefense": 110,
+      "speed": 30
+    },
+    "eggGroups": [
+      "Monster"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Hyper Beam"
+  },
+  {
+    "dexId": 144,
+    "name": "Articuno",
+    "types": [
+      "Ice",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 90,
+      "attack": 85,
+      "defense": 100,
+      "specialAttack": 95,
+      "specialDefense": 125,
+      "speed": 85
+    },
+    "eggGroups": [
+      "No-eggs"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Blizzard"
+  },
+  {
+    "dexId": 145,
+    "name": "Zapdos",
+    "types": [
+      "Electric",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 90,
+      "attack": 90,
+      "defense": 85,
+      "specialAttack": 125,
+      "specialDefense": 90,
+      "speed": 100
+    },
+    "eggGroups": [
+      "No-eggs"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Zap Cannon"
+  },
+  {
+    "dexId": 146,
+    "name": "Moltres",
+    "types": [
+      "Fire",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 90,
+      "attack": 100,
+      "defense": 90,
+      "specialAttack": 125,
+      "specialDefense": 85,
+      "speed": 90
+    },
+    "eggGroups": [
+      "No-eggs"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Overheat"
+  },
+  {
+    "dexId": 147,
+    "name": "Dratini",
+    "types": [
+      "Dragon"
+    ],
+    "baseStats": {
+      "hp": 41,
+      "attack": 64,
+      "defense": 45,
+      "specialAttack": 50,
+      "specialDefense": 50,
+      "speed": 50
+    },
+    "eggGroups": [
+      "Water1",
+      "Dragon"
+    ],
+    "evolvesTo": 148,
+    "signatureMove": "Outrage"
+  },
+  {
+    "dexId": 148,
+    "name": "Dragonair",
+    "types": [
+      "Dragon"
+    ],
+    "baseStats": {
+      "hp": 61,
+      "attack": 84,
+      "defense": 65,
+      "specialAttack": 70,
+      "specialDefense": 70,
+      "speed": 70
+    },
+    "eggGroups": [
+      "Water1",
+      "Dragon"
+    ],
+    "evolvesTo": 149,
+    "signatureMove": "Outrage"
+  },
+  {
+    "dexId": 149,
+    "name": "Dragonite",
+    "types": [
+      "Dragon",
+      "Flying"
+    ],
+    "baseStats": {
+      "hp": 91,
+      "attack": 134,
+      "defense": 95,
+      "specialAttack": 100,
+      "specialDefense": 100,
+      "speed": 80
+    },
+    "eggGroups": [
+      "Water1",
+      "Dragon"
+    ],
+    "evolvesTo": null,
+    "signatureMove": "Outrage"
+  }
+]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       'src/app/dicebound/**/*.test.tsx',
       'src/lib/dicebound/**/*.test.ts',
       'src/lib/voice-journey/**/*.test.ts',
+      'src/app/badge-run/**/*.test.ts',
     ],
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- Adds `scripts/badge-run-fetch-data.ts` — one-time PokéAPI fetch script
- Commits `domain/data/units.json` — 149 Kanto Pokémon (dex 1–149) with stats, types, egg groups, evolutions, and signature moves
- Commits `domain/data/type-chart.json` — 18-type effectiveness chart (non-1 values only)
- Adds Vitest tests asserting data integrity (3/3 passing)

## Test plan
- [ ] `npx vitest run src/app/badge-run/domain/data/__tests__/units.test.ts` passes
- [ ] 149 units in the catalog, 18 types in the chart
- [ ] All required fields non-null

Closes #3815

🤖 Generated with [Claude Code](https://claude.com/claude-code)