### PR TITLE
B-0.5 — Faction assignment

### DIFF
--- a/src/app/badge-run/domain/__tests__/factions.test.ts
+++ b/src/app/badge-run/domain/__tests__/factions.test.ts
@@ -1,0 +1,36 @@
+import { FACTIONS, getFaction, FactionName } from '../data/factions'
+import units from '../data/units.json'
+
+describe('FACTIONS', () => {
+  it('every faction has at least 3 members', () => {
+    for (const [name, ids] of Object.entries(FACTIONS) as [FactionName, readonly number[]][]) {
+      expect(ids.length, `${name} has fewer than 3 members`).toBeGreaterThanOrEqual(3)
+    }
+  })
+
+  it('no unit carries more than one faction', () => {
+    const seen = new Map<number, FactionName>()
+    for (const [name, ids] of Object.entries(FACTIONS) as [FactionName, readonly number[]][]) {
+      for (const id of ids) {
+        expect(seen.has(id), `dexId ${id} appears in both "${seen.get(id)}" and "${name}"`).toBe(false)
+        seen.set(id, name)
+      }
+    }
+  })
+
+  it('all faction dexIds are valid Kanto units (1-149)', () => {
+    const validIds = new Set(units.map(u => u.dexId))
+    for (const [name, ids] of Object.entries(FACTIONS) as [FactionName, readonly number[]][]) {
+      for (const id of ids) {
+        expect(validIds.has(id), `${name} references dexId ${id} which is not in the unit catalog`).toBe(true)
+      }
+    }
+  })
+
+  it('getFaction returns correct faction', () => {
+    expect(getFaction(52)).toBe('Team Rocket')   // Meowth
+    expect(getFaction(133)).toBe('Eeveelutions') // Eevee
+    expect(getFaction(144)).toBe('Legendary Birds') // Articuno
+    expect(getFaction(1)).toBeNull()              // Bulbasaur — unaffiliated
+  })
+})

--- a/src/app/badge-run/domain/data/factions.ts
+++ b/src/app/badge-run/domain/data/factions.ts
@@ -1,0 +1,27 @@
+export type FactionName =
+  | 'Team Rocket'
+  | 'Silph Co.'
+  | 'Elite Four'
+  | 'Fossils'
+  | 'Eeveelutions'
+  | 'Safari Zone'
+  | 'Legendary Birds'
+
+/** dexIds belonging to each faction */
+export const FACTIONS: Record<FactionName, readonly number[]> = {
+  'Team Rocket': [19, 20, 23, 24, 41, 42, 52, 53, 88, 89, 109, 110],
+  'Silph Co.':   [63, 64, 65, 81, 82, 137],
+  'Elite Four':  [79, 80, 87, 90, 91, 93, 94, 106, 107, 124, 130, 131, 148, 149],
+  'Fossils':     [138, 139, 140, 141, 142],
+  'Eeveelutions':[133, 134, 135, 136],
+  'Safari Zone': [29, 30, 31, 32, 33, 34, 46, 47, 48, 49, 102, 103, 111, 112, 113, 115, 123, 128, 147],
+  'Legendary Birds': [144, 145, 146],
+}
+
+/** Returns the faction a unit belongs to, or null if unaffiliated */
+export function getFaction(dexId: number): FactionName | null {
+  for (const [name, ids] of Object.entries(FACTIONS) as [FactionName, readonly number[]][]) {
+    if ((ids as readonly number[]).includes(dexId)) return name
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- Adds `domain/data/factions.ts` with 7 hand-authored factions: Team Rocket, Silph Co., Elite Four, Fossils, Eeveelutions, Safari Zone, Legendary Birds
- Exports `FACTIONS` record (dexId arrays) and `getFaction(dexId)` lookup helper
- 4 tests: ≥3 members per faction, no unit in two factions, all dexIds valid, getFaction spot-checks

## Test plan
- [x] `npx vitest run src/app/badge-run/domain/__tests__/factions.test.ts` — 4/4 pass

Closes #3818

🤖 Generated with [Claude Code](https://claude.com/claude-code)