### PR TITLE
B-0.4 — Unit catalog: tiers and kin

### DIFF
--- a/src/app/badge-run/domain/__tests__/__snapshots__/unit-catalog.test.ts.snap
+++ b/src/app/badge-run/domain/__tests__/__snapshots__/unit-catalog.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`UNIT_CATALOG > tier distribution snapshot 1`] = `
+{
+  "T1": 52,
+  "T2": 39,
+  "T3": 50,
+  "T4": 4,
+  "T5": 4,
+}
+`;

--- a/src/app/badge-run/domain/__tests__/unit-catalog.test.ts
+++ b/src/app/badge-run/domain/__tests__/unit-catalog.test.ts
@@ -1,0 +1,33 @@
+import { UNIT_CATALOG, Tier, Kin } from '../unit-catalog'
+
+describe('UNIT_CATALOG', () => {
+  it('every unit has exactly one tier', () => {
+    const validTiers: Tier[] = ['T1', 'T2', 'T3', 'T4', 'T5']
+    for (const u of UNIT_CATALOG) {
+      expect(validTiers).toContain(u.tier)
+    }
+  })
+
+  it('every unit has exactly one kin', () => {
+    const validKin: Kin[] = ['Pack', 'Flock', 'Brood', 'Shell', 'Mineral', 'Serpent', 'Humanoid', 'Amorphous']
+    for (const u of UNIT_CATALOG) {
+      expect(validKin).toContain(u.kin)
+    }
+  })
+
+  it('tier distribution snapshot', () => {
+    const dist: Record<string, number> = { T1: 0, T2: 0, T3: 0, T4: 0, T5: 0 }
+    for (const u of UNIT_CATALOG) dist[u.tier]++
+    expect(dist).toMatchSnapshot()
+  })
+
+  it('Bulbasaur is T1 (BST 318)', () => {
+    const bulbasaur = UNIT_CATALOG.find(u => u.dexId === 1)
+    expect(bulbasaur?.tier).toBe('T1')
+  })
+
+  it('Dragonite is T5 (BST 600)', () => {
+    const dragonite = UNIT_CATALOG.find(u => u.dexId === 149)
+    expect(dragonite?.tier).toBe('T5')
+  })
+})

--- a/src/app/badge-run/domain/unit-catalog.ts
+++ b/src/app/badge-run/domain/unit-catalog.ts
@@ -1,0 +1,68 @@
+import rawUnits from './data/units.json'
+
+export type Tier = 'T1' | 'T2' | 'T3' | 'T4' | 'T5'
+export type Kin = 'Pack' | 'Flock' | 'Brood' | 'Shell' | 'Mineral' | 'Serpent' | 'Humanoid' | 'Amorphous'
+
+const EGG_GROUP_TO_KIN: Record<string, Kin> = {
+  Monster:       'Brood',
+  Plant:         'Brood',
+  Bug:           'Brood',
+  Dragon:        'Serpent',
+  Water1:        'Shell',
+  Water2:        'Shell',
+  Water3:        'Shell',
+  Flying:        'Flock',
+  Fairy:         'Flock',
+  Ground:        'Pack',
+  Humanshape:    'Humanoid',
+  Mineral:       'Mineral',
+  Amorphous:     'Amorphous',
+  Indeterminate: 'Amorphous',
+  Ditto:         'Amorphous',
+  'No-eggs':     'Amorphous',
+}
+
+export interface CatalogUnit {
+  dexId: number
+  name: string
+  types: string[]
+  baseStats: {
+    hp: number
+    attack: number
+    defense: number
+    specialAttack: number
+    specialDefense: number
+    speed: number
+  }
+  eggGroups: string[]
+  evolvesTo: number | null
+  signatureMove: string | null
+  tier: Tier
+  kin: Kin
+}
+
+function computeBST(stats: CatalogUnit['baseStats']): number {
+  return stats.hp + stats.attack + stats.defense + stats.specialAttack + stats.specialDefense + stats.speed
+}
+
+function getTier(bst: number): Tier {
+  if (bst <= 340) return 'T1'
+  if (bst <= 450) return 'T2'
+  if (bst <= 534) return 'T3'
+  if (bst <= 579) return 'T4'
+  return 'T5'
+}
+
+function getKin(eggGroups: string[]): Kin {
+  for (const eg of eggGroups) {
+    const kin = EGG_GROUP_TO_KIN[eg]
+    if (kin) return kin
+  }
+  return 'Amorphous'  // fallback
+}
+
+export const UNIT_CATALOG: CatalogUnit[] = (rawUnits as typeof rawUnits).map(u => ({
+  ...u,
+  tier: getTier(computeBST(u.baseStats)),
+  kin: getKin(u.eggGroups),
+}))


### PR DESCRIPTION
## Summary
- Adds `domain/unit-catalog.ts` exporting `UNIT_CATALOG` enriched with `tier` and `kin`
- Tier: T1 (BST≤340) / T2 (341-450) / T3 (451-534) / T4 (535-579) / T5 (580+)
- Kin: 8 categories mapped from PokéAPI egg groups
- 5 tests: tier validity, kin validity, snapshot of tier distribution, Bulbasaur=T1, Dragonite=T5

Replaces #3880 (re-stacked after B-0.2 squash merge).

## Test plan
- [x] 5/5 tests pass

Closes #3817

🤖 Generated with [Claude Code](https://claude.com/claude-code)