### PR TITLE
B-1.2 — Battle event log

### DIFF
--- a/src/app/badge-run/domain/__tests__/events.test.ts
+++ b/src/app/badge-run/domain/__tests__/events.test.ts
@@ -1,0 +1,87 @@
+import type { BattleEvent, BattleResult } from '../battle/events'
+
+describe('BattleEvent discriminated union', () => {
+  it('fixture log round-trips through JSON unchanged', () => {
+    const log: BattleEvent[] = [
+      {
+        type: 'unit_acts',
+        turn: 1,
+        actorId: 'attacker-0',
+        targetId: 'defender-0',
+        moveName: 'Flamethrower',
+      },
+      {
+        type: 'damage',
+        turn: 1,
+        targetId: 'defender-0',
+        amount: 45,
+        effectiveness: 2,
+        critical: false,
+      },
+      {
+        type: 'arena_tick',
+        turn: 1,
+        arenaId: 'poison-marsh',
+        rule: 'toxic-spill',
+        affectedUnitIds: ['attacker-0', 'defender-0'],
+      },
+      {
+        type: 'synergy_applied',
+        turn: 1,
+        synergyId: 'kin:Brood:2',
+        affectedUnitIds: ['attacker-0'],
+        effect: '+15% attack',
+      },
+      {
+        type: 'faint',
+        turn: 2,
+        unitId: 'defender-0',
+      },
+      {
+        type: 'battle_end',
+        turn: 2,
+        winnerId: 'team-attacker',
+        loserId: 'team-defender',
+      },
+    ]
+
+    const serialized = JSON.stringify(log)
+    const restored = JSON.parse(serialized) as BattleEvent[]
+    expect(restored).toEqual(log)
+  })
+
+  it('BattleResult fixture round-trips through JSON', () => {
+    const result: BattleResult = {
+      config: {
+        seed: 42,
+        arenaId: 'rock-tunnel',
+        attackerTeamId: 'team-a',
+        defenderTeamId: 'team-b',
+      },
+      events: [
+        { type: 'battle_end', turn: 5, winnerId: 'team-a', loserId: 'team-b' },
+      ],
+      winnerId: 'team-a',
+      totalTurns: 5,
+    }
+
+    const serialized = JSON.stringify(result)
+    const restored = JSON.parse(serialized) as BattleResult
+    expect(restored).toEqual(result)
+  })
+
+  it('type discriminant narrows correctly', () => {
+    const events: BattleEvent[] = [
+      { type: 'damage', turn: 1, targetId: 'x', amount: 10, effectiveness: 1, critical: false },
+      { type: 'faint', turn: 1, unitId: 'x' },
+    ]
+
+    for (const evt of events) {
+      if (evt.type === 'damage') {
+        expect(evt.amount).toBe(10)
+      } else if (evt.type === 'faint') {
+        expect(evt.unitId).toBe('x')
+      }
+    }
+  })
+})

--- a/src/app/badge-run/domain/battle/events.ts
+++ b/src/app/badge-run/domain/battle/events.ts
@@ -1,0 +1,72 @@
+/** A unit takes its turn and uses its move */
+export interface UnitActsEvent {
+  type: 'unit_acts'
+  turn: number
+  actorId: string   // instanceId of the acting unit
+  targetId: string  // instanceId of the target unit
+  moveName: string
+}
+
+/** A unit takes damage */
+export interface DamageEvent {
+  type: 'damage'
+  turn: number
+  targetId: string
+  amount: number        // HP lost (always positive)
+  effectiveness: number // 0, 0.5, 1, 2, 4, etc.
+  critical: boolean
+}
+
+/** A unit faints (HP reaches 0) */
+export interface FaintEvent {
+  type: 'faint'
+  turn: number
+  unitId: string
+}
+
+/** The arena's house rule effect fires (once per round) */
+export interface ArenaTickEvent {
+  type: 'arena_tick'
+  turn: number
+  arenaId: string
+  rule: string         // the HouseRule string
+  affectedUnitIds: string[]
+}
+
+/** A synergy bonus activates */
+export interface SynergyAppliedEvent {
+  type: 'synergy_applied'
+  turn: number
+  synergyId: string    // e.g. "kin:Brood:2" or "faction:Team Rocket:3"
+  affectedUnitIds: string[]
+  effect: string       // human-readable description, e.g. "+15% attack"
+}
+
+/** The battle ends */
+export interface BattleEndEvent {
+  type: 'battle_end'
+  turn: number
+  winnerId: string     // team id of the winner
+  loserId: string
+}
+
+export type BattleEvent =
+  | UnitActsEvent
+  | DamageEvent
+  | FaintEvent
+  | ArenaTickEvent
+  | SynergyAppliedEvent
+  | BattleEndEvent
+
+/** The full result of a simulated battle */
+export interface BattleResult {
+  config: {
+    seed: number
+    arenaId: string
+    attackerTeamId: string
+    defenderTeamId: string
+  }
+  events: BattleEvent[]
+  winnerId: string
+  totalTurns: number
+}


### PR DESCRIPTION
## Summary
- Adds `domain/battle/events.ts` with the full discriminated union of battle events:
  `unit_acts`, `damage`, `faint`, `arena_tick`, `synergy_applied`, `battle_end`
- Adds `BattleResult` type (config + events + winnerId + totalTurns)
- 3 tests: event log JSON round-trip, BattleResult JSON round-trip, type discriminant narrowing

Written before the resolver so the UI becomes a pure consumer of the log.

## Test plan
- [x] `npx vitest run src/app/badge-run/domain/__tests__/events.test.ts` — 3/3 pass

Closes #3821

🤖 Generated with [Claude Code](https://claude.com/claude-code)