### PR TITLE
B-4.8 — Anonymous play and accessibility

### DIFF
--- a/src/app/badge-run/badge-run.css
+++ b/src/app/badge-run/badge-run.css
@@ -1,0 +1,14 @@
+/* Badge Run — shared accessibility styles */
+
+/* Focus visible indicator for all interactive elements */
+.br-btn:focus-visible {
+  outline: 2px solid rgba(255,255,255,0.8);
+  outline-offset: 3px;
+}
+
+/* Respect prefers-reduced-motion: disable transitions */
+@media (prefers-reduced-motion: reduce) {
+  .br-btn {
+    transition: none !important;
+  }
+}

--- a/src/app/badge-run/components/BattleScreen.tsx
+++ b/src/app/badge-run/components/BattleScreen.tsx
@@ -19,10 +19,11 @@ export function BattleScreen() {
     return (
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16, padding: 32 }}>
         <h2 style={{ color: '#fff', fontSize: 20, fontWeight: 700, margin: 0 }}>Round {run.round}</h2>
-        <p style={{ color: 'rgba(255,255,255,0.55)', fontSize: 14, margin: 0 }}>
+        <p style={{ color: 'rgba(255,255,255,0.70)', fontSize: 14, margin: 0 }}>
           Your team enters the arena.
         </p>
         <button
+          className="br-btn"
           onClick={battle}
           style={{ padding: '12px 32px', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.2)', borderRadius: 6, color: '#fff', cursor: 'pointer', fontSize: 15, fontWeight: 600, letterSpacing: 1 }}
         >
@@ -38,7 +39,7 @@ export function BattleScreen() {
       <h2 style={{ color: '#fff', fontSize: 18, fontWeight: 700, margin: 0 }}>
         Battle Log — Round {run.round}
       </h2>
-      <div style={{ flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2, fontFamily: 'monospace', fontSize: 12 }}>
+      <div role="log" aria-live="polite" aria-label="Battle events" style={{ flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2, fontFamily: 'monospace', fontSize: 12 }}>
         {result.events.map((ev, i) => {
           if (ev.type === 'synergy_applied') {
             return (
@@ -64,7 +65,7 @@ export function BattleScreen() {
           if (ev.type === 'damage') {
             const label = effectivenessLabel(ev.effectiveness)
             return (
-              <div key={i} style={{ color: 'rgba(255,255,255,0.55)', padding: '1px 0 1px 12px' }}>
+              <div key={i} style={{ color: 'rgba(255,255,255,0.70)', padding: '1px 0 1px 12px' }}>
                 {ev.amount} dmg
                 {label && (
                   <span style={{ color: label.color, marginLeft: 8 }}>{label.text}</span>
@@ -91,6 +92,7 @@ export function BattleScreen() {
         })}
       </div>
       <button
+        className="br-btn"
         onClick={run.phase === 'evolve' ? evolve : undefined}
         style={{ padding: '10px 24px', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.2)', borderRadius: 6, color: '#fff', cursor: run.phase === 'evolve' ? 'pointer' : 'default', fontSize: 14, alignSelf: 'center' }}
       >

--- a/src/app/badge-run/components/DraftScreen.tsx
+++ b/src/app/badge-run/components/DraftScreen.tsx
@@ -12,14 +12,14 @@ export function DraftScreen() {
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: '24px 16px', gap: 24, maxWidth: 640, margin: '0 auto', width: '100%' }}>
       <div>
-        <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: 12, letterSpacing: 2, margin: 0, textTransform: 'uppercase' }}>
+        <p style={{ color: 'rgba(255,255,255,0.65)', fontSize: 12, letterSpacing: 2, margin: 0, textTransform: 'uppercase' }}>
           Round {run.round} of 8
         </p>
         <h2 style={{ color: '#fff', fontSize: 22, fontWeight: 700, margin: '4px 0 0', letterSpacing: 1 }}>
           {arena?.name ?? arenaId}
         </h2>
         {arena && arena.houseRules.length > 0 && (
-          <p style={{ color: 'rgba(255,255,255,0.4)', fontSize: 12, margin: '4px 0 0' }}>
+          <p style={{ color: 'rgba(255,255,255,0.65)', fontSize: 12, margin: '4px 0 0' }}>
             {arena.houseRules.join(' · ')}
           </p>
         )}
@@ -27,7 +27,7 @@ export function DraftScreen() {
 
       {run.team.length > 0 && (
         <div>
-          <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: 11, letterSpacing: 1, margin: '0 0 6px', textTransform: 'uppercase' }}>
+          <p style={{ color: 'rgba(255,255,255,0.65)', fontSize: 11, letterSpacing: 1, margin: '0 0 6px', textTransform: 'uppercase' }}>
             Your team
           </p>
           <p style={{ color: 'rgba(255,255,255,0.7)', fontSize: 13, margin: 0 }}>
@@ -37,13 +37,14 @@ export function DraftScreen() {
       )}
 
       <div>
-        <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: 11, letterSpacing: 1, margin: '0 0 12px', textTransform: 'uppercase' }}>
+        <p style={{ color: 'rgba(255,255,255,0.65)', fontSize: 11, letterSpacing: 1, margin: '0 0 12px', textTransform: 'uppercase' }}>
           Choose one
         </p>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           {run.offers.map((unit) => (
             <button
               key={unit.dexId}
+              className="br-btn"
               onClick={() => pick(unit.dexId)}
               style={{
                 background: 'rgba(255,255,255,0.05)',
@@ -60,18 +61,18 @@ export function DraftScreen() {
             >
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
                 <span style={{ fontWeight: 700, fontSize: 16 }}>{unit.name}</span>
-                <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.45)', letterSpacing: 1 }}>{unit.tier}</span>
+                <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.65)', letterSpacing: 1 }}>{unit.tier}</span>
               </div>
               <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
                 {unit.types.map(t => (
-                  <span key={t} style={{ fontSize: 11, color: 'rgba(255,255,255,0.55)', background: 'rgba(255,255,255,0.08)', padding: '2px 6px', borderRadius: 4 }}>
+                  <span key={t} style={{ fontSize: 11, color: 'rgba(255,255,255,0.70)', background: 'rgba(255,255,255,0.08)', padding: '2px 6px', borderRadius: 4 }}>
                     {t}
                   </span>
                 ))}
-                <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>{unit.kin}</span>
+                <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.65)' }}>{unit.kin}</span>
               </div>
               {unit.signatureMove && (
-                <p style={{ fontSize: 11, color: 'rgba(255,255,255,0.35)', margin: '4px 0 0' }}>
+                <p style={{ fontSize: 11, color: 'rgba(255,255,255,0.60)', margin: '4px 0 0' }}>
                   {unit.signatureMove}
                 </p>
               )}

--- a/src/app/badge-run/components/SignUpCTA.tsx
+++ b/src/app/badge-run/components/SignUpCTA.tsx
@@ -49,7 +49,7 @@ export function SignUpCTA() {
         <p style={{ color: '#fff', fontSize: 14, fontWeight: 600, margin: '0 0 2px' }}>
           Save your run history
         </p>
-        <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: 12, margin: 0 }}>
+        <p style={{ color: 'rgba(255,255,255,0.65)', fontSize: 12, margin: 0 }}>
           Your runs are anonymous now. Sign in to track your record across devices.
         </p>
       </div>
@@ -61,8 +61,9 @@ export function SignUpCTA() {
           Sign in
         </Link>
         <button
+          className="br-btn"
           onClick={handleDismiss}
-          style={{ padding: '8px 10px', background: 'transparent', border: 'none', color: 'rgba(255,255,255,0.35)', cursor: 'pointer', fontSize: 12 }}
+          style={{ padding: '8px 10px', background: 'transparent', border: 'none', color: 'rgba(255,255,255,0.60)', cursor: 'pointer', fontSize: 12 }}
           aria-label="Dismiss"
         >
           Not now

--- a/src/app/badge-run/components/SummaryScreen.tsx
+++ b/src/app/badge-run/components/SummaryScreen.tsx
@@ -43,14 +43,14 @@ export function SummaryScreen() {
 
       {run.team.length > 0 && (
         <div style={{ width: '100%' }}>
-          <p style={{ color: 'rgba(255,255,255,0.35)', fontSize: 11, letterSpacing: 1, textTransform: 'uppercase', margin: '0 0 8px' }}>
+          <p style={{ color: 'rgba(255,255,255,0.60)', fontSize: 11, letterSpacing: 1, textTransform: 'uppercase', margin: '0 0 8px' }}>
             Your team
           </p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
             {run.team.map((unit, i) => (
               <div key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 12px', background: 'rgba(255,255,255,0.04)', borderRadius: 6, border: '1px solid rgba(255,255,255,0.08)' }}>
                 <span style={{ color: '#fff', fontSize: 14, fontWeight: 600 }}>{unit.name}</span>
-                <span style={{ color: 'rgba(255,255,255,0.4)', fontSize: 12 }}>{unit.tier} · {unit.types.join('/')}</span>
+                <span style={{ color: 'rgba(255,255,255,0.65)', fontSize: 12 }}>{unit.tier} · {unit.types.join('/')}</span>
               </div>
             ))}
           </div>
@@ -58,7 +58,7 @@ export function SummaryScreen() {
       )}
 
       <div style={{ width: '100%', background: 'rgba(255,255,255,0.04)', borderRadius: 8, padding: '12px 16px', border: '1px solid rgba(255,255,255,0.08)' }}>
-        <p style={{ color: 'rgba(255,255,255,0.35)', fontSize: 11, letterSpacing: 1, textTransform: 'uppercase', margin: '0 0 4px' }}>Share</p>
+        <p style={{ color: 'rgba(255,255,255,0.60)', fontSize: 11, letterSpacing: 1, textTransform: 'uppercase', margin: '0 0 4px' }}>Share</p>
         <p style={{ color: 'rgba(255,255,255,0.75)', fontSize: 13, fontFamily: 'monospace', margin: 0 }}>{shareText}</p>
       </div>
 
@@ -66,12 +66,15 @@ export function SummaryScreen() {
 
       <div style={{ display: 'flex', gap: 12 }}>
         <button
+          className="br-btn"
+          aria-label="Copy share text"
           onClick={copyShare}
           style={{ padding: '10px 20px', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.2)', borderRadius: 6, color: '#fff', cursor: 'pointer', fontSize: 13 }}
         >
-          {copied ? 'Copied' : 'Copy'}
+          <span aria-live="polite">{copied ? 'Copied!' : 'Copy'}</span>
         </button>
         <button
+          className="br-btn"
           onClick={reset}
           style={{ padding: '10px 20px', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 6, color: 'rgba(255,255,255,0.6)', cursor: 'pointer', fontSize: 13 }}
         >

--- a/src/app/badge-run/page.tsx
+++ b/src/app/badge-run/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import './badge-run.css'
 import { useEffect } from 'react'
 import { useBlitzStore } from './store'
 import { DraftScreen } from './components/DraftScreen'


### PR DESCRIPTION
## B-4.8 — Anonymous play and accessibility

Full game is playable without a login (confirmed — no auth gating anywhere in the badge-run flow).

Accessibility fixes per CLAUDE.md Principle 8 and CometCave UX contract:

- **Focus states**: New `badge-run.css` with `.br-btn:focus-visible` — white outline ring on keyboard focus for all interactive buttons
- **Reduced motion**: `@media (prefers-reduced-motion: reduce)` suppresses the hover transition on draft choice buttons
- **Screen-reader regions**: `role="log"` + `aria-live="polite"` on the BattleScreen event log; `aria-live="polite"` on copy-success feedback span in SummaryScreen
- **Contrast**: Secondary text opacity bumped from 0.35–0.55 to 0.60–0.70 range (targeting WCAG AA 4.5:1 on dark background)
- **State not color-only**: effectiveness already uses text labels alongside color — no change needed

**Issues closed:** #3843

🤖 Generated with [Claude Code](https://claude.com/claude-code)