### PR TITLE
B-4.2 + B-4.3 — Blitz store (zustand) and daily seed

### DIFF
--- a/src/app/badge-run/domain/__tests__/daily-seed.test.ts
+++ b/src/app/badge-run/domain/__tests__/daily-seed.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { getDailySeed } from '../../store'
+
+describe('getDailySeed', () => {
+  it('returns a positive integer', () => {
+    const seed = getDailySeed()
+    expect(seed).toBeGreaterThan(0)
+    expect(Number.isInteger(seed)).toBe(true)
+  })
+
+  it('looks like a YYYYMMDD date integer', () => {
+    const seed = getDailySeed()
+    const str = String(seed)
+    expect(str).toHaveLength(8)
+    expect(str.startsWith('2')).toBe(true) // 21st century
+  })
+
+  it('is the same when called twice on the same day', () => {
+    expect(getDailySeed()).toBe(getDailySeed())
+  })
+})

--- a/src/app/badge-run/store.ts
+++ b/src/app/badge-run/store.ts
@@ -1,0 +1,62 @@
+'use client'
+import { create } from 'zustand'
+import {
+  type BlitzRun,
+  startBlitz,
+  pickUnit,
+  resolveBattle,
+  resolveEvolution,
+} from './domain/blitz/run'
+
+interface BlitzStore {
+  run: BlitzRun | null
+  /** Start a new run with the given seed */
+  startRun: (seed: number) => void
+  /** Start a run with today's UTC date seed */
+  startDailyRun: () => void
+  /** Pick a unit from the current draft offers */
+  pick: (dexId: number) => void
+  /** Resolve the current battle */
+  battle: () => void
+  /** Apply the evolution after a won battle */
+  evolve: () => void
+  /** Reset back to idle */
+  reset: () => void
+}
+
+/** Returns a deterministic seed for today's UTC date (YYYYMMDD as integer) */
+export function getDailySeed(): number {
+  const now = new Date()
+  const y = now.getUTCFullYear()
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(now.getUTCDate()).padStart(2, '0')
+  return Number(`${y}${m}${d}`)
+}
+
+export const useBlitzStore = create<BlitzStore>((set, get) => ({
+  run: null,
+
+  startRun: (seed) => set({ run: startBlitz(seed) }),
+
+  startDailyRun: () => set({ run: startBlitz(getDailySeed()) }),
+
+  pick: (dexId) => {
+    const { run } = get()
+    if (!run || run.phase !== 'draft') return
+    set({ run: pickUnit(run, dexId) })
+  },
+
+  battle: () => {
+    const { run } = get()
+    if (!run || run.phase !== 'battle') return
+    set({ run: resolveBattle(run) })
+  },
+
+  evolve: () => {
+    const { run } = get()
+    if (!run || run.phase !== 'evolve') return
+    set({ run: resolveEvolution(run) })
+  },
+
+  reset: () => set({ run: null }),
+}))


### PR DESCRIPTION
## B-4.2 + B-4.3 — Blitz store and daily seed

Zustand store (`useBlitzStore`) wiring `startBlitz`, `pick`, `battle`, `evolve`, `reset`. Daily seed derived from UTC date (YYYYMMDD as integer) so the run is shared across all players on the same day.

**Issues closed:** #3852, #3853

🤖 Generated with [Claude Code](https://claude.com/claude-code)