### PR TITLE
B-0.3 — Type effectiveness module

### DIFF
--- a/src/app/badge-run/domain/__tests__/type-chart.test.ts
+++ b/src/app/badge-run/domain/__tests__/type-chart.test.ts
@@ -1,0 +1,28 @@
+import { effectiveness } from '../type-chart'
+
+describe('effectiveness', () => {
+  it('returns 1 for neutral matchup', () => {
+    expect(effectiveness('Normal', ['Normal'])).toBe(1)
+  })
+  it('returns 2 for super effective', () => {
+    expect(effectiveness('Fire', ['Grass'])).toBe(2)
+  })
+  it('returns 0.5 for not very effective', () => {
+    expect(effectiveness('Fire', ['Water'])).toBe(0.5)
+  })
+  it('returns 0 for immune', () => {
+    expect(effectiveness('Normal', ['Ghost'])).toBe(0)
+  })
+  it('returns 4 for 2x stacking on dual type', () => {
+    // Fire vs Grass/Bug → 2 * 2 = 4
+    expect(effectiveness('Fire', ['Grass', 'Bug'])).toBe(4)
+  })
+  it('returns 0.25 for 0.5x stacking on dual type', () => {
+    // Fire vs Fire/Dragon → 0.5 * 0.5 = 0.25
+    expect(effectiveness('Fire', ['Fire', 'Dragon'])).toBe(0.25)
+  })
+  it('returns 0 when one defending type is immune even if other is weak', () => {
+    // Normal vs Ghost/Normal → 0 * 1 = 0
+    expect(effectiveness('Normal', ['Ghost', 'Normal'])).toBe(0)
+  })
+})

--- a/src/app/badge-run/domain/type-chart.ts
+++ b/src/app/badge-run/domain/type-chart.ts
@@ -1,0 +1,12 @@
+import rawChart from './data/type-chart.json'
+
+export type Type = keyof typeof rawChart
+
+// type-chart.json stores only non-1 values; missing = 1.0
+export function effectiveness(attacking: Type, defending: Type[]): number {
+  const row = rawChart[attacking] as Record<string, number> | undefined
+  return defending.reduce((acc, def) => {
+    const val = row?.[def] ?? 1
+    return acc * val
+  }, 1)
+}


### PR DESCRIPTION
## Summary
- Adds `domain/type-chart.ts` with `effectiveness(attacking, defending[])` function
- Reads the committed `type-chart.json` (non-1 values only; missing = 1.0)
- Multiplies matchups across dual-type defenders correctly
- 7 tests: neutral, 2x, 0.5x, 0x, 4x dual, 0.25x dual, immunity cancels weakness

Replaces #3877 (base chain corrected after B-0.1 squash merge).

## Test plan
- [x] `npx vitest run src/app/badge-run/domain/__tests__/type-chart.test.ts` — 7/7 pass

Closes #3816

🤖 Generated with [Claude Code](https://claude.com/claude-code)