### PR TITLE
B-5.1 — Economy: gold income, interest, and streak bonuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "seed-ai-questions": "tsx --env-file=.env.local scripts/seed-ai-questions.ts",
     "sim:micro-land": "tsx scripts/micro-land-sim.ts",
     "sim:badge-run": "tsx scripts/badge-run-sim.ts",
+    "gold:badge-run": "tsx scripts/badge-run-gold-sim.ts",
     "eval:micro-land": "tsx scripts/micro-land-eval.ts",
     "eval:micro-land:smoke": "tsx scripts/micro-land-eval.ts --seconds 120 --runs 1 --theme grassland",
     "eval:badge-run": "tsx scripts/badge-run-eval.ts",

--- a/scripts/badge-run-gold-sim.ts
+++ b/scripts/badge-run-gold-sim.ts
@@ -1,0 +1,57 @@
+/**
+ * Gold curve simulator for Badge Run.
+ * Usage: npx tsx scripts/badge-run-gold-sim.ts [--rounds N]
+ *
+ * Simulates N "perfect" runs (always win) and N "losing" runs to show
+ * the gold curve extremes and a mixed-skill average.
+ */
+import { computeRoundIncome } from '../src/app/badge-run/domain/economy/gold'
+
+const args = process.argv.slice(2)
+const roundsIdx = args.indexOf('--rounds')
+const ROUNDS = roundsIdx >= 0 ? parseInt(args[roundsIdx + 1], 10) : 29
+
+type RunType = 'perfect' | 'losing' | 'mixed'
+
+function simulateGoldCurve(rounds: number, runType: RunType): number[] {
+  let gold = 0
+  let winStreak = 0
+  let lossStreak = 0
+  const curve: number[] = []
+
+  for (let r = 1; r <= rounds; r++) {
+    const streak = runType === 'perfect' ? winStreak
+                 : runType === 'losing'  ? lossStreak
+                 : r % 3 === 0 ? lossStreak : winStreak
+
+    const income = computeRoundIncome(gold, streak)
+    gold += income
+
+    if (runType === 'perfect' || (runType === 'mixed' && r % 3 !== 0)) {
+      winStreak++
+      lossStreak = 0
+    } else {
+      lossStreak++
+      winStreak = 0
+    }
+
+    curve.push(gold)
+  }
+
+  return curve
+}
+
+const perfect = simulateGoldCurve(ROUNDS, 'perfect')
+const losing = simulateGoldCurve(ROUNDS, 'losing')
+const mixed = simulateGoldCurve(ROUNDS, 'mixed')
+
+console.log(`\nBadge Run — Gold Curves (${ROUNDS} rounds)\n`)
+console.log('Round | Perfect | Mixed  | Losing')
+console.log('------|---------|--------|-------')
+for (let r = 0; r < ROUNDS; r++) {
+  const round = String(r + 1).padStart(5)
+  const p = String(perfect[r]).padStart(7)
+  const m = String(mixed[r]).padStart(6)
+  const l = String(losing[r]).padStart(7)
+  console.log(`${round} | ${p} | ${m} | ${l}`)
+}

--- a/src/app/badge-run/domain/__tests__/gold.test.ts
+++ b/src/app/badge-run/domain/__tests__/gold.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { computeInterest, computeStreakBonus, computeRoundIncome, BASE_INCOME } from '../economy/gold'
+
+describe('computeInterest', () => {
+  it('returns 0 for 0 gold saved', () => {
+    expect(computeInterest(0)).toBe(0)
+  })
+  it('returns 0 for 9 gold saved', () => {
+    expect(computeInterest(9)).toBe(0)
+  })
+  it('returns 1 for 10 gold saved', () => {
+    expect(computeInterest(10)).toBe(1)
+  })
+  it('returns 1 for 19 gold saved', () => {
+    expect(computeInterest(19)).toBe(1)
+  })
+  it('returns 3 for 30 gold saved', () => {
+    expect(computeInterest(30)).toBe(3)
+  })
+  it('caps at 5 for 50 gold saved', () => {
+    expect(computeInterest(50)).toBe(5)
+  })
+  it('caps at 5 for 100 gold saved', () => {
+    expect(computeInterest(100)).toBe(5)
+  })
+})
+
+describe('computeStreakBonus', () => {
+  it('returns 0 for streak 0', () => {
+    expect(computeStreakBonus(0)).toBe(0)
+  })
+  it('returns 1 for streak 1', () => {
+    expect(computeStreakBonus(1)).toBe(1)
+  })
+  it('returns 2 for streak 2', () => {
+    expect(computeStreakBonus(2)).toBe(2)
+  })
+  it('returns 3 for streak 3', () => {
+    expect(computeStreakBonus(3)).toBe(3)
+  })
+  it('caps at 3 for streak 5', () => {
+    expect(computeStreakBonus(5)).toBe(3)
+  })
+})
+
+describe('computeRoundIncome', () => {
+  it('returns base income with no savings and no streak', () => {
+    expect(computeRoundIncome(0, 0)).toBe(BASE_INCOME)
+  })
+  it('adds interest for 10 gold saved', () => {
+    expect(computeRoundIncome(10, 0)).toBe(BASE_INCOME + 1)
+  })
+  it('adds streak bonus', () => {
+    expect(computeRoundIncome(0, 2)).toBe(BASE_INCOME + 2)
+  })
+  it('combines interest and streak', () => {
+    expect(computeRoundIncome(20, 3)).toBe(BASE_INCOME + 2 + 3)
+  })
+  it('caps total bonus correctly at max values', () => {
+    expect(computeRoundIncome(50, 10)).toBe(BASE_INCOME + 5 + 3)
+  })
+})

--- a/src/app/badge-run/domain/blitz/run.ts
+++ b/src/app/badge-run/domain/blitz/run.ts
@@ -4,6 +4,7 @@ import { ARENA_SCHEDULE } from '../data/arenas'
 import { runBattle } from '../battle/runner'
 import type { BattleUnit, Team } from '../battle/types'
 import type { BattleResult } from '../battle/events'
+import { computeRoundIncome } from '../economy/gold'
 
 export type BlitzPhase = 'idle' | 'draft' | 'battle' | 'evolve' | 'summary'
 
@@ -18,6 +19,9 @@ export interface BlitzRun {
   opponentTeams: CatalogUnit[][]  // pre-generated, one per round (8 total)
   won: boolean           // true if completed round 8
   lost: boolean          // true if lost a battle
+  gold: number          // current gold
+  winStreak: number     // consecutive rounds won
+  lossStreak: number    // consecutive rounds lost
 }
 
 // ---------------------------------------------------------------------------
@@ -129,6 +133,9 @@ export function startBlitz(seed: number): BlitzRun {
     opponentTeams,
     won: false,
     lost: false,
+    gold: 0,
+    winStreak: 0,
+    lossStreak: 0,
   }
 }
 
@@ -189,15 +196,23 @@ export function resolveBattle(run: BlitzRun): BlitzRun {
 
   if (!playerWon) {
     // Loss — run ends
+    const newLossStreak = run.lossStreak + 1
+    const income = computeRoundIncome(run.gold, newLossStreak)
     return {
       ...run,
       lastBattleResult: result,
       phase: 'summary',
       lost: true,
+      gold: run.gold + income,
+      winStreak: 0,
+      lossStreak: newLossStreak,
     }
   }
 
   // Player won
+  const newWinStreak = run.winStreak + 1
+  const income = computeRoundIncome(run.gold, newWinStreak)
+
   // Check if last picked unit can evolve
   const lastPicked = run.lastPickedDexId !== null
     ? UNIT_CATALOG.find(u => u.dexId === run.lastPickedDexId)
@@ -211,6 +226,9 @@ export function resolveBattle(run: BlitzRun): BlitzRun {
       lastBattleResult: result,
       phase: 'summary',
       won: true,
+      gold: run.gold + income,
+      winStreak: newWinStreak,
+      lossStreak: 0,
     }
   }
 
@@ -220,6 +238,9 @@ export function resolveBattle(run: BlitzRun): BlitzRun {
       ...run,
       lastBattleResult: result,
       phase: 'evolve',
+      gold: run.gold + income,
+      winStreak: newWinStreak,
+      lossStreak: 0,
     }
   }
 
@@ -233,6 +254,9 @@ export function resolveBattle(run: BlitzRun): BlitzRun {
     round: nextRound,
     phase: 'draft',
     offers: newOffers,
+    gold: run.gold + income,
+    winStreak: newWinStreak,
+    lossStreak: 0,
   }
 }
 

--- a/src/app/badge-run/domain/economy/gold.ts
+++ b/src/app/badge-run/domain/economy/gold.ts
@@ -1,0 +1,28 @@
+/** Base gold income per round */
+export const BASE_INCOME = 5
+
+/**
+ * Interest: +1 per 10 gold saved, capped at 5.
+ * e.g. 0-9 saved → 0, 10-19 → 1, 50+ → 5
+ */
+export function computeInterest(savedGold: number): number {
+  return Math.min(5, Math.floor(savedGold / 10))
+}
+
+/**
+ * Streak bonus: +1/+2/+3 for 1/2/3+ consecutive wins or losses.
+ * Both win streaks and loss streaks give the same bonus amount
+ * (loss streak bonus is a "consolation" income boost).
+ */
+export function computeStreakBonus(streak: number): number {
+  return Math.min(3, streak)
+}
+
+/**
+ * Total gold income for a round.
+ * @param savedGold  Gold the player ended last round with (for interest)
+ * @param streak     Length of current win or loss streak (0 if none)
+ */
+export function computeRoundIncome(savedGold: number, streak: number): number {
+  return BASE_INCOME + computeInterest(savedGold) + computeStreakBonus(streak)
+}


### PR DESCRIPTION
## B-5.1 — Economy

Gold income system per the issue spec:
- Base income: 5 gold/round
- Interest: +1 per 10 gold saved, capped at 5
- Streak bonus: +1/+2/+3 for 1/2/3+ consecutive win or loss streak

`domain/economy/gold.ts` — three pure functions: `computeInterest`, `computeStreakBonus`, `computeRoundIncome`

`BlitzRun` now tracks `gold`, `winStreak`, `lossStreak`. Income is awarded on all four `resolveBattle` exit paths (win, loss, evolve branch, round 8 complete).

`scripts/badge-run-gold-sim.ts` — prints gold curve table for perfect/mixed/losing run patterns over N rounds (`npm run gold:badge-run`).

17 unit tests, all passing.

**Issues closed:** #3844

🤖 Generated with [Claude Code](https://claude.com/claude-code)