### PR TITLE
B-4.4 — Draft screen

### DIFF
--- a/src/app/badge-run/components/BattleScreen.tsx
+++ b/src/app/badge-run/components/BattleScreen.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useBlitzStore } from '../store'
+
+export function BattleScreen() {
+  const { run, battle, evolve } = useBlitzStore()
+  if (!run) return null
+
+  if (run.phase === 'evolve') {
+    return (
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16, padding: 32 }}>
+        <h2 style={{ color: '#fff', fontSize: 20, fontWeight: 700, margin: 0 }}>Victory!</h2>
+        <p style={{ color: 'rgba(255,255,255,0.55)', fontSize: 14, margin: 0 }}>
+          Your champion evolves.
+        </p>
+        <button onClick={evolve} style={{ padding: '10px 24px', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.2)', borderRadius: 6, color: '#fff', cursor: 'pointer', fontSize: 14 }}>
+          Continue
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16, padding: 32 }}>
+      <h2 style={{ color: '#fff', fontSize: 20, fontWeight: 700, margin: 0 }}>Battle!</h2>
+      <p style={{ color: 'rgba(255,255,255,0.55)', fontSize: 14, margin: 0 }}>
+        Round {run.round} — your team faces the arena.
+      </p>
+      <button onClick={battle} style={{ padding: '10px 24px', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.2)', borderRadius: 6, color: '#fff', cursor: 'pointer', fontSize: 14 }}>
+        Fight
+      </button>
+    </div>
+  )
+}

--- a/src/app/badge-run/components/DraftScreen.tsx
+++ b/src/app/badge-run/components/DraftScreen.tsx
@@ -1,0 +1,83 @@
+'use client'
+import { useBlitzStore } from '../store'
+import { ARENA_SCHEDULE } from '../domain/data/arenas'
+
+export function DraftScreen() {
+  const { run, pick } = useBlitzStore()
+  if (!run || !run.offers) return null
+
+  const arena = ARENA_SCHEDULE[(run.round - 1) % ARENA_SCHEDULE.length]
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: '24px 16px', gap: 24, maxWidth: 640, margin: '0 auto', width: '100%' }}>
+      <div>
+        <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: 12, letterSpacing: 2, margin: 0, textTransform: 'uppercase' }}>
+          Round {run.round} of 8
+        </p>
+        <h2 style={{ color: '#fff', fontSize: 22, fontWeight: 700, margin: '4px 0 0', letterSpacing: 1 }}>
+          {arena.name}
+        </h2>
+        {arena.houseRules.length > 0 && (
+          <p style={{ color: 'rgba(255,255,255,0.4)', fontSize: 12, margin: '4px 0 0' }}>
+            {arena.houseRules.join(' · ')}
+          </p>
+        )}
+      </div>
+
+      {run.team.length > 0 && (
+        <div>
+          <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: 11, letterSpacing: 1, margin: '0 0 6px', textTransform: 'uppercase' }}>
+            Your team
+          </p>
+          <p style={{ color: 'rgba(255,255,255,0.7)', fontSize: 13, margin: 0 }}>
+            {run.team.map(u => u.name).join(' · ')}
+          </p>
+        </div>
+      )}
+
+      <div>
+        <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: 11, letterSpacing: 1, margin: '0 0 12px', textTransform: 'uppercase' }}>
+          Choose one
+        </p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {run.offers.map((unit) => (
+            <button
+              key={unit.dexId}
+              onClick={() => pick(unit.dexId)}
+              style={{
+                background: 'rgba(255,255,255,0.05)',
+                border: '1px solid rgba(255,255,255,0.12)',
+                borderRadius: 8,
+                padding: '14px 16px',
+                cursor: 'pointer',
+                textAlign: 'left',
+                color: '#fff',
+                transition: 'background 0.15s',
+              }}
+              onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.10)')}
+              onMouseLeave={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.05)')}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                <span style={{ fontWeight: 700, fontSize: 16 }}>{unit.name}</span>
+                <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.45)', letterSpacing: 1 }}>{unit.tier}</span>
+              </div>
+              <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+                {unit.types.map(t => (
+                  <span key={t} style={{ fontSize: 11, color: 'rgba(255,255,255,0.55)', background: 'rgba(255,255,255,0.08)', padding: '2px 6px', borderRadius: 4 }}>
+                    {t}
+                  </span>
+                ))}
+                <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>{unit.kin}</span>
+              </div>
+              {unit.signatureMove && (
+                <p style={{ fontSize: 11, color: 'rgba(255,255,255,0.35)', margin: '4px 0 0' }}>
+                  {unit.signatureMove}
+                </p>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/badge-run/components/SummaryScreen.tsx
+++ b/src/app/badge-run/components/SummaryScreen.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { useBlitzStore } from '../store'
+
+export function SummaryScreen() {
+  const { run, reset } = useBlitzStore()
+  if (!run) return null
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16, padding: 32 }}>
+      <h2 style={{ color: '#fff', fontSize: 24, fontWeight: 800, margin: 0 }}>
+        {run.won ? 'Champion!' : 'Defeated'}
+      </h2>
+      <p style={{ color: 'rgba(255,255,255,0.55)', fontSize: 14, margin: 0, textAlign: 'center', maxWidth: 320 }}>
+        {run.won
+          ? `You conquered all 8 rounds. Your team: ${run.team.map(u => u.name).join(', ')}.`
+          : `Fell in round ${run.round}. Your team: ${run.team.map(u => u.name).join(', ')}.`
+        }
+      </p>
+      <button onClick={reset} style={{ padding: '10px 24px', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.2)', borderRadius: 6, color: '#fff', cursor: 'pointer', fontSize: 14 }}>
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/src/app/badge-run/page.tsx
+++ b/src/app/badge-run/page.tsx
@@ -1,11 +1,30 @@
+'use client'
+import { useEffect } from 'react'
+import { useBlitzStore } from './store'
+import { DraftScreen } from './components/DraftScreen'
+import { BattleScreen } from './components/BattleScreen'
+import { SummaryScreen } from './components/SummaryScreen'
+
 export default function BadgeRunPage() {
-  return (
-    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16, padding: 32 }}>
-      <h1 style={{ fontSize: 32, fontWeight: 800, color: '#fff', margin: 0, letterSpacing: 2 }}>THE BADGE RUN</h1>
-      <p style={{ fontSize: 14, color: 'rgba(255,255,255,0.45)', letterSpacing: 1, textAlign: 'center', maxWidth: 400 }}>
-        The arena stirs. Champions are being summoned from across the cosmos.
-        Return soon — the run is not yet ready.
-      </p>
-    </div>
-  )
+  const { run, startDailyRun } = useBlitzStore()
+
+  useEffect(() => {
+    if (!run) startDailyRun()
+  }, [run, startDailyRun])
+
+  if (!run || run.phase === 'idle') {
+    return (
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: 14, letterSpacing: 1 }}>
+          Summoning the arena…
+        </p>
+      </div>
+    )
+  }
+
+  if (run.phase === 'draft') return <DraftScreen />
+  if (run.phase === 'battle' || run.phase === 'evolve') return <BattleScreen />
+  if (run.phase === 'summary') return <SummaryScreen />
+
+  return null
 }


### PR DESCRIPTION
## Summary
- Wires `page.tsx` to route between DraftScreen, BattleScreen, SummaryScreen based on run phase
- `DraftScreen`: shows round/arena context, current team, 3 unit offer cards with type/tier/kin/move
- `BattleScreen`: minimal placeholder with fight/evolve buttons
- `SummaryScreen`: win/loss display with full team list and reset

Closes #3839

🤖 Generated with [Claude Code](https://claude.com/claude-code)