### PR TITLE
B-4.7 — Shared shell contract: sign-up CTA at run end

### DIFF
--- a/src/app/badge-run/components/SignUpCTA.tsx
+++ b/src/app/badge-run/components/SignUpCTA.tsx
@@ -1,0 +1,73 @@
+'use client'
+import { useState } from 'react'
+import Link from 'next/link'
+
+const KEY = 'badge-run:signup-dismissed-until'
+const SUPPRESS_DAYS = 14
+
+function shouldShow(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    const raw = window.localStorage.getItem(KEY)
+    if (!raw) return true
+    const until = Number(raw)
+    return Date.now() > until
+  } catch {
+    return true
+  }
+}
+
+function dismiss(): void {
+  try {
+    const until = Date.now() + SUPPRESS_DAYS * 24 * 60 * 60 * 1000
+    window.localStorage.setItem(KEY, String(until))
+  } catch {}
+}
+
+export function SignUpCTA() {
+  const [visible, setVisible] = useState(shouldShow)
+  if (!visible) return null
+
+  function handleDismiss() {
+    dismiss()
+    setVisible(false)
+  }
+
+  return (
+    <div style={{
+      width: '100%',
+      background: 'rgba(255,255,255,0.05)',
+      border: '1px solid rgba(255,255,255,0.12)',
+      borderRadius: 8,
+      padding: '14px 16px',
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: 12,
+    }}>
+      <div>
+        <p style={{ color: '#fff', fontSize: 14, fontWeight: 600, margin: '0 0 2px' }}>
+          Save your run history
+        </p>
+        <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: 12, margin: 0 }}>
+          Your runs are anonymous now. Sign in to track your record across devices.
+        </p>
+      </div>
+      <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+        <Link
+          href="/auth/sign-in"
+          style={{ padding: '8px 14px', background: 'rgba(255,255,255,0.12)', border: '1px solid rgba(255,255,255,0.2)', borderRadius: 5, color: '#fff', fontSize: 12, textDecoration: 'none', whiteSpace: 'nowrap' }}
+        >
+          Sign in
+        </Link>
+        <button
+          onClick={handleDismiss}
+          style={{ padding: '8px 10px', background: 'transparent', border: 'none', color: 'rgba(255,255,255,0.35)', cursor: 'pointer', fontSize: 12 }}
+          aria-label="Dismiss"
+        >
+          Not now
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/badge-run/components/SummaryScreen.tsx
+++ b/src/app/badge-run/components/SummaryScreen.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState } from 'react'
 import { useBlitzStore, getDailySeed } from '../store'
+import { SignUpCTA } from './SignUpCTA'
 
 function buildShareString(run: { round: number; won: boolean; lost: boolean }): string {
   const today = new Date()
@@ -60,6 +61,8 @@ export function SummaryScreen() {
         <p style={{ color: 'rgba(255,255,255,0.35)', fontSize: 11, letterSpacing: 1, textTransform: 'uppercase', margin: '0 0 4px' }}>Share</p>
         <p style={{ color: 'rgba(255,255,255,0.75)', fontSize: 13, fontFamily: 'monospace', margin: 0 }}>{shareText}</p>
       </div>
+
+      <SignUpCTA />
 
       <div style={{ display: 'flex', gap: 12 }}>
         <button


### PR DESCRIPTION
## B-4.7 — Shared shell contract

`SignUpCTA` inline component shown at run end. Sells depth (stats, streaks, leaderboards) not access. 14-day localStorage suppression after dismissal. No modal, no gate — follows CometCave UX Principle 1 (anonymous-first).

**Issues closed:** #3858

🤖 Generated with [Claude Code](https://claude.com/claude-code)