### PR TITLE
B-1.5 — Battle runner

### DIFF
--- a/src/app/badge-run/domain/__tests__/runner.test.ts
+++ b/src/app/badge-run/domain/__tests__/runner.test.ts
@@ -1,0 +1,155 @@
+import { runBattle } from '../battle/runner'
+import type { BattleUnit, Team } from '../battle/types'
+
+function makeUnit(overrides: Partial<BattleUnit> & { instanceId: string }): BattleUnit {
+  return {
+    dexId: 1,
+    name: 'TestMon',
+    types: ['Normal'],
+    tier: 'T2',
+    kin: 'Pack',
+    maxHp: 60,
+    currentHp: 60,
+    attack: 60,
+    defense: 60,
+    specialAttack: 60,
+    specialDefense: 60,
+    speed: 60,
+    signatureMove: null,
+    fainted: false,
+    ...overrides,
+  }
+}
+
+function makeTeam(id: string, units: BattleUnit[]): Team {
+  return { id, units }
+}
+
+function make3v3(): { attackerTeam: Team; defenderTeam: Team } {
+  const attackerTeam = makeTeam('team-a', [
+    makeUnit({ instanceId: 'a-0', types: ['Fire'] }),
+    makeUnit({ instanceId: 'a-1', types: ['Water'] }),
+    makeUnit({ instanceId: 'a-2', types: ['Grass'] }),
+  ])
+  const defenderTeam = makeTeam('team-d', [
+    makeUnit({ instanceId: 'd-0', types: ['Normal'] }),
+    makeUnit({ instanceId: 'd-1', types: ['Rock'] }),
+    makeUnit({ instanceId: 'd-2', types: ['Electric'] }),
+  ])
+  return { attackerTeam, defenderTeam }
+}
+
+describe('runBattle', () => {
+  it('determinism: same inputs produce identical events and result', () => {
+    const { attackerTeam, defenderTeam } = make3v3()
+    const arenaId = 'rock-tunnel'
+    const seed = 42
+
+    const run1 = runBattle(attackerTeam, defenderTeam, arenaId, seed)
+    const run2 = runBattle(attackerTeam, defenderTeam, arenaId, seed)
+
+    expect(run1.events).toEqual(run2.events)
+    expect(run1.result).toEqual(run2.result)
+  })
+
+  it('cycle cap: nearly unkillable units still produce a valid result within MAX_ROUNDS', () => {
+    // Huge HP, minimal damage output (low attack vs high defense)
+    const tankTeam = makeTeam('team-tank', [
+      makeUnit({ instanceId: 't-0', maxHp: 100000, currentHp: 100000, attack: 1, defense: 10000, specialDefense: 10000 }),
+      makeUnit({ instanceId: 't-1', maxHp: 100000, currentHp: 100000, attack: 1, defense: 10000, specialDefense: 10000 }),
+    ])
+    const tankTeam2 = makeTeam('team-tank2', [
+      makeUnit({ instanceId: 'u-0', maxHp: 100000, currentHp: 100000, attack: 1, defense: 10000, specialDefense: 10000 }),
+      makeUnit({ instanceId: 'u-1', maxHp: 100000, currentHp: 100000, attack: 1, defense: 10000, specialDefense: 10000 }),
+    ])
+
+    const { result } = runBattle(tankTeam, tankTeam2, 'rock-tunnel', 99)
+
+    expect(result.totalTurns).toBeLessThanOrEqual(100)
+    const validIds = new Set(['team-tank', 'team-tank2'])
+    expect(validIds.has(result.winnerId)).toBe(true)
+    expect(validIds.has(result.config.attackerTeamId)).toBe(true)
+    expect(validIds.has(result.config.defenderTeamId)).toBe(true)
+  })
+
+  it('valid result: winner is one of the two team IDs, loser is the other, totalTurns >= 1', () => {
+    const { attackerTeam, defenderTeam } = make3v3()
+    const { result } = runBattle(attackerTeam, defenderTeam, 'tidal-shelf', 7)
+
+    expect([attackerTeam.id, defenderTeam.id]).toContain(result.winnerId)
+    const loserId = result.events.find(e => e.type === 'battle_end')
+    expect(loserId).toBeDefined()
+    if (loserId && loserId.type === 'battle_end') {
+      expect(loserId.winnerId).toBe(result.winnerId)
+      const otherId = result.winnerId === attackerTeam.id ? defenderTeam.id : attackerTeam.id
+      expect(loserId.loserId).toBe(otherId)
+    }
+    expect(result.totalTurns).toBeGreaterThanOrEqual(1)
+  })
+
+  it('events structure: all events have correct turn field, battle_end is last', () => {
+    const { attackerTeam, defenderTeam } = make3v3()
+    const { events } = runBattle(attackerTeam, defenderTeam, 'poison-marsh', 13)
+
+    expect(events.length).toBeGreaterThan(0)
+
+    // All events have a turn field >= 1
+    for (const ev of events) {
+      expect(ev.turn).toBeGreaterThanOrEqual(1)
+    }
+
+    // battle_end is the last event
+    const lastEvent = events[events.length - 1]
+    expect(lastEvent.type).toBe('battle_end')
+
+    // There should be exactly one battle_end event
+    const battleEnds = events.filter(e => e.type === 'battle_end')
+    expect(battleEnds).toHaveLength(1)
+  })
+
+  it('does not mutate input teams', () => {
+    const { attackerTeam, defenderTeam } = make3v3()
+    const originalAttackerHp = attackerTeam.units.map(u => u.currentHp)
+    const originalDefenderHp = defenderTeam.units.map(u => u.currentHp)
+
+    runBattle(attackerTeam, defenderTeam, 'rock-tunnel', 1)
+
+    expect(attackerTeam.units.map(u => u.currentHp)).toEqual(originalAttackerHp)
+    expect(defenderTeam.units.map(u => u.currentHp)).toEqual(originalDefenderHp)
+    expect(attackerTeam.units.every(u => !u.fainted)).toBe(true)
+    expect(defenderTeam.units.every(u => !u.fainted)).toBe(true)
+  })
+
+  it('unknown arenaId is handled gracefully (no crash, valid result)', () => {
+    const { attackerTeam, defenderTeam } = make3v3()
+    const { result, events } = runBattle(attackerTeam, defenderTeam, 'nonexistent-arena', 5)
+
+    expect(result.totalTurns).toBeGreaterThanOrEqual(1)
+    expect(events[events.length - 1].type).toBe('battle_end')
+  })
+
+  it('6v6 battle resolves in a finite number of rounds', () => {
+    const attackerTeam = makeTeam('team-a6', [
+      makeUnit({ instanceId: 'a-0', types: ['Fire'], speed: 80 }),
+      makeUnit({ instanceId: 'a-1', types: ['Water'], speed: 70 }),
+      makeUnit({ instanceId: 'a-2', types: ['Grass'], speed: 65 }),
+      makeUnit({ instanceId: 'a-3', types: ['Electric'], speed: 60 }),
+      makeUnit({ instanceId: 'a-4', types: ['Ice'], speed: 55 }),
+      makeUnit({ instanceId: 'a-5', types: ['Fighting'], speed: 50 }),
+    ])
+    const defenderTeam = makeTeam('team-d6', [
+      makeUnit({ instanceId: 'd-0', types: ['Normal'], speed: 75 }),
+      makeUnit({ instanceId: 'd-1', types: ['Rock'], speed: 68 }),
+      makeUnit({ instanceId: 'd-2', types: ['Bug'], speed: 62 }),
+      makeUnit({ instanceId: 'd-3', types: ['Poison'], speed: 57 }),
+      makeUnit({ instanceId: 'd-4', types: ['Dragon'], speed: 52 }),
+      makeUnit({ instanceId: 'd-5', types: ['Dark'], speed: 45 }),
+    ])
+
+    const { result } = runBattle(attackerTeam, defenderTeam, 'volcanic-cavern', 2024)
+
+    expect(result.totalTurns).toBeGreaterThanOrEqual(1)
+    expect(result.totalTurns).toBeLessThanOrEqual(100)
+    expect([attackerTeam.id, defenderTeam.id]).toContain(result.winnerId)
+  })
+})

--- a/src/app/badge-run/domain/battle/runner.ts
+++ b/src/app/badge-run/domain/battle/runner.ts
@@ -1,0 +1,199 @@
+import { makePRNG } from '../rng'
+import { getArena } from '../data/arenas'
+import { effectiveness } from '../type-chart'
+import { buildTurnQueue } from './turn-queue'
+import { computeDamage } from './damage'
+import type { MoveData, MoveCategory } from './damage'
+import type { BattleUnit, Team } from './types'
+import type { BattleEvent, BattleResult } from './events'
+import type { Type } from '../type-chart'
+
+const MAX_ROUNDS = 100
+
+/** Power by tier */
+const TIER_POWER: Record<string, number> = {
+  T1: 40,
+  T2: 50,
+  T3: 60,
+  T4: 75,
+  T5: 90,
+}
+
+function deepCopyTeam(team: Team): Team {
+  return {
+    id: team.id,
+    units: team.units.map(u => ({ ...u })),
+  }
+}
+
+function aliveUnits(units: BattleUnit[]): BattleUnit[] {
+  return units.filter(u => !u.fainted)
+}
+
+function totalHp(units: BattleUnit[]): number {
+  return units.reduce((sum, u) => sum + u.currentHp, 0)
+}
+
+function buildMove(unit: BattleUnit, arena: ReturnType<typeof getArena>): MoveData {
+  const type = unit.types[0] as Type
+  const category: MoveCategory = unit.attack >= unit.specialAttack ? 'physical' : 'special'
+  const basePower = TIER_POWER[unit.tier] ?? 50
+  const name = unit.signatureMove ?? `${unit.types[0]} Strike`
+
+  // Apply arena type boost if move type matches
+  let power = basePower
+  if (arena) {
+    const boost = arena.typeBoosts[type as keyof typeof arena.typeBoosts]
+    if (boost !== undefined) {
+      power = basePower * boost
+    }
+  }
+
+  return { name, type, category, power }
+}
+
+export function runBattle(
+  attackerTeam: Team,
+  defenderTeam: Team,
+  arenaId: string,
+  seed: number,
+): { events: BattleEvent[]; result: BattleResult } {
+  const attacker = deepCopyTeam(attackerTeam)
+  const defender = deepCopyTeam(defenderTeam)
+  const arena = getArena(arenaId)
+  const rng = makePRNG(seed)
+  const events: BattleEvent[] = []
+
+  let turn = 0
+  let winnerId: string | null = null
+
+  function checkWin(): boolean {
+    const attackerAlive = aliveUnits(attacker.units).length > 0
+    const defenderAlive = aliveUnits(defender.units).length > 0
+
+    if (!attackerAlive && !defenderAlive) {
+      // Both wiped out simultaneously — attacker wins by convention
+      winnerId = attacker.id
+      return true
+    }
+    if (!attackerAlive) {
+      winnerId = defender.id
+      return true
+    }
+    if (!defenderAlive) {
+      winnerId = attacker.id
+      return true
+    }
+    return false
+  }
+
+  for (let round = 0; round < MAX_ROUNDS; round++) {
+    turn = round + 1
+
+    // --- Arena tick ---
+    const arenaAffected: string[] = []
+    if (arena && arena.houseRules.includes('toxic-spill')) {
+      const allUnits = [...attacker.units, ...defender.units].filter(u => !u.fainted)
+      for (const unit of allUnits) {
+        const poisonDmg = Math.max(1, Math.floor(unit.maxHp * 0.05))
+        unit.currentHp = Math.max(0, unit.currentHp - poisonDmg)
+        arenaAffected.push(unit.instanceId)
+        if (unit.currentHp === 0 && !unit.fainted) {
+          unit.fainted = true
+          events.push({ type: 'faint', turn, unitId: unit.instanceId })
+        }
+      }
+    }
+
+    events.push({
+      type: 'arena_tick',
+      turn,
+      arenaId,
+      rule: arena ? (arena.houseRules[0] ?? 'none') : 'none',
+      affectedUnitIds: arenaAffected,
+    })
+
+    // Check win after arena tick
+    if (checkWin()) break
+
+    // --- Build turn queue ---
+    const queue = buildTurnQueue(attacker.units, defender.units, rng)
+
+    // --- Process each unit's action ---
+    for (const entry of queue) {
+      if (entry.unit.fainted) continue
+
+      // Pick a random alive enemy
+      const enemies =
+        entry.teamId === 'attacker'
+          ? aliveUnits(defender.units)
+          : aliveUnits(attacker.units)
+
+      if (enemies.length === 0) break
+
+      const target = enemies[rng.nextInt(enemies.length)]
+      const move = buildMove(entry.unit, arena)
+
+      events.push({
+        type: 'unit_acts',
+        turn,
+        actorId: entry.unit.instanceId,
+        targetId: target.instanceId,
+        moveName: move.name,
+      })
+
+      const dmg = computeDamage(entry.unit, target, move)
+      const effectivenessValue = effectiveness(move.type, target.types as Type[])
+
+      target.currentHp = Math.max(0, target.currentHp - dmg)
+
+      events.push({
+        type: 'damage',
+        turn,
+        targetId: target.instanceId,
+        amount: dmg,
+        effectiveness: effectivenessValue,
+        critical: false,
+      })
+
+      if (target.currentHp === 0 && !target.fainted) {
+        target.fainted = true
+        events.push({ type: 'faint', turn, unitId: target.instanceId })
+      }
+
+      if (checkWin()) break
+    }
+
+    if (winnerId !== null) break
+  }
+
+  // --- Cycle cap: determine winner by remaining HP ---
+  if (winnerId === null) {
+    const attackerHp = totalHp(attacker.units)
+    const defenderHp = totalHp(defender.units)
+    winnerId = attackerHp >= defenderHp ? attacker.id : defender.id
+  }
+
+  const loserId = winnerId === attacker.id ? defender.id : attacker.id
+
+  events.push({
+    type: 'battle_end',
+    turn,
+    winnerId,
+    loserId,
+  })
+
+  const result: BattleResult = {
+    config: {
+      seed,
+      arenaId,
+      attackerTeamId: attacker.id,
+      defenderTeamId: defender.id,
+    },
+    events,
+    winnerId,
+    totalTurns: turn,
+  }
+
+  return { events, result }
+}


### PR DESCRIPTION
Re-stacked. runBattle() with speed-ordered turns, damage, arena effects, 100-round cap. 7 tests. Closes #3824. 🤖 Generated with [Claude Code](https://claude.com/claude-code)