### PR TITLE
B-1.3 — Turn queue

### DIFF
--- a/src/app/badge-run/domain/__tests__/turn-queue.test.ts
+++ b/src/app/badge-run/domain/__tests__/turn-queue.test.ts
@@ -1,0 +1,76 @@
+import { buildTurnQueue } from '../battle/turn-queue'
+import { makePRNG } from '../rng'
+import type { BattleUnit } from '../battle/types'
+
+function makeUnit(overrides: Partial<BattleUnit> & { instanceId: string; speed: number }): BattleUnit {
+  return {
+    dexId: 1,
+    name: 'TestMon',
+    types: ['Normal'],
+    tier: 'T1',
+    kin: 'Pack',
+    maxHp: 100,
+    currentHp: 100,
+    attack: 50,
+    defense: 50,
+    specialAttack: 50,
+    specialDefense: 50,
+    signatureMove: null,
+    fainted: false,
+    ...overrides,
+  }
+}
+
+describe('buildTurnQueue', () => {
+  it('orders units by speed descending', () => {
+    const attacker = [makeUnit({ instanceId: 'a-0', speed: 40 })]
+    const defender = [makeUnit({ instanceId: 'd-0', speed: 80 })]
+    const rng = makePRNG(1)
+    const queue = buildTurnQueue(attacker, defender, rng)
+    expect(queue[0].unit.instanceId).toBe('d-0')
+    expect(queue[1].unit.instanceId).toBe('a-0')
+  })
+
+  it('tie-breaks deterministically with the same seed', () => {
+    const attacker = [makeUnit({ instanceId: 'a-0', speed: 50 })]
+    const defender = [makeUnit({ instanceId: 'd-0', speed: 50 })]
+    const queue1 = buildTurnQueue(attacker, defender, makePRNG(42))
+    const queue2 = buildTurnQueue(attacker, defender, makePRNG(42))
+    expect(queue1.map(e => e.unit.instanceId)).toEqual(queue2.map(e => e.unit.instanceId))
+  })
+
+  it('different seeds can produce different tie-break order', () => {
+    const attacker = [makeUnit({ instanceId: 'a-0', speed: 50 })]
+    const defender = [makeUnit({ instanceId: 'd-0', speed: 50 })]
+    const results = new Set<string>()
+    // Try a handful of seeds — at least two should differ
+    for (let seed = 0; seed < 20; seed++) {
+      const queue = buildTurnQueue(attacker, defender, makePRNG(seed))
+      results.add(queue[0].unit.instanceId)
+    }
+    expect(results.size).toBeGreaterThan(1)
+  })
+
+  it('fainted units are excluded from the queue', () => {
+    const attacker = [
+      makeUnit({ instanceId: 'a-0', speed: 80 }),
+      makeUnit({ instanceId: 'a-1', speed: 60, fainted: true }),
+    ]
+    const defender = [makeUnit({ instanceId: 'd-0', speed: 70 })]
+    const rng = makePRNG(1)
+    const queue = buildTurnQueue(attacker, defender, rng)
+    expect(queue).toHaveLength(2)
+    expect(queue.map(e => e.unit.instanceId)).not.toContain('a-1')
+  })
+
+  it('labels entries with correct teamId', () => {
+    const attacker = [makeUnit({ instanceId: 'a-0', speed: 50 })]
+    const defender = [makeUnit({ instanceId: 'd-0', speed: 50 })]
+    const rng = makePRNG(1)
+    const queue = buildTurnQueue(attacker, defender, rng)
+    const aEntry = queue.find(e => e.unit.instanceId === 'a-0')
+    const dEntry = queue.find(e => e.unit.instanceId === 'd-0')
+    expect(aEntry?.teamId).toBe('attacker')
+    expect(dEntry?.teamId).toBe('defender')
+  })
+})

--- a/src/app/badge-run/domain/battle/turn-queue.ts
+++ b/src/app/badge-run/domain/battle/turn-queue.ts
@@ -1,0 +1,39 @@
+import type { BattleUnit } from './types'
+import type { PRNG } from '../rng'
+
+export interface TurnEntry {
+  unit: BattleUnit
+  /** Which team this unit belongs to: 'attacker' | 'defender' */
+  teamId: string
+}
+
+/**
+ * Build the action order for one round.
+ *
+ * Units are sorted by speed descending. Ties are broken by a
+ * deterministic RNG draw (higher draw goes first), so replaying
+ * the same seed always produces the same order.
+ *
+ * Fainted units are excluded.
+ */
+export function buildTurnQueue(
+  attackerUnits: BattleUnit[],
+  defenderUnits: BattleUnit[],
+  rng: PRNG
+): TurnEntry[] {
+  const entries: (TurnEntry & { tiebreaker: number })[] = [
+    ...attackerUnits
+      .filter(u => !u.fainted)
+      .map(u => ({ unit: u, teamId: 'attacker', tiebreaker: rng.next() })),
+    ...defenderUnits
+      .filter(u => !u.fainted)
+      .map(u => ({ unit: u, teamId: 'defender', tiebreaker: rng.next() })),
+  ]
+
+  entries.sort((a, b) => {
+    if (b.unit.speed !== a.unit.speed) return b.unit.speed - a.unit.speed
+    return b.tiebreaker - a.tiebreaker // higher draw wins tie
+  })
+
+  return entries.map(({ unit, teamId }) => ({ unit, teamId }))
+}


### PR DESCRIPTION
Re-stacked. Speed-ordered action cycle, seeded RNG tie-breaking. 5/5 tests. Closes #3822. 🤖 Generated with [Claude Code](https://claude.com/claude-code)