### PR TITLE
B-2.3 — Synergy resolution

### DIFF
--- a/src/app/badge-run/domain/__tests__/runner.test.ts
+++ b/src/app/badge-run/domain/__tests__/runner.test.ts
@@ -93,9 +93,13 @@ describe('runBattle', () => {
 
     expect(events.length).toBeGreaterThan(0)
 
-    // All events have a turn field >= 1
+    // synergy_applied events fire at turn 0 (pre-battle); all others are >= 1
     for (const ev of events) {
-      expect(ev.turn).toBeGreaterThanOrEqual(1)
+      if (ev.type === 'synergy_applied') {
+        expect(ev.turn).toBe(0)
+      } else {
+        expect(ev.turn).toBeGreaterThanOrEqual(1)
+      }
     }
 
     // battle_end is the last event

--- a/src/app/badge-run/domain/__tests__/synergy-resolution.test.ts
+++ b/src/app/badge-run/domain/__tests__/synergy-resolution.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { runBattle } from '../battle/runner'
+import type { Team } from '../battle/types'
+
+// Helper to build a minimal BattleUnit
+function makeUnit(instanceId: string, dexId: number, kin: string): any {
+  return {
+    instanceId, dexId, name: instanceId, types: ['Normal'], tier: 'T1', kin,
+    maxHp: 100, currentHp: 100, attack: 100, defense: 100,
+    specialAttack: 100, specialDefense: 100, speed: 100,
+    signatureMove: null, fainted: false,
+  }
+}
+
+function makeTeam(id: string, units: ReturnType<typeof makeUnit>[]): Team {
+  return { id, units }
+}
+
+describe('synergy resolution in runBattle', () => {
+  it('kin synergy fires: 2 Pack units produce a synergy_applied event with synergyId kin:Pack:2', () => {
+    const attackerTeam = makeTeam('team-a', [
+      makeUnit('a-0', 1, 'Pack'),
+      makeUnit('a-1', 2, 'Pack'),
+    ])
+    const defenderTeam = makeTeam('team-d', [
+      makeUnit('d-0', 3, 'Flock'),
+      makeUnit('d-1', 4, 'Flock'),
+    ])
+
+    const { events } = runBattle(attackerTeam, defenderTeam, 'rock-tunnel', 1)
+
+    const synergyEvents = events.filter(e => e.type === 'synergy_applied')
+    const packSynergy = synergyEvents.find(
+      e => e.type === 'synergy_applied' && e.synergyId === 'kin:Pack:2'
+    )
+    expect(packSynergy).toBeDefined()
+  })
+
+  it('faction synergy fires: 2 Team Rocket units (dexIds 19, 20) produce a synergy_applied event with synergyId faction:Team Rocket:2', () => {
+    const attackerTeam = makeTeam('team-a', [
+      makeUnit('a-0', 19, 'Pack'),
+      makeUnit('a-1', 20, 'Pack'),
+    ])
+    const defenderTeam = makeTeam('team-d', [
+      makeUnit('d-0', 3, 'Brood'),
+      makeUnit('d-1', 4, 'Brood'),
+    ])
+
+    const { events } = runBattle(attackerTeam, defenderTeam, 'rock-tunnel', 2)
+
+    const synergyEvents = events.filter(e => e.type === 'synergy_applied')
+    const rocketSynergy = synergyEvents.find(
+      e => e.type === 'synergy_applied' && e.synergyId === 'faction:Team Rocket:2'
+    )
+    expect(rocketSynergy).toBeDefined()
+  })
+
+  it('synergy events are at turn 0', () => {
+    const attackerTeam = makeTeam('team-a', [
+      makeUnit('a-0', 1, 'Pack'),
+      makeUnit('a-1', 2, 'Pack'),
+    ])
+    const defenderTeam = makeTeam('team-d', [
+      makeUnit('d-0', 3, 'Flock'),
+      makeUnit('d-1', 4, 'Flock'),
+    ])
+
+    const { events } = runBattle(attackerTeam, defenderTeam, 'rock-tunnel', 3)
+
+    const synergyEvents = events.filter(e => e.type === 'synergy_applied')
+    expect(synergyEvents.length).toBeGreaterThan(0)
+    for (const ev of synergyEvents) {
+      expect(ev.turn).toBe(0)
+    }
+  })
+
+  it('no synergy for lone units: all different kins produce no synergy_applied events', () => {
+    const attackerTeam = makeTeam('team-a', [
+      makeUnit('a-0', 1, 'Pack'),
+      makeUnit('a-1', 2, 'Flock'),
+      makeUnit('a-2', 3, 'Brood'),
+    ])
+    const defenderTeam = makeTeam('team-d', [
+      makeUnit('d-0', 4, 'Shell'),
+      makeUnit('d-1', 5, 'Mineral'),
+      makeUnit('d-2', 6, 'Serpent'),
+    ])
+
+    const { events } = runBattle(attackerTeam, defenderTeam, 'rock-tunnel', 4)
+
+    const synergyEvents = events.filter(e => e.type === 'synergy_applied')
+    expect(synergyEvents).toHaveLength(0)
+  })
+
+  it('both teams get synergy resolution: events from both attacker and defender appear', () => {
+    const attackerTeam = makeTeam('team-a', [
+      makeUnit('a-0', 1, 'Pack'),
+      makeUnit('a-1', 2, 'Pack'),
+    ])
+    const defenderTeam = makeTeam('team-d', [
+      makeUnit('d-0', 3, 'Flock'),
+      makeUnit('d-1', 4, 'Flock'),
+    ])
+
+    const { events } = runBattle(attackerTeam, defenderTeam, 'rock-tunnel', 5)
+
+    const synergyEvents = events.filter(e => e.type === 'synergy_applied')
+    // Attacker Pack synergy
+    const packSynergy = synergyEvents.find(
+      e => e.type === 'synergy_applied' && e.synergyId === 'kin:Pack:2'
+    )
+    // Defender Flock synergy
+    const flockSynergy = synergyEvents.find(
+      e => e.type === 'synergy_applied' && e.synergyId === 'kin:Flock:2'
+    )
+    expect(packSynergy).toBeDefined()
+    expect(flockSynergy).toBeDefined()
+  })
+})

--- a/src/app/badge-run/domain/battle/runner.ts
+++ b/src/app/badge-run/domain/battle/runner.ts
@@ -8,6 +8,8 @@ import type { BattleEvent, BattleResult } from './events'
 import type { Type } from '../type-chart'
 import { applyHouseRulePowerModifier, getEffectiveness, applyBlizzardSpeed } from './arena-effects'
 import { getTargets } from './positioning'
+import { applyKinSynergies } from './kin-synergies'
+import { applyFactionSynergies } from './faction-synergies'
 
 const MAX_ROUNDS = 100
 
@@ -71,6 +73,24 @@ export function runBattle(
   const arena = getArena(arenaId)
   const rng = makePRNG(seed)
   const events: BattleEvent[] = []
+
+  // --- Resolve synergies (pre-battle, turn 0) ---
+  const synergyEvents: BattleEvent[] = []
+  for (const [team] of [[attacker], [defender]] as const) {
+    const kinResults = applyKinSynergies(team.units)
+    const factionResults = applyFactionSynergies(team.units)
+    for (const s of [...kinResults, ...factionResults]) {
+      synergyEvents.push({
+        type: 'synergy_applied',
+        turn: 0,
+        synergyId: s.synergyId,
+        affectedUnitIds: s.affectedUnitIds,
+        effect: s.effect,
+      })
+    }
+  }
+  // Prepend synergy events (they happen before turn 1)
+  events.push(...synergyEvents)
 
   let turn = 0
   let winnerId: string | null = null


### PR DESCRIPTION
## Summary
- `runner.ts` now resolves kin + faction synergies after deep-copying teams, emitting `synergy_applied` events at turn 0
- 5 integration tests; also fixes runner tests to accept turn-0 events

Closes #3830

🤖 Generated with [Claude Code](https://claude.com/claude-code)