### PR TITLE
B-2.1 — Kin breakpoints

### DIFF
--- a/src/app/badge-run/domain/__tests__/kin-synergies.test.ts
+++ b/src/app/badge-run/domain/__tests__/kin-synergies.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest'
+import { applyKinSynergies } from '../battle/kin-synergies'
+import type { BattleUnit } from '../battle/types'
+
+function makeUnit(id: string, kin: BattleUnit['kin']): BattleUnit {
+  return {
+    instanceId: id, dexId: 1, name: id, types: ['Normal'], tier: 'T1', kin,
+    maxHp: 100, currentHp: 100, attack: 100, defense: 100,
+    specialAttack: 100, specialDefense: 100, speed: 100,
+    signatureMove: null, fainted: false,
+  }
+}
+
+function makeTeam(kin: BattleUnit['kin'], count: number): BattleUnit[] {
+  return Array.from({ length: count }, (_, i) => makeUnit(`u${i}`, kin))
+}
+
+describe('applyKinSynergies', () => {
+  // Pack
+  describe('Pack', () => {
+    it('at 2: attack becomes 110', () => {
+      const team = makeTeam('Pack', 2)
+      applyKinSynergies(team)
+      expect(team[0].attack).toBe(110)
+      expect(team[1].attack).toBe(110)
+    })
+
+    it('at 4: attack becomes 120', () => {
+      const team = makeTeam('Pack', 4)
+      applyKinSynergies(team)
+      expect(team[0].attack).toBe(120)
+    })
+
+    it('at 6: attack becomes 130, defense becomes 110', () => {
+      const team = makeTeam('Pack', 6)
+      applyKinSynergies(team)
+      expect(team[0].attack).toBe(130)
+      expect(team[0].defense).toBe(110)
+    })
+  })
+
+  // Flock
+  describe('Flock', () => {
+    it('at 2: speed becomes 110', () => {
+      const team = makeTeam('Flock', 2)
+      applyKinSynergies(team)
+      expect(team[0].speed).toBe(110)
+    })
+
+    it('at 4: speed becomes 120', () => {
+      const team = makeTeam('Flock', 4)
+      applyKinSynergies(team)
+      expect(team[0].speed).toBe(120)
+    })
+
+    it('at 6: speed becomes 130', () => {
+      const team = makeTeam('Flock', 6)
+      applyKinSynergies(team)
+      expect(team[0].speed).toBe(130)
+    })
+  })
+
+  // Brood
+  describe('Brood', () => {
+    it('at 2: maxHp becomes 110, currentHp becomes 110', () => {
+      const team = makeTeam('Brood', 2)
+      applyKinSynergies(team)
+      expect(team[0].maxHp).toBe(110)
+      expect(team[0].currentHp).toBe(110)
+    })
+
+    it('at 4: maxHp becomes 120, currentHp becomes 120', () => {
+      const team = makeTeam('Brood', 4)
+      applyKinSynergies(team)
+      expect(team[0].maxHp).toBe(120)
+      expect(team[0].currentHp).toBe(120)
+    })
+
+    it('at 6: maxHp becomes 130, currentHp becomes 130', () => {
+      const team = makeTeam('Brood', 6)
+      applyKinSynergies(team)
+      expect(team[0].maxHp).toBe(130)
+      expect(team[0].currentHp).toBe(130)
+    })
+  })
+
+  // Shell
+  describe('Shell', () => {
+    it('at 2: defense becomes 110', () => {
+      const team = makeTeam('Shell', 2)
+      applyKinSynergies(team)
+      expect(team[0].defense).toBe(110)
+      expect(team[0].specialDefense).toBe(100)
+    })
+
+    it('at 4: defense becomes 115, specialDefense becomes 110', () => {
+      const team = makeTeam('Shell', 4)
+      applyKinSynergies(team)
+      expect(team[0].defense).toBe(115)
+      expect(team[0].specialDefense).toBe(110)
+    })
+
+    it('at 6: defense becomes 120, specialDefense becomes 120', () => {
+      const team = makeTeam('Shell', 6)
+      applyKinSynergies(team)
+      expect(team[0].defense).toBe(120)
+      expect(team[0].specialDefense).toBe(120)
+    })
+  })
+
+  // Mineral
+  describe('Mineral', () => {
+    it('at 2: defense becomes 115', () => {
+      const team = makeTeam('Mineral', 2)
+      applyKinSynergies(team)
+      expect(team[0].defense).toBe(115)
+    })
+
+    it('at 4: defense becomes 125', () => {
+      const team = makeTeam('Mineral', 4)
+      applyKinSynergies(team)
+      expect(team[0].defense).toBe(125)
+    })
+
+    it('at 6: defense becomes 130, specialDefense becomes 115', () => {
+      const team = makeTeam('Mineral', 6)
+      applyKinSynergies(team)
+      expect(team[0].defense).toBe(130)
+      expect(team[0].specialDefense).toBe(115)
+    })
+  })
+
+  // Serpent
+  describe('Serpent', () => {
+    it('at 2: attack becomes 110, specialAttack becomes 110', () => {
+      const team = makeTeam('Serpent', 2)
+      applyKinSynergies(team)
+      expect(team[0].attack).toBe(110)
+      expect(team[0].specialAttack).toBe(110)
+    })
+
+    it('at 4: attack becomes 120, specialAttack becomes 120', () => {
+      const team = makeTeam('Serpent', 4)
+      applyKinSynergies(team)
+      expect(team[0].attack).toBe(120)
+      expect(team[0].specialAttack).toBe(120)
+    })
+
+    it('at 6: attack becomes 130, specialAttack becomes 130', () => {
+      const team = makeTeam('Serpent', 6)
+      applyKinSynergies(team)
+      expect(team[0].attack).toBe(130)
+      expect(team[0].specialAttack).toBe(130)
+    })
+  })
+
+  // Humanoid
+  describe('Humanoid', () => {
+    it('at 2: attack becomes 110', () => {
+      const team = makeTeam('Humanoid', 2)
+      applyKinSynergies(team)
+      expect(team[0].attack).toBe(110)
+    })
+
+    it('at 4: attack becomes 125', () => {
+      const team = makeTeam('Humanoid', 4)
+      applyKinSynergies(team)
+      expect(team[0].attack).toBe(125)
+    })
+
+    it('at 6: attack becomes 140', () => {
+      const team = makeTeam('Humanoid', 6)
+      applyKinSynergies(team)
+      expect(team[0].attack).toBe(140)
+    })
+  })
+
+  // Amorphous
+  describe('Amorphous', () => {
+    it('at 2: specialAttack becomes 110', () => {
+      const team = makeTeam('Amorphous', 2)
+      applyKinSynergies(team)
+      expect(team[0].specialAttack).toBe(110)
+    })
+
+    it('at 4: specialAttack becomes 120', () => {
+      const team = makeTeam('Amorphous', 4)
+      applyKinSynergies(team)
+      expect(team[0].specialAttack).toBe(120)
+    })
+
+    it('at 6: specialAttack becomes 130, specialDefense becomes 110', () => {
+      const team = makeTeam('Amorphous', 6)
+      applyKinSynergies(team)
+      expect(team[0].specialAttack).toBe(130)
+      expect(team[0].specialDefense).toBe(110)
+    })
+  })
+
+  // Edge cases
+  describe('edge cases', () => {
+    it('1 unit of a kin: no boost applied', () => {
+      const team = makeTeam('Pack', 1)
+      applyKinSynergies(team)
+      expect(team[0].attack).toBe(100)
+      expect(team[0].defense).toBe(100)
+    })
+
+    it('3 units: level 2 boost applies (×2 threshold)', () => {
+      const team = makeTeam('Pack', 3)
+      applyKinSynergies(team)
+      // 3 units triggers the 2-unit threshold (level 0 = ×1.10)
+      expect(team[0].attack).toBe(110)
+    })
+
+    it('returns correct synergyId for Pack at 2', () => {
+      const team = makeTeam('Pack', 2)
+      const result = applyKinSynergies(team)
+      expect(result).toHaveLength(1)
+      expect(result[0].synergyId).toBe('kin:Pack:2')
+    })
+
+    it('returns correct synergyId for Flock at 4', () => {
+      const team = makeTeam('Flock', 4)
+      const result = applyKinSynergies(team)
+      expect(result[0].synergyId).toBe('kin:Flock:4')
+    })
+
+    it('returns correct synergyId for Brood at 6', () => {
+      const team = makeTeam('Brood', 6)
+      const result = applyKinSynergies(team)
+      expect(result[0].synergyId).toBe('kin:Brood:6')
+    })
+
+    it('returns affectedUnitIds for all units in the kin group', () => {
+      const team = makeTeam('Shell', 4)
+      const result = applyKinSynergies(team)
+      expect(result[0].affectedUnitIds).toEqual(['u0', 'u1', 'u2', 'u3'])
+    })
+
+    it('handles multiple kin groups independently', () => {
+      const packUnits = makeTeam('Pack', 2)
+      const flockUnits = makeTeam('Flock', 4)
+      const mixed = [...packUnits, ...flockUnits]
+      const result = applyKinSynergies(mixed)
+      expect(result).toHaveLength(2)
+      // Pack at 2: attack boosted
+      expect(packUnits[0].attack).toBe(110)
+      // Flock at 4: speed boosted
+      expect(flockUnits[0].speed).toBe(120)
+    })
+  })
+})

--- a/src/app/badge-run/domain/battle/kin-synergies.ts
+++ b/src/app/badge-run/domain/battle/kin-synergies.ts
@@ -1,0 +1,72 @@
+import type { BattleUnit } from './types'
+import type { Kin } from '../unit-catalog'
+
+interface StatBoost {
+  attack?: number
+  defense?: number
+  specialAttack?: number
+  specialDefense?: number
+  speed?: number
+  hp?: number
+}
+
+// [at-2-boost, at-4-boost, at-6-boost] — highest applicable level wins (not cumulative)
+const KIN_BREAKPOINTS: Record<Kin, [StatBoost, StatBoost, StatBoost]> = {
+  Pack:     [{ attack: 1.10 }, { attack: 1.20 }, { attack: 1.30, defense: 1.10 }],
+  Flock:    [{ speed: 1.10 }, { speed: 1.20 }, { speed: 1.30 }],
+  Brood:    [{ hp: 1.10 }, { hp: 1.20 }, { hp: 1.30 }],
+  Shell:    [{ defense: 1.10 }, { defense: 1.15, specialDefense: 1.10 }, { defense: 1.20, specialDefense: 1.20 }],
+  Mineral:  [{ defense: 1.15 }, { defense: 1.25 }, { defense: 1.30, specialDefense: 1.15 }],
+  Serpent:  [{ attack: 1.10, specialAttack: 1.10 }, { attack: 1.20, specialAttack: 1.20 }, { attack: 1.30, specialAttack: 1.30 }],
+  Humanoid: [{ attack: 1.10 }, { attack: 1.25 }, { attack: 1.40 }],
+  Amorphous:[{ specialAttack: 1.10 }, { specialAttack: 1.20 }, { specialAttack: 1.30, specialDefense: 1.10 }],
+}
+
+function activeLevel(count: number): number {
+  if (count >= 6) return 2
+  if (count >= 4) return 1
+  if (count >= 2) return 0
+  return -1
+}
+
+function applyBoost(unit: BattleUnit, boost: StatBoost): void {
+  if (boost.attack)        unit.attack        = Math.round(unit.attack        * boost.attack)
+  if (boost.defense)       unit.defense       = Math.round(unit.defense       * boost.defense)
+  if (boost.specialAttack) unit.specialAttack = Math.round(unit.specialAttack * boost.specialAttack)
+  if (boost.specialDefense)unit.specialDefense= Math.round(unit.specialDefense* boost.specialDefense)
+  if (boost.speed)         unit.speed         = Math.round(unit.speed         * boost.speed)
+  if (boost.hp) {
+    unit.maxHp     = Math.round(unit.maxHp     * boost.hp)
+    unit.currentHp = Math.round(unit.currentHp * boost.hp)
+  }
+}
+
+/**
+ * Apply kin synergy bonuses to all units in the list (mutates in place).
+ * Returns a list of { synergyId, affectedUnitIds, effect } for event emission.
+ */
+export function applyKinSynergies(units: BattleUnit[]): { synergyId: string; affectedUnitIds: string[]; effect: string }[] {
+  const kinCounts = new Map<Kin, BattleUnit[]>()
+  for (const unit of units) {
+    const list = kinCounts.get(unit.kin as Kin) ?? []
+    list.push(unit)
+    kinCounts.set(unit.kin as Kin, list)
+  }
+
+  const applied: { synergyId: string; affectedUnitIds: string[]; effect: string }[] = []
+
+  for (const [kin, kinUnits] of kinCounts) {
+    const level = activeLevel(kinUnits.length)
+    if (level < 0) continue
+    const count = level === 2 ? 6 : level === 1 ? 4 : 2
+    const boost = KIN_BREAKPOINTS[kin][level]
+    for (const unit of kinUnits) applyBoost(unit, boost)
+    const effect = Object.entries(boost).map(([k, v]) => `+${Math.round((v - 1) * 100)}% ${k}`).join(', ')
+    applied.push({
+      synergyId: `kin:${kin}:${count}`,
+      affectedUnitIds: kinUnits.map(u => u.instanceId),
+      effect,
+    })
+  }
+  return applied
+}


### PR DESCRIPTION
## Summary
- Adds `kin-synergies.ts` with `applyKinSynergies`: mutates units in place, fires at 2/4/6 units of same kin, highest threshold wins
- 8 kin × 3 breakpoints + edge cases = 31 tests

## Kin bonuses
| Kin | 2 | 4 | 6 |
|---|---|---|---|
| Pack | atk×1.10 | atk×1.20 | atk×1.30, def×1.10 |
| Flock | spd×1.10 | spd×1.20 | spd×1.30 |
| Brood | hp×1.10 | hp×1.20 | hp×1.30 |
| Shell | def×1.10 | def×1.15, spDef×1.10 | def×1.20, spDef×1.20 |
| Mineral | def×1.15 | def×1.25 | def×1.30, spDef×1.15 |
| Serpent | atk/spAtk×1.10 | ×1.20 | ×1.30 |
| Humanoid | atk×1.10 | atk×1.25 | atk×1.40 |
| Amorphous | spAtk×1.10 | spAtk×1.20 | spAtk×1.30, spDef×1.10 |

Closes #3828

🤖 Generated with [Claude Code](https://claude.com/claude-code)