### PR TITLE
B-1.7 — Positioning

### DIFF
--- a/src/app/badge-run/domain/__tests__/positioning.test.ts
+++ b/src/app/badge-run/domain/__tests__/positioning.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { getTargets } from '../battle/positioning'
+import type { BattleUnit } from '../battle/types'
+
+function makeUnit(id: string, fainted = false): BattleUnit {
+  return {
+    instanceId: id, dexId: 1, name: id, types: ['Normal'], tier: 'T1', kin: 'Amorphous',
+    maxHp: 100, currentHp: fainted ? 0 : 100, attack: 50, defense: 50,
+    specialAttack: 50, specialDefense: 50, speed: 50, signatureMove: null, fainted,
+  }
+}
+
+const physicalMove = { name: 'Tackle', type: 'Normal' as const, category: 'physical' as const, power: 40 }
+const specialMove = { name: 'Swift', type: 'Normal' as const, category: 'special' as const, power: 40 }
+
+describe('getTargets', () => {
+  it('physical targets front row when front row alive', () => {
+    const units = [makeUnit('front1'), makeUnit('front2'), makeUnit('front3'), makeUnit('back1')]
+    const targets = getTargets(units, physicalMove, [])
+    expect(targets.map(u => u.instanceId)).toEqual(['front1', 'front2', 'front3'])
+  })
+
+  it('physical falls through to back row when front row all fainted', () => {
+    const units = [makeUnit('front1', true), makeUnit('front2', true), makeUnit('front3', true), makeUnit('back1'), makeUnit('back2')]
+    const targets = getTargets(units, physicalMove, [])
+    expect(targets.map(u => u.instanceId)).toEqual(['back1', 'back2'])
+  })
+
+  it('special move can target any alive unit including back row', () => {
+    const units = [makeUnit('front1'), makeUnit('front2'), makeUnit('front3'), makeUnit('back1')]
+    const targets = getTargets(units, specialMove, [])
+    expect(targets.map(u => u.instanceId)).toEqual(['front1', 'front2', 'front3', 'back1'])
+  })
+
+  it('excavation site: physical reaches back row too', () => {
+    const units = [makeUnit('front1'), makeUnit('front2'), makeUnit('front3'), makeUnit('back1')]
+    const targets = getTargets(units, physicalMove, ['excavation'])
+    expect(targets.map(u => u.instanceId)).toEqual(['front1', 'front2', 'front3', 'back1'])
+  })
+
+  it('excludes fainted units from results', () => {
+    const units = [makeUnit('front1', true), makeUnit('front2'), makeUnit('front3'), makeUnit('back1')]
+    const targets = getTargets(units, physicalMove, [])
+    expect(targets.map(u => u.instanceId)).toEqual(['front2', 'front3'])
+  })
+})

--- a/src/app/badge-run/domain/battle/positioning.ts
+++ b/src/app/badge-run/domain/battle/positioning.ts
@@ -1,0 +1,12 @@
+import type { BattleUnit } from './types'
+import type { MoveData } from './damage'
+
+export function getTargets(enemyUnits: BattleUnit[], move: MoveData, houseRules: string[]): BattleUnit[] {
+  const excavation = houseRules.includes('excavation')
+  if (move.category === 'physical' && !excavation) {
+    const aliveFront = enemyUnits.slice(0, 3).filter(u => !u.fainted)
+    if (aliveFront.length > 0) return aliveFront
+    return enemyUnits.slice(3).filter(u => !u.fainted)
+  }
+  return enemyUnits.filter(u => !u.fainted)
+}

--- a/src/app/badge-run/domain/battle/runner.ts
+++ b/src/app/badge-run/domain/battle/runner.ts
@@ -7,6 +7,7 @@ import type { BattleUnit, Team } from './types'
 import type { BattleEvent, BattleResult } from './events'
 import type { Type } from '../type-chart'
 import { applyHouseRulePowerModifier, getEffectiveness, applyBlizzardSpeed } from './arena-effects'
+import { getTargets } from './positioning'
 
 const MAX_ROUNDS = 100
 
@@ -144,15 +145,17 @@ export function runBattle(
       if (entry.unit.fainted) continue
 
       // Pick a random alive enemy
-      const enemies =
+      const enemyUnits =
         entry.teamId === 'attacker'
-          ? aliveUnits(defender.units)
-          : aliveUnits(attacker.units)
+          ? defender.units
+          : attacker.units
+
+      const move = buildMove(entry.unit, arena)
+      const enemies = getTargets(enemyUnits, move, houseRules)
 
       if (enemies.length === 0) break
 
       const target = enemies[rng.nextInt(enemies.length)]
-      const move = buildMove(entry.unit, arena)
 
       events.push({
         type: 'unit_acts',


### PR DESCRIPTION
## Summary
- Adds `positioning.ts` with `getTargets`: physical moves target front row (indices 0-2) first, fall back to back row if front all fainted; special moves reach all alive units
- Excavation Site exception: physical also reaches back row
- Updates `runner.ts` to use `getTargets` for positioning-aware target selection
- 5 tests covering all positioning scenarios

## Test plan
- [x] 5 positioning tests pass
- [x] 7 runner tests still pass

Closes #3826

🤖 Generated with [Claude Code](https://claude.com/claude-code)