### PR TITLE
B-1.4 — Damage resolution

### DIFF
--- a/src/app/badge-run/domain/__tests__/damage.test.ts
+++ b/src/app/badge-run/domain/__tests__/damage.test.ts
@@ -1,0 +1,105 @@
+import { computeDamage, type MoveData } from '../battle/damage'
+import type { BattleUnit } from '../battle/types'
+
+function makeUnit(overrides: {
+  instanceId: string
+  types: string[]
+  attack?: number
+  defense?: number
+  specialAttack?: number
+  specialDefense?: number
+}): BattleUnit {
+  return {
+    dexId: 1,
+    name: 'TestMon',
+    tier: 'T1',
+    kin: 'Pack',
+    maxHp: 100,
+    currentHp: 100,
+    attack: overrides.attack ?? 80,
+    defense: overrides.defense ?? 80,
+    specialAttack: overrides.specialAttack ?? 80,
+    specialDefense: overrides.specialDefense ?? 80,
+    speed: 80,
+    signatureMove: null,
+    fainted: false,
+    ...overrides,
+  }
+}
+
+const CASES: Array<{
+  label: string
+  attacker: BattleUnit
+  defender: BattleUnit
+  move: MoveData
+  expectedMin: number
+  expectedMax: number
+}> = [
+  {
+    label: 'neutral physical move, no STAB',
+    attacker: makeUnit({ instanceId: 'a', types: ['Water'], attack: 80 }),
+    defender: makeUnit({ instanceId: 'd', types: ['Normal'], defense: 80 }),
+    move: { name: 'Tackle', type: 'Normal', category: 'physical', power: 40 },
+    expectedMin: 40,
+    expectedMax: 40,
+  },
+  {
+    label: 'physical move with STAB (1.5x)',
+    attacker: makeUnit({ instanceId: 'a', types: ['Fire'], attack: 80 }),
+    defender: makeUnit({ instanceId: 'd', types: ['Normal'], defense: 80 }),
+    move: { name: 'Ember', type: 'Fire', category: 'physical', power: 40 },
+    expectedMin: 60,
+    expectedMax: 60,
+  },
+  {
+    label: 'super effective (2x)',
+    attacker: makeUnit({ instanceId: 'a', types: ['Normal'], attack: 80 }),
+    defender: makeUnit({ instanceId: 'd', types: ['Fire'], defense: 80 }),
+    move: { name: 'Water Gun', type: 'Water', category: 'physical', power: 40 },
+    expectedMin: 80,
+    expectedMax: 80,
+  },
+  {
+    label: 'STAB + super effective (3x total)',
+    attacker: makeUnit({ instanceId: 'a', types: ['Water'], attack: 80 }),
+    defender: makeUnit({ instanceId: 'd', types: ['Fire'], defense: 80 }),
+    move: { name: 'Surf', type: 'Water', category: 'physical', power: 90 },
+    expectedMin: 270,
+    expectedMax: 270,
+  },
+  {
+    label: 'immune (0 damage)',
+    attacker: makeUnit({ instanceId: 'a', types: ['Normal'], attack: 80 }),
+    defender: makeUnit({ instanceId: 'd', types: ['Ghost'], defense: 80 }),
+    move: { name: 'Tackle', type: 'Normal', category: 'physical', power: 40 },
+    expectedMin: 0,
+    expectedMax: 0,
+  },
+  {
+    label: 'special move uses SpAtk/SpDef',
+    attacker: makeUnit({ instanceId: 'a', types: ['Fire'], specialAttack: 120, attack: 40 }),
+    defender: makeUnit({ instanceId: 'd', types: ['Normal'], specialDefense: 60, defense: 40 }),
+    move: { name: 'Flamethrower', type: 'Fire', category: 'special', power: 90 },
+    // 90 * (120/60) * 1 * 1.5 = 270
+    expectedMin: 270,
+    expectedMax: 270,
+  },
+  {
+    label: 'minimum damage is 1 for non-zero effectiveness',
+    attacker: makeUnit({ instanceId: 'a', types: ['Normal'], attack: 1 }),
+    defender: makeUnit({ instanceId: 'd', types: ['Normal'], defense: 10000 }),
+    move: { name: 'Tackle', type: 'Normal', category: 'physical', power: 1 },
+    expectedMin: 1,
+    expectedMax: 1,
+  },
+]
+
+describe('computeDamage', () => {
+  for (const tc of CASES) {
+    it(tc.label, () => {
+      const dmg = computeDamage(tc.attacker, tc.defender, tc.move)
+      expect(dmg).toBeGreaterThanOrEqual(tc.expectedMin)
+      expect(dmg).toBeLessThanOrEqual(tc.expectedMax)
+    })
+  }
+})

--- a/src/app/badge-run/domain/battle/damage.ts
+++ b/src/app/badge-run/domain/battle/damage.ts
@@ -1,0 +1,38 @@
+import { effectiveness, type Type } from '../type-chart'
+import type { BattleUnit } from './types'
+
+export type MoveCategory = 'physical' | 'special'
+
+export interface MoveData {
+  name: string
+  type: Type
+  category: MoveCategory
+  power: number
+}
+
+/**
+ * Compute damage dealt.
+ *
+ * Formula: floor(power × (atk / def) × effectiveness × stab)
+ * - Physical moves: attacker.attack vs defender.defense
+ * - Special moves: attacker.specialAttack vs defender.specialDefense
+ * - STAB: 1.5 if attacker's primary type matches move type, else 1
+ * - effectiveness: from the type chart (dual-type defenders multiply)
+ *
+ * Minimum damage is 1 (unless effectiveness is 0).
+ */
+export function computeDamage(
+  attacker: BattleUnit,
+  defender: BattleUnit,
+  move: MoveData
+): number {
+  const atk = move.category === 'physical' ? attacker.attack : attacker.specialAttack
+  const def = move.category === 'physical' ? defender.defense : defender.specialDefense
+
+  const stab = attacker.types.includes(move.type) ? 1.5 : 1
+  const eff = effectiveness(move.type, defender.types as Type[])
+
+  const raw = move.power * (atk / def) * eff * stab
+  if (eff === 0) return 0
+  return Math.max(1, Math.floor(raw))
+}


### PR DESCRIPTION
## Summary
- Adds `domain/battle/damage.ts` with `computeDamage(attacker, defender, move)`
- Formula: `floor(power × atk/def × effectiveness × stab)`
  - Physical: `attack` vs `defense`; Special: `specialAttack` vs `specialDefense`
  - STAB: 1.5x if attacker's types include move type
  - Min damage: 1 (unless immune = 0)
- 7 table-driven tests: neutral, STAB, 2x, STAB+2x=3x, immune, special stats, min=1

## Test plan
- [x] `npx vitest run src/app/badge-run/domain/__tests__/damage.test.ts` — 7/7 pass

Closes #3823

🤖 Generated with [Claude Code](https://claude.com/claude-code)