### PR TITLE
B-1.1 — Seeded RNG and battle types

### DIFF
--- a/src/app/badge-run/domain/__tests__/rng.test.ts
+++ b/src/app/badge-run/domain/__tests__/rng.test.ts
@@ -1,0 +1,46 @@
+import { makePRNG } from '../rng'
+
+describe('makePRNG', () => {
+  it('same seed produces same sequence', () => {
+    const a = makePRNG(42)
+    const b = makePRNG(42)
+    const seqA = Array.from({ length: 10 }, () => a.next())
+    const seqB = Array.from({ length: 10 }, () => b.next())
+    expect(seqA).toEqual(seqB)
+  })
+
+  it('different seeds produce different sequences', () => {
+    const a = makePRNG(1)
+    const b = makePRNG(2)
+    const seqA = Array.from({ length: 5 }, () => a.next())
+    const seqB = Array.from({ length: 5 }, () => b.next())
+    expect(seqA).not.toEqual(seqB)
+  })
+
+  it('next() returns values in [0, 1)', () => {
+    const rng = makePRNG(99)
+    for (let i = 0; i < 100; i++) {
+      const v = rng.next()
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThan(1)
+    }
+  })
+
+  it('nextInt(n) returns integers in [0, n)', () => {
+    const rng = makePRNG(7)
+    for (let i = 0; i < 100; i++) {
+      const v = rng.nextInt(6)
+      expect(Number.isInteger(v)).toBe(true)
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThan(6)
+    }
+  })
+
+  it('sequence is deterministic across re-creation', () => {
+    const first = makePRNG(12345)
+    const expected = Array.from({ length: 20 }, () => first.next())
+    const second = makePRNG(12345)
+    const actual = Array.from({ length: 20 }, () => second.next())
+    expect(actual).toEqual(expected)
+  })
+})

--- a/src/app/badge-run/domain/battle/types.ts
+++ b/src/app/badge-run/domain/battle/types.ts
@@ -1,0 +1,33 @@
+/** A unit as it appears in a battle (snapshot of catalog data + live HP) */
+export interface BattleUnit {
+  /** Unique per-battle instance id (e.g. "attacker-0", "defender-2") */
+  instanceId: string
+  dexId: number
+  name: string
+  types: string[]
+  tier: string
+  kin: string
+  maxHp: number
+  currentHp: number
+  attack: number
+  defense: number
+  specialAttack: number
+  specialDefense: number
+  speed: number
+  signatureMove: string | null
+  fainted: boolean
+}
+
+export interface Team {
+  id: string
+  units: BattleUnit[]
+}
+
+export interface BattleConfig {
+  seed: number
+  arenaId: string
+  /** The player's team */
+  attacker: Team
+  /** The opponent's team */
+  defender: Team
+}

--- a/src/app/badge-run/domain/rng.ts
+++ b/src/app/badge-run/domain/rng.ts
@@ -1,0 +1,38 @@
+/**
+ * Seeded deterministic PRNG (Mulberry32).
+ * Pure — no Date.now(), no Math.random().
+ *
+ * Usage:
+ *   const rng = makePRNG(42)
+ *   rng.next()      // 0–1 float
+ *   rng.nextInt(6)  // 0–5 integer
+ */
+export interface PRNG {
+  /** Returns a float in [0, 1) */
+  next(): number
+  /** Returns an integer in [0, n) */
+  nextInt(n: number): number
+  /** Returns a float in [min, max) */
+  nextFloat(min: number, max: number): number
+}
+
+export function makePRNG(seed: number): PRNG {
+  let s = seed >>> 0
+
+  function next(): number {
+    s = (s + 0x6d2b79f5) >>> 0
+    let t = Math.imul(s ^ (s >>> 15), 1 | s)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  return {
+    next,
+    nextInt(n: number): number {
+      return Math.floor(next() * n)
+    },
+    nextFloat(min: number, max: number): number {
+      return min + next() * (max - min)
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `domain/rng.ts`: Mulberry32 seeded PRNG — `makePRNG(seed)` returns `{ next(), nextInt(n), nextFloat(min, max) }`
- Adds `domain/battle/types.ts`: foundational `BattleUnit`, `Team`, `BattleConfig` interfaces
- 5 tests: same seed → same sequence, different seeds differ, range [0,1), integer range, determinism across re-creation

## Test plan
- [x] `npx vitest run src/app/badge-run/domain/__tests__/rng.test.ts` — 5/5 pass

Closes #3820

🤖 Generated with [Claude Code](https://claude.com/claude-code)