### PR TITLE
B-4.6 — Run summary with team display and spoiler-free share string

### DIFF
--- a/src/app/badge-run/components/SummaryScreen.tsx
+++ b/src/app/badge-run/components/SummaryScreen.tsx
@@ -1,24 +1,80 @@
 'use client'
-import { useBlitzStore } from '../store'
+import { useState } from 'react'
+import { useBlitzStore, getDailySeed } from '../store'
+
+function buildShareString(run: { round: number; won: boolean; lost: boolean }): string {
+  const today = new Date()
+  const date = `${today.getUTCFullYear()}-${String(today.getUTCMonth() + 1).padStart(2, '0')}-${String(today.getUTCDate()).padStart(2, '0')}`
+  const roundsCompleted = run.won ? 8 : run.round - 1
+  const result = run.won ? 'cleared' : `fell round ${run.round}`
+  return `Badge Run ${roundsCompleted}/8 — ${result} | ${date}`
+}
 
 export function SummaryScreen() {
   const { run, reset } = useBlitzStore()
+  const [copied, setCopied] = useState(false)
+
   if (!run) return null
 
+  const shareText = buildShareString(run)
+
+  function copyShare() {
+    navigator.clipboard.writeText(shareText).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }).catch(() => {
+      // Clipboard not available — just show the text
+    })
+  }
+
   return (
-    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16, padding: 32 }}>
-      <h2 style={{ color: '#fff', fontSize: 24, fontWeight: 800, margin: 0 }}>
-        {run.won ? 'Champion!' : 'Defeated'}
-      </h2>
-      <p style={{ color: 'rgba(255,255,255,0.55)', fontSize: 14, margin: 0, textAlign: 'center', maxWidth: 320 }}>
-        {run.won
-          ? `You conquered all 8 rounds. Your team: ${run.team.map(u => u.name).join(', ')}.`
-          : `Fell in round ${run.round}. Your team: ${run.team.map(u => u.name).join(', ')}.`
-        }
-      </p>
-      <button onClick={reset} style={{ padding: '10px 24px', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.2)', borderRadius: 6, color: '#fff', cursor: 'pointer', fontSize: 14 }}>
-        Try again
-      </button>
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 20, padding: '32px 16px', maxWidth: 480, margin: '0 auto', width: '100%' }}>
+      <div style={{ textAlign: 'center' }}>
+        <h2 style={{ color: '#fff', fontSize: 28, fontWeight: 800, margin: '0 0 8px', letterSpacing: 1 }}>
+          {run.won ? 'Champion' : 'Defeated'}
+        </h2>
+        <p style={{ color: 'rgba(255,255,255,0.5)', fontSize: 14, margin: 0 }}>
+          {run.won
+            ? 'All 8 arenas conquered.'
+            : `Fell in round ${run.round} of 8.`}
+        </p>
+      </div>
+
+      {run.team.length > 0 && (
+        <div style={{ width: '100%' }}>
+          <p style={{ color: 'rgba(255,255,255,0.35)', fontSize: 11, letterSpacing: 1, textTransform: 'uppercase', margin: '0 0 8px' }}>
+            Your team
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {run.team.map((unit, i) => (
+              <div key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 12px', background: 'rgba(255,255,255,0.04)', borderRadius: 6, border: '1px solid rgba(255,255,255,0.08)' }}>
+                <span style={{ color: '#fff', fontSize: 14, fontWeight: 600 }}>{unit.name}</span>
+                <span style={{ color: 'rgba(255,255,255,0.4)', fontSize: 12 }}>{unit.tier} · {unit.types.join('/')}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div style={{ width: '100%', background: 'rgba(255,255,255,0.04)', borderRadius: 8, padding: '12px 16px', border: '1px solid rgba(255,255,255,0.08)' }}>
+        <p style={{ color: 'rgba(255,255,255,0.35)', fontSize: 11, letterSpacing: 1, textTransform: 'uppercase', margin: '0 0 4px' }}>Share</p>
+        <p style={{ color: 'rgba(255,255,255,0.75)', fontSize: 13, fontFamily: 'monospace', margin: 0 }}>{shareText}</p>
+      </div>
+
+      <div style={{ display: 'flex', gap: 12 }}>
+        <button
+          onClick={copyShare}
+          style={{ padding: '10px 20px', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.2)', borderRadius: 6, color: '#fff', cursor: 'pointer', fontSize: 13 }}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+        <button
+          onClick={reset}
+          style={{ padding: '10px 20px', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 6, color: 'rgba(255,255,255,0.6)', cursor: 'pointer', fontSize: 13 }}
+        >
+          Run again
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/app/badge-run/domain/__tests__/share.test.ts
+++ b/src/app/badge-run/domain/__tests__/share.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+
+// Mirror the share string format (not importing the component to avoid 'use client')
+function buildShareString(run: { round: number; won: boolean; lost: boolean }): string {
+  const today = new Date()
+  const date = `${today.getUTCFullYear()}-${String(today.getUTCMonth() + 1).padStart(2, '0')}-${String(today.getUTCDate()).padStart(2, '0')}`
+  const roundsCompleted = run.won ? 8 : run.round - 1
+  const result = run.won ? 'cleared' : `fell round ${run.round}`
+  return `Badge Run ${roundsCompleted}/8 — ${result} | ${date}`
+}
+
+describe('buildShareString', () => {
+  it('formats a win correctly', () => {
+    const s = buildShareString({ round: 8, won: true, lost: false })
+    expect(s).toContain('8/8')
+    expect(s).toContain('cleared')
+  })
+
+  it('formats a loss correctly', () => {
+    const s = buildShareString({ round: 3, won: false, lost: true })
+    expect(s).toContain('2/8') // rounds completed = round - 1 = 2
+    expect(s).toContain('fell round 3')
+  })
+
+  it('contains today\'s date', () => {
+    const s = buildShareString({ round: 1, won: false, lost: true })
+    const year = new Date().getUTCFullYear().toString()
+    expect(s).toContain(year)
+  })
+})


### PR DESCRIPTION
## B-4.6 — Run summary

`SummaryScreen` shows final team with tier/types per unit, round reached, win/loss, and a spoiler-free share string (`Badge Run X/8 — cleared | YYYY-MM-DD` or `fell round N`). Copy-to-clipboard with 2s feedback.

**Issues closed:** #3857

🤖 Generated with [Claude Code](https://claude.com/claude-code)