### PR TITLE
pre-Epic 5: reduce TIER_COPIES per B-3.5 gate recommendation

### DIFF
--- a/src/app/badge-run/domain/draft/pool.ts
+++ b/src/app/badge-run/domain/draft/pool.ts
@@ -1,11 +1,11 @@
 import { UNIT_CATALOG, type CatalogUnit, type Tier } from '../unit-catalog'
 
 const TIER_COPIES: Record<Tier, number> = {
-  T1: 20,
-  T2: 16,
-  T3: 12,
-  T4: 9,
-  T5: 6,
+  T1: 4,
+  T2: 3,
+  T3: 2,
+  T4: 2,
+  T5: 1,
 }
 
 export interface PoolEntry {


### PR DESCRIPTION
## Pre-Epic 5 prerequisite: TIER_COPIES reduction

Required change documented in `docs/badge-run-ghost-findings.md` before any Epic 5 work begins.

B-3.5 eval showed 2.1% pool utilization (2,324 copies vs 48 picks). T5 had 6 copies vs ~2 picks — zero scarcity possible.

**New values:**

| Tier | Before | After |
|------|--------|-------|
| T1 | 20 | 4 |
| T2 | 16 | 3 |
| T3 | 12 | 2 |
| T4 | 9 | 2 |
| T5 | 6 | 1 |

Projected pool utilization: 48/437 ≈ 11%. T5 (4 copies total) and T4 (8 copies total) create real scarcity where drafting strategy matters most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)